### PR TITLE
doc: Fix a name error in an example

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -172,7 +172,7 @@ Use this platform when building images for your local Docker daemon:
 
 ```starlark
 image_manifest(
-    name = "app",
+    name = "image",
     base = "@ubuntu",
     layers = [
         ":app_layer",


### PR DESCRIPTION
The second rule references `:image` and in the context of the example it looks like it means the rule named `app`.