### PR TITLE
feat: add tag_file attribute to image_push and image_load

### DIFF
--- a/docs/load.md
+++ b/docs/load.md
@@ -68,7 +68,7 @@ bazel run //path/to:load_target -- --platform linux/amd64
 <pre>
 load("@rules_img//img:load.bzl", "image_load")
 
-image_load(<a href="#image_load-name">name</a>, <a href="#image_load-build_settings">build_settings</a>, <a href="#image_load-daemon">daemon</a>, <a href="#image_load-image">image</a>, <a href="#image_load-stamp">stamp</a>, <a href="#image_load-strategy">strategy</a>, <a href="#image_load-tag">tag</a>, <a href="#image_load-tag_list">tag_list</a>)
+image_load(<a href="#image_load-name">name</a>, <a href="#image_load-build_settings">build_settings</a>, <a href="#image_load-daemon">daemon</a>, <a href="#image_load-image">image</a>, <a href="#image_load-stamp">stamp</a>, <a href="#image_load-strategy">strategy</a>, <a href="#image_load-tag">tag</a>, <a href="#image_load-tag_file">tag_file</a>, <a href="#image_load-tag_list">tag_list</a>)
 </pre>
 
 Loads container images into a local daemon (Docker or containerd).
@@ -157,6 +157,7 @@ Performance notes:
 | <a id="image_load-stamp"></a>stamp |  Whether to use stamping for [template expansion](/docs/templating.md). If 'enabled', uses volatile-status.txt and version.txt if present. 'auto' uses the global default setting.   | String | optional |  `"auto"`  |
 | <a id="image_load-strategy"></a>strategy |  Strategy for handling image layers during load.<br><br>Available strategies: - **`auto`** (default): Uses the global default load strategy - **`eager`**: Downloads all layers during the build phase. Ensures all layers are   available locally before running the load command. - **`lazy`**: Downloads layers only when needed during the load operation. More   efficient for large images where some layers might already exist in the daemon.   | String | optional |  `"auto"`  |
 | <a id="image_load-tag"></a>tag |  Tag to apply when loading the image.<br><br>Optional - if omitted, the image is loaded without a tag.<br><br>Subject to [template expansion](/docs/templating.md).   | String | optional |  `""`  |
-| <a id="image_load-tag_list"></a>tag_list |  List of tags to apply when loading the image.<br><br>Useful for applying multiple tags in a single load:<br><br><pre><code class="language-python">tag_list = ["latest", "v1.0.0", "stable"]</code></pre><br><br>Cannot be used together with `tag`. Each tag is subject to [template expansion](/docs/templating.md).   | List of strings | optional |  `[]`  |
+| <a id="image_load-tag_file"></a>tag_file |  File containing newline-delimited tags to apply when loading the image.<br><br>The file should contain one tag per line. Empty lines are ignored. Tags from this file are merged with tags specified via `tag` or `tag_list` attributes.<br><br>Example file content: <pre><code>latest&#10;v1.0.0&#10;stable</code></pre><br><br>Can be combined with `tag` or `tag_list` to merge tags from multiple sources. Each tag is subject to [template expansion](/docs/templating.md).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="image_load-tag_list"></a>tag_list |  List of tags to apply when loading the image.<br><br>Useful for applying multiple tags in a single load:<br><br><pre><code class="language-python">tag_list = ["latest", "v1.0.0", "stable"]</code></pre><br><br>Cannot be used together with `tag`. Can be combined with `tag_file` to merge tags from both sources. Each tag is subject to [template expansion](/docs/templating.md).   | List of strings | optional |  `[]`  |
 
 

--- a/docs/push.md
+++ b/docs/push.md
@@ -9,7 +9,8 @@ Public API for container image push rules.
 <pre>
 load("@rules_img//img:push.bzl", "image_push")
 
-image_push(<a href="#image_push-name">name</a>, <a href="#image_push-build_settings">build_settings</a>, <a href="#image_push-image">image</a>, <a href="#image_push-registry">registry</a>, <a href="#image_push-repository">repository</a>, <a href="#image_push-stamp">stamp</a>, <a href="#image_push-strategy">strategy</a>, <a href="#image_push-tag">tag</a>, <a href="#image_push-tag_list">tag_list</a>)
+image_push(<a href="#image_push-name">name</a>, <a href="#image_push-build_settings">build_settings</a>, <a href="#image_push-image">image</a>, <a href="#image_push-registry">registry</a>, <a href="#image_push-repository">repository</a>, <a href="#image_push-stamp">stamp</a>, <a href="#image_push-strategy">strategy</a>, <a href="#image_push-tag">tag</a>, <a href="#image_push-tag_file">tag_file</a>,
+           <a href="#image_push-tag_list">tag_list</a>)
 </pre>
 
 Pushes container images to a registry.
