### PR TITLE
stamping in config, manifest and index

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -12,7 +12,7 @@ and `image_index` to compose a multi-platform container image index.
 <pre>
 load("@rules_img//img:image.bzl", "image_index")
 
-image_index(<a href="#image_index-name">name</a>, <a href="#image_index-annotations">annotations</a>, <a href="#image_index-manifests">manifests</a>, <a href="#image_index-platforms">platforms</a>)
+image_index(<a href="#image_index-name">name</a>, <a href="#image_index-annotations">annotations</a>, <a href="#image_index-build_settings">build_settings</a>, <a href="#image_index-manifests">manifests</a>, <a href="#image_index-platforms">platforms</a>, <a href="#image_index-stamp">stamp</a>)
 </pre>
 
 Creates a multi-platform OCI image index from platform-specific manifests.
@@ -66,9 +66,11 @@ Output groups:
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="image_index-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="image_index-annotations"></a>annotations |  Arbitrary metadata for the image index.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="image_index-annotations"></a>annotations |  Arbitrary metadata for the image index.<br><br>Subject to [template expansion](/docs/templating.md).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="image_index-build_settings"></a>build_settings |  Build settings for template expansion.<br><br>Maps template variable names to string_flag targets. These values can be used in the annotations attribute using `{{.VARIABLE_NAME}}` syntax (Go template).<br><br>Example: <pre><code class="language-python">build_settings = {&#10;    "REGISTRY": "//settings:docker_registry",&#10;    "VERSION": "//settings:app_version",&#10;}</code></pre><br><br>See [template expansion](/docs/templating.md) for more details.   | Dictionary: String -> Label | optional |  `{}`  |
 | <a id="image_index-manifests"></a>manifests |  List of manifests for specific platforms.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="image_index-platforms"></a>platforms |  (Optional) list of target platforms to build the manifest for. Uses a split transition. If specified, the 'manifests' attribute should contain exactly one manifest.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="image_index-stamp"></a>stamp |  Enable build stamping for template expansion.<br><br>Controls whether to include volatile build information: - **`auto`** (default): Uses the global stamping configuration - **`enabled`**: Always include stamp information (BUILD_TIMESTAMP, BUILD_USER, etc.) if Bazel's "--stamp" flag is set - **`disabled`**: Never include stamp information<br><br>See [template expansion](/docs/templating.md) for available stamp variables.   | String | optional |  `"auto"`  |
 
 
 <a id="image_manifest"></a>
@@ -78,8 +80,8 @@ Output groups:
 <pre>
 load("@rules_img//img:image.bzl", "image_manifest")
 
-image_manifest(<a href="#image_manifest-name">name</a>, <a href="#image_manifest-annotations">annotations</a>, <a href="#image_manifest-base">base</a>, <a href="#image_manifest-cmd">cmd</a>, <a href="#image_manifest-config_fragment">config_fragment</a>, <a href="#image_manifest-entrypoint">entrypoint</a>, <a href="#image_manifest-env">env</a>, <a href="#image_manifest-labels">labels</a>, <a href="#image_manifest-layers">layers</a>,
-               <a href="#image_manifest-platform">platform</a>, <a href="#image_manifest-stop_signal">stop_signal</a>, <a href="#image_manifest-user">user</a>, <a href="#image_manifest-working_dir">working_dir</a>)
+image_manifest(<a href="#image_manifest-name">name</a>, <a href="#image_manifest-annotations">annotations</a>, <a href="#image_manifest-base">base</a>, <a href="#image_manifest-build_settings">build_settings</a>, <a href="#image_manifest-cmd">cmd</a>, <a href="#image_manifest-config_fragment">config_fragment</a>, <a href="#image_manifest-entrypoint">entrypoint</a>, <a href="#image_manifest-env">env</a>,
+               <a href="#image_manifest-labels">labels</a>, <a href="#image_manifest-layers">layers</a>, <a href="#image_manifest-platform">platform</a>, <a href="#image_manifest-stamp">stamp</a>, <a href="#image_manifest-stop_signal">stop_signal</a>, <a href="#image_manifest-user">user</a>, <a href="#image_manifest-working_dir">working_dir</a>)
 </pre>
 
 Builds a single-platform OCI container image from a set of layers.
