### PR TITLE
Generate OCI image layout on demand

### DIFF
--- a/cmd/img/BUILD.bazel
+++ b/cmd/img/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//cmd/layer",
         "//cmd/layermeta",
         "//cmd/manifest",
+        "//cmd/ocilayout",
         "//cmd/push",
         "//cmd/validate",
         "//pkg/api",

--- a/cmd/img/img.go
+++ b/cmd/img/img.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tweag/rules_img/cmd/layer"
 	"github.com/tweag/rules_img/cmd/layermeta"
 	"github.com/tweag/rules_img/cmd/manifest"
+	"github.com/tweag/rules_img/cmd/ocilayout"
 	"github.com/tweag/rules_img/cmd/push"
 	"github.com/tweag/rules_img/cmd/validate"
 	"github.com/tweag/rules_img/pkg/api"
@@ -29,6 +30,7 @@ Commands:
   layer           creates a layer from files
   layer-metadata  creates a layer metadata file from a layer
   manifest        creates an image manifest and config from layers
+  oci-layout      assembles an OCI layout directory from manifest and layers
   validate        validates layers and images
   push            pushes an image to a registry`
 
@@ -67,6 +69,8 @@ func Run(ctx context.Context, args []string) {
 		compress.CompressProcess(ctx, args[2:])
 	case "download-blob":
 		downloadblob.DownloadBlobProcess(ctx, args[2:])
+	case "oci-layout":
+		ocilayout.OCILayoutProcess(ctx, args[2:])
 	case "expand-template":
 		expandtemplate.ExpandTemplateProcess(ctx, args[2:])
 	default:

--- a/cmd/ocilayout/BUILD.bazel
+++ b/cmd/ocilayout/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "ocilayout",
+    srcs = [
+        "copy_linux.go",
+        "copy_other.go",
+        "flags.go",
+        "ocilayout.go",
+    ],
+    importpath = "github.com/tweag/rules_img/cmd/ocilayout",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_malt3_go_containerregistry//pkg/v1:pkg",
+    ],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//img/private/release:__subpackages__"],
+)

--- a/cmd/ocilayout/copy_linux.go
+++ b/cmd/ocilayout/copy_linux.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package ocilayout
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+)
+
+// tryReflink attempts to use FICLONE ioctl for efficient copying on Linux
+// This creates a reflink (copy-on-write) copy when supported by the filesystem
+func tryReflink(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	// Try FICLONE ioctl for reflink copy
+	// FICLONE = 0x40049409
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, dstFile.Fd(), 0x40049409, srcFile.Fd())
+	if errno == 0 {
+		return nil
+	}
+
+	// If FICLONE is not supported (e.g., different filesystem, not btrfs/xfs),
+	// fall back to regular copy
+	if errno == syscall.ENOTSUP || errno == syscall.EXDEV || errno == syscall.EINVAL {
+		_, err = io.Copy(dstFile, srcFile)
+		return err
+	}
+
+	return fmt.Errorf("FICLONE ioctl failed: %v", errno)
+}

--- a/cmd/ocilayout/copy_other.go
+++ b/cmd/ocilayout/copy_other.go
@@ -1,0 +1,26 @@
+//go:build !linux
+
+package ocilayout
+
+import (
+	"io"
+	"os"
+)
+
+// tryReflink is not supported on non-Linux platforms, so it just does a regular copy
+func tryReflink(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	return err
+}

--- a/cmd/ocilayout/flags.go
+++ b/cmd/ocilayout/flags.go
@@ -1,0 +1,44 @@
+package ocilayout
+
+import (
+	"fmt"
+	"strings"
+)
+
+// stringSliceFlag is a custom flag type for string slices
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string {
+	return fmt.Sprintf("%v", *s)
+}
+
+func (s *stringSliceFlag) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
+// layerMapping represents a metadata file to blob file mapping
+type layerMapping struct {
+	metadata string
+	blob     string
+}
+
+// layerMappingFlag is a custom flag type for layer mappings
+type layerMappingFlag []layerMapping
+
+func (l *layerMappingFlag) String() string {
+	var parts []string
+	for _, m := range *l {
+		parts = append(parts, fmt.Sprintf("%s=%s", m.metadata, m.blob))
+	}
+	return strings.Join(parts, ",")
+}
+
+func (l *layerMappingFlag) Set(value string) error {
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid layer format, expected metadata=blob, got %s", value)
+	}
+	*l = append(*l, layerMapping{metadata: parts[0], blob: parts[1]})
+	return nil
+}

--- a/cmd/ocilayout/ocilayout.go
+++ b/cmd/ocilayout/ocilayout.go
@@ -1,0 +1,304 @@
+package ocilayout
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	v1 "github.com/malt3/go-containerregistry/pkg/v1"
+)
+
+const OCILayoutVersion = "1.0.0"
+
+type blobMap map[string]string // digest -> source path
+
+func OCILayoutProcess(ctx context.Context, args []string) {
+	var manifestPath string
+	var indexPath string
+	var outputDir string
+	var configPath string
+	var layerFlags layerMappingFlag
+	var manifestPaths stringSliceFlag
+	var configPaths stringSliceFlag
+	var useSymlinks bool
+
+	flagSet := flag.NewFlagSet("oci-layout", flag.ExitOnError)
+	flagSet.Usage = func() {
+		fmt.Fprintf(flagSet.Output(), "Assembles an OCI layout directory from manifest/index and layers.\n\n")
+		fmt.Fprintf(flagSet.Output(), "Usage: img oci-layout [OPTIONS]\n")
+		flagSet.PrintDefaults()
+		examples := []string{
+			"img oci-layout --manifest manifest.json --config config.json --layer layer1_meta.json=layer1.tar.gz --output oci-layout",
+			"img oci-layout --index index.json --manifest-path m1.json --config-path c1.json --layer l1_meta.json=l1.tar.gz --output oci-layout",
+		}
+		fmt.Fprintf(flagSet.Output(), "\nExamples:\n")
+		for _, example := range examples {
+			fmt.Fprintf(flagSet.Output(), "  $ %s\n", example)
+		}
+	}
+
+	flagSet.StringVar(&manifestPath, "manifest", "", "Path to the image manifest (for single manifest)")
+	flagSet.StringVar(&indexPath, "index", "", "Path to the image index (for multi-platform)")
+	flagSet.StringVar(&configPath, "config", "", "Path to the image config (for single manifest)")
+	flagSet.StringVar(&outputDir, "output", "", "Output directory for OCI layout (required)")
+	flagSet.Var(&layerFlags, "layer", "Layer mapping in format metadata=blob (can be specified multiple times)")
+	flagSet.Var(&manifestPaths, "manifest-path", "Path to manifest file (for index, can be specified multiple times)")
+	flagSet.Var(&configPaths, "config-path", "Path to config file (for index, can be specified multiple times)")
+	flagSet.BoolVar(&useSymlinks, "symlink", false, "Use symlinks instead of copying files")
+
+	if err := flagSet.Parse(args); err != nil {
+		flagSet.Usage()
+		os.Exit(1)
+	}
+
+	// Validate required flags
+	if outputDir == "" {
+		fmt.Fprintf(os.Stderr, "Error: --output is required\n")
+		flagSet.Usage()
+		os.Exit(1)
+	}
+
+	var err error
+	if indexPath != "" {
+		if manifestPath != "" || configPath != "" {
+			fmt.Fprintf(os.Stderr, "Error: cannot use --manifest or --config with --index\n")
+			os.Exit(1)
+		}
+		if len(manifestPaths) != len(configPaths) {
+			fmt.Fprintf(os.Stderr, "Error: number of --manifest-path must match --config-path\n")
+			os.Exit(1)
+		}
+		if len(manifestPaths) == 0 {
+			fmt.Fprintf(os.Stderr, "Error: --index requires at least one --manifest-path and --config-path\n")
+			os.Exit(1)
+		}
+		err = assembleOCILayoutWithIndex(indexPath, outputDir, manifestPaths, configPaths, layerFlags, useSymlinks)
+	} else {
+		if manifestPath == "" {
+			fmt.Fprintf(os.Stderr, "Error: either --manifest or --index is required\n")
+			flagSet.Usage()
+			os.Exit(1)
+		}
+		if configPath == "" {
+			fmt.Fprintf(os.Stderr, "Error: --config is required when using --manifest\n")
+			flagSet.Usage()
+			os.Exit(1)
+		}
+		if len(manifestPaths) > 0 || len(configPaths) > 0 {
+			fmt.Fprintf(os.Stderr, "Error: cannot use --manifest-path or --config-path without --index\n")
+			os.Exit(1)
+		}
+		err = assembleOCILayout(manifestPath, configPath, outputDir, layerFlags, useSymlinks)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func assembleOCILayout(manifestPath, configPath, outputDir string, layers layerMappingFlag, useSymlinks bool) error {
+	if err := setupOCILayout(outputDir); err != nil {
+		return err
+	}
+
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("reading manifest: %w", err)
+	}
+
+	var manifest v1.Manifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return fmt.Errorf("unmarshaling manifest: %w", err)
+	}
+
+	// Build a map of available layers by their digest
+	layerBlobsByDigest := make(map[string]string)
+	for _, layer := range layers {
+		metadataData, err := os.ReadFile(layer.metadata)
+		if err != nil {
+			return fmt.Errorf("reading layer metadata %s: %w", layer.metadata, err)
+		}
+
+		var metadata struct {
+			Digest string `json:"digest"`
+		}
+		if err := json.Unmarshal(metadataData, &metadata); err != nil {
+			return fmt.Errorf("unmarshaling layer metadata %s: %w", layer.metadata, err)
+		}
+
+		// Extract hex digest from sha256:xxxx format
+		digest := strings.TrimPrefix(metadata.Digest, "sha256:")
+		layerBlobsByDigest[digest] = layer.blob
+	}
+
+	blobs := make(blobMap)
+	blobs[manifest.Config.Digest.Hex] = configPath
+
+	// Only add layers that we have blobs for
+	for _, layerDesc := range manifest.Layers {
+		if blobPath, ok := layerBlobsByDigest[layerDesc.Digest.Hex]; ok {
+			blobs[layerDesc.Digest.Hex] = blobPath
+		}
+	}
+
+	blobsDir := filepath.Join(outputDir, "blobs", "sha256")
+
+	// Copy manifest to blobs directory
+	manifestDigest := hashBytes(manifestData)
+	blobs[manifestDigest.Hex] = manifestPath
+
+	if err := copyBlobs(blobs, blobsDir, useSymlinks); err != nil {
+		return err
+	}
+
+	index := v1.IndexManifest{
+		SchemaVersion: 2,
+		MediaType:     "application/vnd.oci.image.index.v1+json",
+		Manifests: []v1.Descriptor{
+			{
+				MediaType: manifest.MediaType,
+				Digest:    manifestDigest,
+				Size:      int64(len(manifestData)),
+			},
+		},
+	}
+
+	return writeJSON(filepath.Join(outputDir, "index.json"), index)
+}
+
+func copyFile(src, dst string, useSymlinks bool) error {
+	if useSymlinks {
+		absSrc, err := filepath.Abs(src)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(absSrc, dst)
+	}
+
+	if err := os.Link(src, dst); err == nil {
+		return nil
+	}
+
+	if err := tryReflink(src, dst); err == nil {
+		return nil
+	}
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	return err
+}
+
+func hashBytes(data []byte) v1.Hash {
+	h, _, _ := v1.SHA256(bytes.NewReader(data))
+	return h
+}
+
+func assembleOCILayoutWithIndex(indexPath, outputDir string, manifestPaths, configPaths []string, layers layerMappingFlag, useSymlinks bool) error {
+	if err := setupOCILayout(outputDir); err != nil {
+		return err
+	}
+
+	// Build a map of available layers by their digest
+	layerBlobsByDigest := make(map[string]string)
+	for _, layer := range layers {
+		metadataData, err := os.ReadFile(layer.metadata)
+		if err != nil {
+			return fmt.Errorf("reading layer metadata %s: %w", layer.metadata, err)
+		}
+
+		var metadata struct {
+			Digest string `json:"digest"`
+		}
+		if err := json.Unmarshal(metadataData, &metadata); err != nil {
+			return fmt.Errorf("unmarshaling layer metadata %s: %w", layer.metadata, err)
+		}
+
+		// Extract hex digest from sha256:xxxx format
+		digest := strings.TrimPrefix(metadata.Digest, "sha256:")
+		layerBlobsByDigest[digest] = layer.blob
+	}
+
+	blobs := make(blobMap)
+
+	for i := range manifestPaths {
+		manifestData, err := os.ReadFile(manifestPaths[i])
+		if err != nil {
+			return fmt.Errorf("reading manifest %d: %w", i, err)
+		}
+
+		var manifest v1.Manifest
+		if err := json.Unmarshal(manifestData, &manifest); err != nil {
+			return fmt.Errorf("unmarshaling manifest %d: %w", i, err)
+		}
+
+		// Add manifest to blobs
+		manifestDigest := hashBytes(manifestData)
+		blobs[manifestDigest.Hex] = manifestPaths[i]
+
+		// Add config to blobs
+		blobs[manifest.Config.Digest.Hex] = configPaths[i]
+
+		// Only add layers that we have blobs for
+		for _, layerDesc := range manifest.Layers {
+			if blobPath, ok := layerBlobsByDigest[layerDesc.Digest.Hex]; ok {
+				blobs[layerDesc.Digest.Hex] = blobPath
+			}
+		}
+	}
+
+	blobsDir := filepath.Join(outputDir, "blobs", "sha256")
+	if err := copyBlobs(blobs, blobsDir, useSymlinks); err != nil {
+		return err
+	}
+
+	// Copy the index file unmodified
+	return copyFile(indexPath, filepath.Join(outputDir, "index.json"), false)
+}
+
+func setupOCILayout(outputDir string) error {
+	blobsDir := filepath.Join(outputDir, "blobs", "sha256")
+	if err := os.MkdirAll(blobsDir, 0755); err != nil {
+		return fmt.Errorf("creating blobs directory: %w", err)
+	}
+
+	ociLayout := map[string]string{
+		"imageLayoutVersion": OCILayoutVersion,
+	}
+	return writeJSON(filepath.Join(outputDir, "oci-layout"), ociLayout)
+}
+
+func writeJSON(path string, v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", path, err)
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+func copyBlobs(blobs blobMap, blobsDir string, useSymlinks bool) error {
+	for digest, srcPath := range blobs {
+		dstPath := filepath.Join(blobsDir, digest)
+		if err := copyFile(srcPath, dstPath, useSymlinks); err != nil {
+			return fmt.Errorf("copying blob %s: %w", digest, err)
+		}
+	}
+	return nil
+}

--- a/img/private/index.bzl
+++ b/img/private/index.bzl
@@ -81,6 +81,48 @@ def _image_index_impl(ctx):
 
 image_index = rule(
     implementation = _image_index_impl,
+    doc = """Creates a multi-platform OCI image index from platform-specific manifests.
+
+This rule combines multiple single-platform images (created by image_manifest) into
+a multi-platform image index. The index allows container runtimes to automatically
+select the appropriate image for their platform.
+
+The rule supports two usage patterns:
+1. Explicit manifests: Provide pre-built manifests for each platform
+2. Platform transitions: Provide one manifest target and a list of platforms
+
+The rule produces:
+- OCI image index JSON file
+- An optional OCI layout directory (via output groups)
+- ImageIndexInfo provider for use by image_push
+
+Example (explicit manifests):
+```python
+image_index(
+    name = "multiarch_app",
+    manifests = [
+        ":app_linux_amd64",
+        ":app_linux_arm64",
+        ":app_darwin_amd64",
+    ],
+)
+```
+
+Example (platform transitions):
+```python
+image_index(
+    name = "multiarch_app",
+    manifests = [":app"],
+    platforms = [
+        "@platforms//os-cpu:linux-x86_64",
+        "@platforms//os-cpu:linux-aarch64",
+    ],
+)
+```
+
+Output groups:
+- `oci_layout`: Complete OCI layout directory with all platform blobs
+""",
     attrs = {
         "manifests": attr.label_list(
             providers = [ImageManifestInfo],

--- a/img/private/index.bzl
+++ b/img/private/index.bzl
@@ -1,11 +1,56 @@
 """Image index rule for composing multi-layer OCI images."""
 
-load("//img/private/common:build.bzl", "TOOLCHAINS")
+load("//img/private/common:build.bzl", "TOOLCHAIN", "TOOLCHAINS")
 load("//img/private/common:transitions.bzl", "multi_platform_image_transition", "reset_platform_transition")
 load("//img/private/common:write_index_json.bzl", "write_index_json")
 load("//img/private/providers:index_info.bzl", "ImageIndexInfo")
 load("//img/private/providers:manifest_info.bzl", "ImageManifestInfo")
 load("//img/private/providers:pull_info.bzl", "PullInfo")
+
+def _build_oci_layout(ctx, index_out, manifests):
+    """Build the OCI layout for a multi-platform image.
+
+    Args:
+        ctx: Rule context.
+        index_out: The index file.
+        manifests: List of ImageManifestInfo providers.
+
+    Returns:
+        The OCI layout directory (tree artifact).
+    """
+    oci_layout_dir = ctx.actions.declare_directory(ctx.label.name + "_oci_layout")
+
+    args = ctx.actions.args()
+    args.add("oci-layout")
+    args.add("--index", index_out.path)
+    args.add("--output", oci_layout_dir.path)
+
+    inputs = [index_out]
+
+    # Add manifest and config files for each platform
+    for manifest in manifests:
+        args.add("--manifest-path", manifest.manifest.path)
+        args.add("--config-path", manifest.config.path)
+        inputs.append(manifest.manifest)
+        inputs.append(manifest.config)
+
+        # Add layers with metadata=blob mapping
+        for layer in manifest.layers:
+            if layer.blob != None:
+                args.add("--layer", "{}={}".format(layer.metadata.path, layer.blob.path))
+                inputs.append(layer.metadata)
+                inputs.append(layer.blob)
+
+    img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
+    ctx.actions.run(
+        inputs = inputs,
+        outputs = [oci_layout_dir],
+        executable = img_toolchain_info.tool_exe,
+        arguments = [args],
+        mnemonic = "OCILayoutIndex",
+    )
+
+    return oci_layout_dir
 
 def _image_index_impl(ctx):
     pull_infos = [manifest[PullInfo] for manifest in ctx.attr.manifests if PullInfo in manifest]
@@ -14,16 +59,20 @@ def _image_index_impl(ctx):
         if pull_info != other:
             fail("index rule called with images that are based on different external images. This is not yet supported.")
     index_out = ctx.actions.declare_file(ctx.attr.name + "_index.json")
+    manifests = [manifest[ImageManifestInfo] for manifest in ctx.attr.manifests]
     write_index_json(
         ctx,
         output = index_out,
-        manifests = [manifest[ImageManifestInfo] for manifest in ctx.attr.manifests],
+        manifests = manifests,
     )
     providers = [
         DefaultInfo(files = depset([index_out])),
+        OutputGroupInfo(
+            oci_layout = depset([_build_oci_layout(ctx, index_out, manifests)]),
+        ),
         ImageIndexInfo(
             index = index_out,
-            manifests = [manifest[ImageManifestInfo] for manifest in ctx.attr.manifests],
+            manifests = manifests,
         ),
     ]
     if pull_info != None:

--- a/img/private/manifest.bzl
+++ b/img/private/manifest.bzl
@@ -233,6 +233,38 @@ def _image_manifest_impl(ctx):
 
 image_manifest = rule(
     implementation = _image_manifest_impl,
+    doc = """Builds a single-platform OCI container image from a set of layers.
+
+This rule assembles container images by combining:
+- Optional base image layers (from another image_manifest or image_index)
+- Additional layers created by image_layer rules
+- Image configuration (entrypoint, environment, labels, etc.)
+
+The rule produces:
+- OCI manifest and config JSON files
+- An optional OCI layout directory (via output groups)
+- ImageManifestInfo provider for use by image_index or image_push
+
+Example:
+```python
+image_manifest(
+    name = "my_app",
+    base = "@distroless_cc",
+    layers = [
+        ":app_layer",
+        ":config_layer",
+    ],
+    entrypoint = ["/usr/bin/app"],
+    env = {
+        "APP_ENV": "production",
+    },
+)
+```
+
+Output groups:
+- `descriptor`: OCI descriptor JSON file
+- `oci_layout`: Complete OCI layout directory with blobs
+""",
     attrs = {
         "base": attr.label(
             doc = "Base image to inherit layers from. Should provide ImageManifestInfo or ImageIndexInfo.",

--- a/img/private/release/source_files/BUILD.bazel
+++ b/img/private/release/source_files/BUILD.bazel
@@ -13,6 +13,7 @@ release_files = [
     "//cmd/layer:all_files",
     "//cmd/layermeta:all_files",
     "//cmd/manifest:all_files",
+    "//cmd/ocilayout:all_files",
     "//cmd/push:all_files",
     "//cmd/registry:all_files",
     "//cmd/validate:all_files",


### PR DESCRIPTION
This adds a new output group "oci_layout" containing a TreeArtifact with an OCI image layout of the image on disk to `image_manifest` and `image_index`.
This format can be used as a rules_oci base image and is usable by many generic container tools, including crane.

You can build it using the `--output_groups` flag, request it with a `filegroup`, or by accessing `OutputGroupInfo`.