### PR TITLE
Fix template expansion in image_load rule

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 # To update these lines, execute
 # `bazel run @rules_bazel_integration_test//tools:update_deleted_packages`
-build --deleted_packages=e2e/cc,e2e/cc/base,e2e/cc/custom_standard_library,e2e/cc/patches,e2e/cc/platform,e2e/generic,e2e/generic/load,e2e/generic/platform,e2e/go,e2e/go/cross,e2e/go/customization,e2e/go/image,e2e/go/multiarch-manual,e2e/go/multiarch-transition
-query --deleted_packages=e2e/cc,e2e/cc/base,e2e/cc/custom_standard_library,e2e/cc/patches,e2e/cc/platform,e2e/generic,e2e/generic/load,e2e/generic/platform,e2e/go,e2e/go/cross,e2e/go/customization,e2e/go/image,e2e/go/multiarch-manual,e2e/go/multiarch-transition
+build --deleted_packages=e2e/cc,e2e/cc/base,e2e/cc/custom_standard_library,e2e/cc/patches,e2e/cc/platform,e2e/generic,e2e/generic/build_settings,e2e/generic/load,e2e/generic/platform,e2e/go,e2e/go/cross,e2e/go/customization,e2e/go/image,e2e/go/multiarch-manual,e2e/go/multiarch-transition
+query --deleted_packages=e2e/cc,e2e/cc/base,e2e/cc/custom_standard_library,e2e/cc/patches,e2e/cc/platform,e2e/generic,e2e/generic/build_settings,e2e/generic/load,e2e/generic/platform,e2e/go,e2e/go/cross,e2e/go/customization,e2e/go/image,e2e/go/multiarch-manual,e2e/go/multiarch-transition
 
 import %workspace%/.bazelrc.common
 

--- a/e2e/generic/build_settings/BUILD.bazel
+++ b/e2e/generic/build_settings/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+package(default_visibility = ["//visibility:public"])
+
+string_flag(
+    name = "registry",
+    build_setting_default = "ghcr.io",
+)
+
+string_flag(
+    name = "user",
+    build_setting_default = "malt3",
+)
+
+string_flag(
+    name = "tag",
+    build_setting_default = "templated_tag",
+)

--- a/e2e/generic/load/BUILD.bazel
+++ b/e2e/generic/load/BUILD.bazel
@@ -36,6 +36,18 @@ image_load(
     tag = "ghcr.io/malt3/rules_img:sideloaded",
 )
 
+# load an image with template variables
+image_load(
+    name = "load_image_template",
+    build_settings = {
+        "REGISTRY": "//build_settings:registry",
+        "USER": "//build_settings:user",
+        "TAG": "//build_settings:tag",
+    },
+    image = ":image",
+    tag = "{{.REGISTRY}}/{{.USER}}/rules_img:{{.TAG}}",
+)
+
 # Load an index (multi-platform)
 image_load(
     name = "load_index",
@@ -72,6 +84,7 @@ build_test(
         ":image",
         ":load_index",
         ":load_image",
+        ":load_image_template",
         ":load_normalized",
     ],
 )

--- a/img/private/load.bzl
+++ b/img/private/load.bzl
@@ -114,7 +114,7 @@ def _expand_or_write(ctx, load_request, output_name):
             inputs = inputs,
             outputs = [final_json],
             executable = img_toolchain_info.tool_exe,
-            arguments = ["expand-template"] + args,
+            arguments = ["expand-template", "--kind", "load"] + args,
             mnemonic = "ExpandTemplate",
         )
         return final_json

--- a/img/private/push.bzl
+++ b/img/private/push.bzl
@@ -185,7 +185,7 @@ def _expand_or_write(ctx, push_request, output_name):
             inputs = inputs,
             outputs = [final_json],
             executable = img_toolchain_info.tool_exe,
-            arguments = ["expand-template"] + args,
+            arguments = ["expand-template", "--kind", "push"] + args,
             mnemonic = "ExpandTemplate",
         )
         return final_json


### PR DESCRIPTION
Fixes #26: The template expansion logic was expecting a push manifest. It is now capable of expanding push and load templates.