### PR TITLE
cas read: don't set explicit read limit

### DIFF
--- a/src/pkg/cas/read.go
+++ b/src/pkg/cas/read.go
@@ -162,7 +162,6 @@ func (c *CAS) streamReadOne(ctx context.Context, digest Digest) (io.ReadCloser, 
 	resp, err := c.byteStreamClient.Read(ctx, &bytestream_proto.ReadRequest{
 		ResourceName: fmt.Sprintf("blobs/%x/%d", digest.Hash, digest.SizeBytes),
 		ReadOffset:   0,
-		ReadLimit:    digest.SizeBytes,
 	})
 	if err != nil {
 		cancel()


### PR DESCRIPTION
bb-storage doesn't support read limits, so we should leave the upper limit of bytes to be read up to the server.