@@ -123,15 +125,17 @@ Output groups:
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="image_manifest-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="image_manifest-annotations"></a>annotations |  This field contains arbitrary metadata for the manifest.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="image_manifest-annotations"></a>annotations |  This field contains arbitrary metadata for the manifest.<br><br>Subject to [template expansion](/docs/templating.md).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="image_manifest-base"></a>base |  Base image to inherit layers from. Should provide ImageManifestInfo or ImageIndexInfo.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="image_manifest-build_settings"></a>build_settings |  Build settings for template expansion.<br><br>Maps template variable names to string_flag targets. These values can be used in env, labels, and annotations attributes using `{{.VARIABLE_NAME}}` syntax (Go template).<br><br>Example: <pre><code class="language-python">build_settings = {&#10;    "REGISTRY": "//settings:docker_registry",&#10;    "VERSION": "//settings:app_version",&#10;}</code></pre><br><br>See [template expansion](/docs/templating.md) for more details.   | Dictionary: String -> Label | optional |  `{}`  |
 | <a id="image_manifest-cmd"></a>cmd |  Default arguments to the entrypoint of the container. These values act as defaults and may be replaced by any specified when creating a container. If an Entrypoint value is not specified, then the first entry of the Cmd array SHOULD be interpreted as the executable to run.   | List of strings | optional |  `[]`  |
 | <a id="image_manifest-config_fragment"></a>config_fragment |  Optional JSON file containing a partial image config, which will be used as a base for the final image config.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="image_manifest-entrypoint"></a>entrypoint |  A list of arguments to use as the command to execute when the container starts. These values act as defaults and may be replaced by an entrypoint specified when creating a container.   | List of strings | optional |  `[]`  |
-| <a id="image_manifest-env"></a>env |  Default environment variables to set when starting a container based on this image.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
-| <a id="image_manifest-labels"></a>labels |  This field contains arbitrary metadata for the container.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="image_manifest-env"></a>env |  Default environment variables to set when starting a container based on this image.<br><br>Subject to [template expansion](/docs/templating.md).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="image_manifest-labels"></a>labels |  This field contains arbitrary metadata for the container.<br><br>Subject to [template expansion](/docs/templating.md).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="image_manifest-layers"></a>layers |  Layers to include in the image. Either a LayerInfo provider or a DefaultInfo with tar files.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="image_manifest-platform"></a>platform |  Dict containing additional runtime requirements of the image.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="image_manifest-stamp"></a>stamp |  Enable build stamping for template expansion.<br><br>Controls whether to include volatile build information: - **`auto`** (default): Uses the global stamping configuration - **`enabled`**: Always include stamp information (BUILD_TIMESTAMP, BUILD_USER, etc.) if Bazel's "--stamp" flag is set - **`disabled`**: Never include stamp information<br><br>See [template expansion](/docs/templating.md) for available stamp variables.   | String | optional |  `"auto"`  |
 | <a id="image_manifest-stop_signal"></a>stop_signal |  This field contains the system call signal that will be sent to the container to exit. The signal can be a signal name in the format SIGNAME, for instance SIGKILL or SIGRTMIN+3.   | String | optional |  `""`  |
 | <a id="image_manifest-user"></a>user |  The username or UID which is a platform-specific structure that allows specific control over which user the process run as. This acts as a default value to use when the value is not specified when creating a container.   | String | optional |  `""`  |
 | <a id="image_manifest-working_dir"></a>working_dir |  Sets the current working directory of the entrypoint process in the container. This value acts as a default and may be replaced by a working directory specified when creating a container.   | String | optional |  `""`  |

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1,14 +1,15 @@
-# Templating and Stamping in image_push
+# Templating and Stamping
 
-The `image_push` rule supports Go templates for dynamic configuration of registry, repository, and tags. This feature enables flexible image naming based on build settings and Bazel's workspace status (stamping).
+The `image_manifest`, `image_index`, `image_push`, and `image_load` rules support Go templates for dynamic configuration. This feature enables flexible image naming and metadata based on build settings and Bazel's workspace status (stamping).
 
 ## Overview
 
 Templates allow you to:
 - Use different registries/repositories for different environments (dev, staging, prod)
 - Include version information from your build system
