### PR TITLE
tar layer creation: calculate digests of inputs in advance

### DIFF
--- a/src/cmd/layer/BUILD.bazel
+++ b/src/cmd/layer/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/api",
         "//pkg/compress",
         "//pkg/contentmanifest",
+        "//pkg/digestfs",
         "//pkg/tarcas",
         "//pkg/tree",
         "//pkg/tree/runfiles",

--- a/src/pkg/digestfs/BUILD.bazel
+++ b/src/pkg/digestfs/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "digestfs",
-    srcs = ["digestfs.go"],
+    srcs = [
+        "digestfs.go",
+        "precacher.go",
+    ],
     importpath = "github.com/tweag/rules_img/src/pkg/digestfs",
     visibility = ["//visibility:public"],
 )

--- a/src/pkg/digestfs/precacher.go
+++ b/src/pkg/digestfs/precacher.go
@@ -1,0 +1,90 @@
+package digestfs
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Precacher manages background digest calculation for a FileSystem
+type Precacher struct {
+	fs         *FileSystem
+	tasks      chan string
+	done       chan struct{}
+	wg         sync.WaitGroup
+	numWorkers int
+}
+
+// NewPrecacher creates a new precacher for the given FileSystem
+func NewPrecacher(fs *FileSystem, numWorkers int) *Precacher {
+	if numWorkers <= 0 {
+		numWorkers = 4 // Default to 4 workers
+	}
+
+	p := &Precacher{
+		fs:         fs,
+		tasks:      make(chan string, numWorkers*2), // Small buffer to avoid blocking
+		done:       make(chan struct{}),
+		numWorkers: numWorkers,
+	}
+
+	// Start worker goroutines
+	for i := 0; i < numWorkers; i++ {
+		p.wg.Add(1)
+		go p.worker()
+	}
+
+	return p
+}
+
+// PrecacheFiles schedules files for background digest calculation in order
+func (p *Precacher) PrecacheFiles(files []string) {
+	// Send files to workers in order
+	go func() {
+		for _, file := range files {
+			select {
+			case p.tasks <- file:
+			case <-p.done:
+				return
+			}
+		}
+	}()
+}
+
+// Close shuts down the precaching workers
+func (p *Precacher) Close() error {
+	close(p.done)
+	p.wg.Wait()
+	close(p.tasks)
+	return nil
+}
+
+// worker processes precaching requests
+func (p *Precacher) worker() {
+	defer p.wg.Done()
+
+	for {
+		select {
+		case path := <-p.tasks:
+			// Precalculate digest for this file
+			p.precacheFile(path)
+		case <-p.done:
+			return
+		}
+	}
+}
+
+// precacheFile calculates and caches the digest for a single file
+func (p *Precacher) precacheFile(path string) {
+	// Open file and trigger digest calculation
+	file, err := p.fs.OpenFile(path)
+	if err != nil {
+		// Ignore errors - precaching is optional
+		return
+	}
+	defer file.Close()
+
+	cachedDigestFile := file.(*cachedDigestFile)
+	if err := cachedDigestFile.precache(); err != nil {
+		fmt.Printf("Precaching error for %s: %v\n", path, err)
+	}
+}

--- a/src/pkg/tarcas/factory.go
+++ b/src/pkg/tarcas/factory.go
@@ -6,6 +6,7 @@ import (
 	"hash"
 
 	"github.com/tweag/rules_img/src/pkg/api"
+	"github.com/tweag/rules_img/src/pkg/digestfs"
 )
 
 type SHA256Helper struct{}
@@ -18,10 +19,22 @@ func NewSHA256CAS(appender api.TarAppender, options ...Option) *CAS[SHA256Helper
 	return New[SHA256Helper](appender, options...)
 }
 
+func NewSHA256CASWithDigestFS(appender api.TarAppender, digestFS *digestfs.FileSystem, options ...Option) *CAS[SHA256Helper] {
+	return NewWithDigestFS[SHA256Helper](appender, digestFS, options...)
+}
+
 func CASFactory(hashAlgorithm string, appender api.TarAppender, options ...Option) (api.TarCAS, error) {
 	switch {
 	case hashAlgorithm == "sha256":
 		return NewSHA256CAS(appender, options...), nil
+	}
+	return nil, errors.New("unsupported hash algorithm")
+}
+
+func CASFactoryWithDigestFS(hashAlgorithm string, appender api.TarAppender, digestFS *digestfs.FileSystem, options ...Option) (api.TarCAS, error) {
+	switch {
+	case hashAlgorithm == "sha256":
+		return NewSHA256CASWithDigestFS(appender, digestFS, options...), nil
 	}
 	return nil, errors.New("unsupported hash algorithm")
 }

--- a/src/pkg/tarcas/tarcas.go
+++ b/src/pkg/tarcas/tarcas.go
@@ -55,6 +55,28 @@ func New[HM hashHelper](appender api.TarAppender, opts ...Option) *CAS[HM] {
 	}
 }
 
+func NewWithDigestFS[HM hashHelper](appender api.TarAppender, digestFS *digestfs.FileSystem, opts ...Option) *CAS[HM] {
+	options := options{
+		structure:                 CASFirst,
+		writeHeaderCallbackFilter: WriteHeaderCallbackFilterDefault,
+	}
+	for _, opt := range opts {
+		opt.apply(&options)
+	}
+
+	return &CAS[HM]{
+		tarAppender:  appender,
+		hashOrder:    [][]byte{},
+		nodeOrder:    [][]byte{},
+		treeOrder:    [][]byte{},
+		storedHashes: make(map[string]struct{}),
+		storedNodes:  make(map[string]struct{}),
+		storedTrees:  make(map[string]struct{}),
+		digestFS:     digestFS,
+		options:      options,
+	}
+}
+
 func (c *CAS[HM]) writeHeaderAndData(hdr *tar.Header, data io.Reader) error {
 	// Create a tar entry with header and data combined
 	var buf bytes.Buffer


### PR DESCRIPTION
This change adds worker goroutines that inspect input files used to create a layer. The inputs will be hashed in advance to prefill the cache used when deduplicating files while building the tar file. This change should help to improve layer creation, as the throughput is currently limited by how fast we can feed data into the compressor.