### PR TITLE
pull: handle missing "registry" attr correctly

### DIFF
--- a/e2e/generic/MODULE.bazel
+++ b/e2e/generic/MODULE.bazel
@@ -50,3 +50,12 @@ pull(
     registry = "index.docker.io",
     repository = "library/nginx",
 )
+
+# minimal information:
+# Just the digest and the repository.
+# This relies on the default registry (index.docker.io) for compatibility with rules_oci.
+pull(
+    name = "debian",
+    digest = "sha256:432f545c6ba13b79e2681f4cc4858788b0ab099fc1cca799cc0fae4687c69070",
+    repository = "debian",
+)

--- a/e2e/generic/load/BUILD.bazel
+++ b/e2e/generic/load/BUILD.bazel
@@ -83,6 +83,13 @@ image_load(
     visibility = ["//visibility:public"],
 )
 
+image_load(
+    name = "load_debian",
+    image = "@debian",
+    tag = "ghcr.io/malt3/rules_img:debian-sideloaded",
+    visibility = ["//visibility:public"],
+)
+
 build_test(
     name = "test",
     targets = [

--- a/img/private/repository_rules/pull.bzl
+++ b/img/private/repository_rules/pull.bzl
@@ -146,6 +146,10 @@ def _pull_impl(rctx):
         registries.append(rctx.attr.registry)
     if len(rctx.attr.registries) > 0:
         registries.extend(rctx.attr.registries)
+    if len(registries) == 0:
+        # default to Docker Hub.
+        # This exists mostly for compatibility with rules_oci.
+        registries.append("index.docker.io")
 
     name = getattr(rctx, "original_name", rctx.attr.name)
     if not hasattr(rctx, "original_name"):


### PR DESCRIPTION
We need to record what registry an image comes from to support shallow base images. When no registry is specified, pulling works, but the registry wasn't recorded. This leads to issues at deploy time, where the layers of the base image need to be streamed in if they are missing.
Without a proper source, it's unclear where to stream them from.

This change ensures we always record a registry for any downloaded image, even if the registry attr is left uninitialized.

Fixes #65