-- Add git commit hashes or timestamps to tags
+- Add git commit hashes or timestamps to tags and labels
 - Create conditional logic for tag naming
+- Inject dynamic metadata into container labels, environment variables, and annotations
 
 ## Basic Templating with Build Settings
 
@@ -74,7 +75,7 @@ This would push to:
 
 ## Stamping with Workspace Status
 
-Stamping allows you to include dynamic build information like git commits, timestamps, and version numbers in your container tags.
+Stamping allows you to include dynamic build information like git commits, timestamps, and version numbers in your container tags, labels, environment variables, and annotations.
 
 ### Requirements for Stamping
 
@@ -84,7 +85,7 @@ Stamping allows you to include dynamic build information like git commits, times
    - By default, Bazel disables stamping for build reproducibility and performance
    - You must explicitly add `--stamp` to your build command or `.bazelrc`
 
-2. **Target level**: Enable stamping for specific `image_push` targets
+2. **Target level**: Enable stamping for specific `image_push`, `image_load`, `image_manifest`, or `image_index` targets
    - Set `stamp = "enabled"` on the target, OR
    - Set `stamp = "auto"` (the default) and use `--@rules_img//img/settings:stamp=enabled`
 

--- a/e2e/go/customization/BUILD.bazel
+++ b/e2e/go/customization/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "int_flag", "string_flag")
-load("@rules_img//img:image.bzl", "image_manifest")
+load("@rules_img//img:image.bzl", "image_index", "image_manifest")
 load("@rules_img//img:layer.bzl", "image_layer")
 load("@rules_img//img:push.bzl", "image_push")
 
@@ -35,6 +35,57 @@ image_manifest(
     ],
     stop_signal = "SIGKILL",
     user = "0",
