### PR TITLE
pull: use canonical label to refer to @platforms

### DIFF
--- a/img/private/repository_rules/pull.bzl
+++ b/img/private/repository_rules/pull.bzl
@@ -32,7 +32,7 @@ def _map_os_arch_to_constraints(os_arch_pairs):
     select_dict = {}
     for os_arch in sorted(os_arch_pairs):
         select_dict['"@rules_img//img/constraints:{}"'.format(os_arch)] = "[]"
-    select_dict['"//conditions:default"'] = '["@platforms//:incompatible"]'
+    select_dict['"//conditions:default"'] = '["{}"]'.format(str(Label("@platforms//:incompatible")))
 
     # Build the select expression string
     select_items = []


### PR DESCRIPTION
Unlike `use_extension`, which sees all module dependencies of the Bazel module it was defined in, `use_repo_rule` sees modules from the perspective of the caller. To work around this, we now embed a canonical repo name to refer to the platforms module.

Fixes #228.