### PR TITLE
enable stamping by default

### DIFF
--- a/e2e/generic/load/BUILD.bazel
+++ b/e2e/generic/load/BUILD.bazel
@@ -38,7 +38,7 @@ image_load(
 
 # load an image with template variables
 image_load(
-    name = "load_image_template",
+    name = "load_image_templated",
     build_settings = {
         "REGISTRY": "//build_settings:registry",
         "USER": "//build_settings:user",
@@ -84,7 +84,7 @@ build_test(
         ":image",
         ":load_index",
         ":load_image",
-        ":load_image_template",
+        ":load_image_templated",
         ":load_normalized",
     ],
 )

--- a/img/settings/BUILD.bazel
+++ b/img/settings/BUILD.bazel
@@ -22,7 +22,7 @@ string_flag(
 
 string_flag(
     name = "stamp",
-    build_setting_default = "disabled",
+    build_setting_default = "enabled",
     values = [
         "enabled",
         "disabled",


### PR DESCRIPTION
As a first-time user, I'd expect the `--stamp` argument to Bazel to be honored without having to also enable it in another place.

Maybe there's a reason you have it this way?