### PR TITLE
fix formatting bug during push

### DIFF
--- a/pkg/push/BUILD.bazel
+++ b/pkg/push/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "index.go",
         "layer.go",
         "manifest.go",
+        "progress.go",
         "pushcasregistry.go",
         "pusheager.go",
         "pushlazy.go",

--- a/pkg/push/progress.go
+++ b/pkg/push/progress.go
@@ -1,0 +1,27 @@
+package push
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	registryv1 "github.com/malt3/go-containerregistry/pkg/v1"
+)
+
+func progressPrinter(updates <-chan registryv1.Update) {
+	var lastUpdate time.Time
+	for update := range updates {
+		relative := float64(update.Complete) / float64(update.Total) * 100
+		if update.Error != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", update.Error)
+			continue
+		}
+		if time.Since(lastUpdate) < 10*time.Millisecond {
+			// Avoid printing too frequently
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "\033[KProgress: %.2f %% (%v / %v bytes)\r", relative, update.Complete, update.Total)
+		lastUpdate = time.Now()
+	}
+	fmt.Fprintf(os.Stderr, "\033[K") // Clear the line after progress is done
+}

--- a/pkg/push/pusheager.go
+++ b/pkg/push/pusheager.go
@@ -3,8 +3,6 @@ package push
 import (
 	"context"
 	"fmt"
-	"os"
-	"time"
 
 	"github.com/malt3/go-containerregistry/pkg/authn"
 	"github.com/malt3/go-containerregistry/pkg/name"
@@ -90,21 +88,4 @@ func (p *eagerPusher) PushIndex(ctx context.Context, reference string, req PushI
 		return "", err
 	}
 	return digest.String(), nil
-}
-
-func progressPrinter(updates <-chan registryv1.Update) {
-	var lastUpdate time.Time
-	for update := range updates {
-		relative := float64(update.Complete) / float64(update.Total) * 100
-		if update.Error != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", update.Error)
-			continue
-		}
-		if time.Since(lastUpdate) < 10*time.Millisecond {
-			// Avoid printing too frequently
-			continue
-		}
-		fmt.Fprintf(os.Stderr, "Progress: %.2f %% (%v / %v bytes)\r", relative, update.Complete, update.Total)
-		lastUpdate = time.Now()
-	}
 }


### PR DESCRIPTION
The output of the progress message would not be cleared at the end, leading to garbled text when the final tag is printed.