### PR TITLE
loader: set default load platform to Linux

### DIFF
--- a/src/pkg/load/load.go
+++ b/src/pkg/load/load.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -288,6 +289,11 @@ func platformMatches(manifestPlatform *registryv1.Platform, requestedPlatforms [
 }
 
 // getCurrentPlatform returns the current platform string
+// It checks the DOCKER_DEFAULT_PLATFORM environment variable first
+// If not set, it defaults to "linux/$(GOARCH)".
 func getCurrentPlatform() string {
-	return runtime.GOOS + "/" + runtime.GOARCH
+	if plt, ok := os.LookupEnv("DOCKER_DEFAULT_PLATFORM"); ok {
+		return plt
+	}
+	return "linux/" + runtime.GOARCH
 }

--- a/src/pkg/load/loader.go
+++ b/src/pkg/load/loader.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 	"slices"
 
 	registryv1 "github.com/malt3/go-containerregistry/pkg/v1"
@@ -205,8 +204,9 @@ func (l *loader) selectManifestForPlatform(op api.IndexedLoadDeployOperation) (i
 	}
 
 	// If no platform specified, use current platform
+	// (but assume linux, the only true docker os 🐧)
 	if len(platforms) == 0 {
-		platforms = []string{runtime.GOOS + "/" + runtime.GOARCH}
+		platforms = []string{getCurrentPlatform()}
 	}
 
 	// Find matching manifest


### PR DESCRIPTION
On macOS, users probably want to load Linux images by default.
We also now check for $DOCKER_DEFAULT_PLATFORM, like docker.
Thanks to @mortenmj for the bug report.