+)
+
+image_manifest(
+    name = "go_image_with_stamping",
+    annotations = {
+        "org.opencontainers.image.title": "Go Application with Template Stamping",
+        "org.opencontainers.image.source": "{{.repo}}",
+        "build.version": "{{.tag}}",
+    },
+    build_settings = {
+        "repo": ":repo",
+        "tag": ":tag",
+        "copyright_year": ":copyright_year",
+        "is_production": ":is_production",
+    },
+    entrypoint = ["/bin/app"],
+    env = {
+        "VERSION": "{{.tag}}",
+        "BUILD_TIME": "{{if .BUILD_TIMESTAMP}}{{.BUILD_TIMESTAMP}}{{else}}0{{end}}",
+        "PRODUCTION_MODE": "{{.is_production}}",
+    },
+    labels = {
+        "org.opencontainers.image.version": "{{.tag}}",
+        "build.timestamp": "{{.BUILD_TIMESTAMP}}",
+        "build.year": "{{.copyright_year}}",
+        "production": "{{.is_production}}",
+    },
+    layers = [
+        ":go_layer",
+    ],
+    stamp = "enabled",
+)
+
+image_index(
+    name = "index_with_stamping",
+    annotations = {
+        "org.opencontainers.image.title": "Multi-platform Go Application",
+        "org.opencontainers.image.source": "{{.repo}}",
+        "build.version": "{{.tag}}",
+        "build.timestamp": "{{.BUILD_TIMESTAMP}}",
+        "build.year": "{{.copyright_year}}",
+        "production": "{{.is_production}}",
+    },
+    build_settings = {
+        "repo": ":repo",
+        "tag": ":tag",
+        "copyright_year": ":copyright_year",
+        "is_production": ":is_production",
+    },
+    manifests = [":go_image_with_stamping"],
+    stamp = "enabled",
 )
 
 image_push(
@@ -90,6 +141,8 @@ build_test(
     targets = [
         ":go_layer",
         ":go_image",
+        ":go_image_with_stamping",
+        ":index_with_stamping",
         ":push",
     ],
 )

--- a/img/private/BUILD.bazel
+++ b/img/private/BUILD.bazel
@@ -15,10 +15,14 @@ bzl_library(
     srcs = ["index.bzl"],
     visibility = ["//img:__subpackages__"],
     deps = [
+        ":stamp",
         "//img:providers",
+        "//img/private/common:build",
         "//img/private/common:transitions",
         "//img/private/common:write_index_json",
         "//img/private/providers:oci_layout_settings_info",
+        "//img/private/providers:stamp_setting_info",
+        "@bazel_skylib//rules:common_settings",
     ],
 )
 
@@ -82,6 +86,8 @@ bzl_library(
     srcs = ["manifest.bzl"],
     visibility = ["//img:__subpackages__"],
     deps = [
+        ":stamp",
+        "//img/private/common:build",
         "//img/private/common:layer_helper",
         "//img/private/common:transitions",
         "//img/private/config:defs",
@@ -90,6 +96,8 @@ bzl_library(
         "//img/private/providers:manifest_info",
         "//img/private/providers:oci_layout_settings_info",
         "//img/private/providers:pull_info",
+        "//img/private/providers:stamp_setting_info",
+        "@bazel_skylib//rules:common_settings",
     ],
 )
 

--- a/img/private/common/write_index_json.bzl
+++ b/img/private/common/write_index_json.bzl
@@ -5,7 +5,7 @@ load("//img/private/common:build.bzl", "TOOLCHAIN")
 def _annotation_arg(tup):
     return "{}={}".format(tup[0], tup[1])
 
-def write_index_json(ctx, *, output, digest, manifests):
+def write_index_json(ctx, *, output, digest, manifests, config_json = None):
     """Write an index.json file for a multi-platform image.
 
     Args:
@@ -13,18 +13,27 @@ def write_index_json(ctx, *, output, digest, manifests):
         output: Output file to write.
         digest: Digest file to write.
         manifests: List of manifests to include in the index.
+        config_json: Optional config JSON file with template expansions.
     """
     manifest_descriptors = [manifest.descriptor for manifest in manifests]
     args = ctx.actions.args()
     args.add("index")
     args.add("--digest", digest.path)
     args.add_all(manifest_descriptors, format_each = "--manifest-descriptor=%s")
-    args.add_all(ctx.attr.annotations.items(), map_each = _annotation_arg, format_each = "--annotation=%s")
+
+    inputs = manifest_descriptors
+
+    if config_json:
+        args.add("--config-templates", config_json.path)
+        inputs.append(config_json)
+    else:
+        args.add_all(ctx.attr.annotations.items(), map_each = _annotation_arg, format_each = "--annotation=%s")
+
     args.add(output.path)
     img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
     ctx.actions.run(
         outputs = [output, digest],
-        inputs = manifest_descriptors,
+        inputs = inputs,
         executable = img_toolchain_info.tool_exe,
         arguments = [args],
         mnemonic = "ImageIndex",

--- a/img/private/stamp.bzl
+++ b/img/private/stamp.bzl
@@ -57,19 +57,25 @@ def should_stamp(*, ctx, template_strings):
         want_stamp = want_stamp,
     )
 
-def expand_or_write(*, ctx, templates, output_name):
+def expand_or_write(*, ctx, templates, output_name, only_if_stamping = False):
     """Either expand templates or write JSON directly based on build_settings.
 
     Args:
         ctx: The rule context
         templates: The templates dictionary (dict of template name to value (str) or values (list of str))
         output_name: The name for the output file
+        only_if_stamping: If True, only create the file if stamping is needed (templates contain {{}})
 
     Returns:
-        The File object for the final JSON
+        The File object for the final JSON, or None if only_if_stamping=True and no stamping needed
     """
     build_settings = get_build_settings(ctx)
     stamp_settings = should_stamp(ctx = ctx, template_strings = [json.encode(v) for v in templates.values()])
+
+    # If only_if_stamping is True and no stamping is needed, return None
+    if only_if_stamping and not stamp_settings.want_stamp:
+        return None
+
     final_json = ctx.actions.declare_file(output_name)
 
     if build_settings or stamp_settings.want_stamp:


### PR DESCRIPTION
This change enables stamping in OCI labels, annotations, and env.

Closes #57