@@ -114,6 +115,7 @@ bazel run //path/to:push_app
 | <a id="image_push-stamp"></a>stamp |  Enable build stamping for template expansion.<br><br>Controls whether to include volatile build information: - **`auto`** (default): Uses the global stamping configuration - **`enabled`**: Always include stamp information (BUILD_TIMESTAMP, BUILD_USER, etc.) if Bazel's "--stamp" flag is set - **`disabled`**: Never include stamp information<br><br>See [template expansion](/docs/templating.md) for available stamp variables.   | String | optional |  `"auto"`  |
 | <a id="image_push-strategy"></a>strategy |  Push strategy to use.<br><br>See [push strategies documentation](/docs/push-strategies.md) for detailed information.   | String | optional |  `"auto"`  |
 | <a id="image_push-tag"></a>tag |  Tag to apply to the pushed image.<br><br>Optional - if omitted, the image is pushed by digest only.<br><br>Subject to [template expansion](/docs/templating.md).   | String | optional |  `""`  |
-| <a id="image_push-tag_list"></a>tag_list |  List of tags to apply to the pushed image.<br><br>Useful for applying multiple tags in a single push:<br><br><pre><code class="language-python">tag_list = ["latest", "v1.0.0", "stable"]</code></pre><br><br>Cannot be used together with `tag`. Each tag is subject to [template expansion](/docs/templating.md).   | List of strings | optional |  `[]`  |
+| <a id="image_push-tag_file"></a>tag_file |  File containing newline-delimited tags to apply to the pushed image.<br><br>The file should contain one tag per line. Empty lines are ignored. Tags from this file are merged with tags specified via `tag` or `tag_list` attributes.<br><br>Example file content: <pre><code>latest&#10;v1.0.0&#10;stable</code></pre><br><br>Can be combined with `tag` or `tag_list` to merge tags from multiple sources. Each tag is subject to [template expansion](/docs/templating.md).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="image_push-tag_list"></a>tag_list |  List of tags to apply to the pushed image.<br><br>Useful for applying multiple tags in a single push:<br><br><pre><code class="language-python">tag_list = ["latest", "v1.0.0", "stable"]</code></pre><br><br>Cannot be used together with `tag`. Can be combined with `tag_file` to merge tags from both sources. Each tag is subject to [template expansion](/docs/templating.md).   | List of strings | optional |  `[]`  |
 
 

--- a/e2e/generic/BUILD.bazel
+++ b/e2e/generic/BUILD.bazel
@@ -301,6 +301,27 @@ image_push(
     visibility = ["//visibility:public"],
 )
 
+# File containing multiple tags (one per line)
+write_file(
+    name = "push_tags_file",
+    out = "push_tags.txt",
+    content = [
+        "v1.0.0",
+        "v1.0",
+        "stable",
+    ],
+)
+
+# Test push with tag_file
+image_push(
+    name = "push_tag_file",
+    image = ":single_layer_manifest",
+    registry = "ghcr.io",
+    repository = "malt3/rules_img/e2e-generic-tag-file",
+    tag_file = ":push_tags_file",
+    visibility = ["//visibility:public"],
+)
+
 # Build tests to ensure all targets can be built
 build_test(
     name = "layer_tests",
@@ -342,6 +363,7 @@ build_test(
         ":push_index",
         ":push_complex",
         ":push_with_created",
+        ":push_tag_file",
     ],
 )
 

--- a/e2e/generic/load/BUILD.bazel
+++ b/e2e/generic/load/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_img//img:image.bzl", "image_index", "image_manifest")
 load("@rules_img//img:layer.bzl", "image_layer")
 load("@rules_img//img:load.bzl", "image_load")
@@ -95,6 +96,25 @@ image_load(
     visibility = ["//visibility:public"],
 )
 
+# File containing multiple tags (one per line)
+write_file(
+    name = "tags_file",
+    out = "tags.txt",
+    content = [
+        "ghcr.io/malt3/rules_img:from-file-v1",
+        "ghcr.io/malt3/rules_img:from-file-v2",
+        "ghcr.io/malt3/rules_img:from-file-stable",
+    ],
+)
+
+# Load with tags from file
+image_load(
+    name = "load_tag_file",
+    image = ":image",
+    tag_file = ":tags_file",
+    visibility = ["//visibility:public"],
+)
+
 build_test(
     name = "test",
     targets = [
@@ -105,5 +125,6 @@ build_test(
         ":load_image_templated",
         ":load_normalized",
         ":load_multi_tags",
+        ":load_tag_file",
     ],
 )


### PR DESCRIPTION
Add support for specifying container image tags from a file. The tag_file attribute accepts a file containing newline-delimited tags that are merged with any tags specified via tag or tag_list.

Implementation details:
- Extended expand-template command to support newline_delimited_lists_files
- Updated expand_or_write() to handle file-based list inputs
- Modified image_push and image_load rules to accept tag_file attribute
- Tags from files support template expansion
- Empty lines in files are ignored
- Duplicate tags are automatically removed

Fixes #205