### PR TITLE
Add annotations_file attribute

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -12,7 +12,7 @@ and `image_index` to compose a multi-platform container image index.
 <pre>
 load("@rules_img//img:image.bzl", "image_index")
 
-image_index(<a href="#image_index-name">name</a>, <a href="#image_index-annotations">annotations</a>, <a href="#image_index-build_settings">build_settings</a>, <a href="#image_index-manifests">manifests</a>, <a href="#image_index-platforms">platforms</a>, <a href="#image_index-stamp">stamp</a>)
+image_index(<a href="#image_index-name">name</a>, <a href="#image_index-annotations">annotations</a>, <a href="#image_index-annotations_file">annotations_file</a>, <a href="#image_index-build_settings">build_settings</a>, <a href="#image_index-manifests">manifests</a>, <a href="#image_index-platforms">platforms</a>, <a href="#image_index-stamp">stamp</a>)
 </pre>
 
 Creates a multi-platform OCI image index from platform-specific manifests.
@@ -67,6 +67,7 @@ Output groups:
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="image_index-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="image_index-annotations"></a>annotations |  Arbitrary metadata for the image index.<br><br>Subject to [template expansion](/docs/templating.md).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="image_index-annotations_file"></a>annotations_file |  File containing newline-delimited KEY=VALUE annotations for the image index.<br><br>The file should contain one annotation per line in KEY=VALUE format. Empty lines are ignored. Annotations from this file are merged with annotations specified via the `annotations` attribute.<br><br>Example file content: <pre><code>version=1.0.0&#10;build.date=2024-01-15&#10;source.url=https://github.com/...</code></pre><br><br>Each annotation is subject to [template expansion](/docs/templating.md).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="image_index-build_settings"></a>build_settings |  Build settings for template expansion.<br><br>Maps template variable names to string_flag targets. These values can be used in the annotations attribute using `{{.VARIABLE_NAME}}` syntax (Go template).<br><br>Example: <pre><code class="language-python">build_settings = {&#10;    "REGISTRY": "//settings:docker_registry",&#10;    "VERSION": "//settings:app_version",&#10;}</code></pre><br><br>See [template expansion](/docs/templating.md) for more details.   | Dictionary: String -> Label | optional |  `{}`  |
 | <a id="image_index-manifests"></a>manifests |  List of manifests for specific platforms.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="image_index-platforms"></a>platforms |  (Optional) list of target platforms to build the manifest for. Uses a split transition. If specified, the 'manifests' attribute should contain exactly one manifest.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
@@ -80,8 +81,9 @@ Output groups:
 <pre>
 load("@rules_img//img:image.bzl", "image_manifest")
 
-image_manifest(<a href="#image_manifest-name">name</a>, <a href="#image_manifest-annotations">annotations</a>, <a href="#image_manifest-base">base</a>, <a href="#image_manifest-build_settings">build_settings</a>, <a href="#image_manifest-cmd">cmd</a>, <a href="#image_manifest-config_fragment">config_fragment</a>, <a href="#image_manifest-created">created</a>, <a href="#image_manifest-entrypoint">entrypoint</a>,
-               <a href="#image_manifest-env">env</a>, <a href="#image_manifest-labels">labels</a>, <a href="#image_manifest-layers">layers</a>, <a href="#image_manifest-platform">platform</a>, <a href="#image_manifest-stamp">stamp</a>, <a href="#image_manifest-stop_signal">stop_signal</a>, <a href="#image_manifest-user">user</a>, <a href="#image_manifest-working_dir">working_dir</a>)
+image_manifest(<a href="#image_manifest-name">name</a>, <a href="#image_manifest-annotations">annotations</a>, <a href="#image_manifest-annotations_file">annotations_file</a>, <a href="#image_manifest-base">base</a>, <a href="#image_manifest-build_settings">build_settings</a>, <a href="#image_manifest-cmd">cmd</a>, <a href="#image_manifest-config_fragment">config_fragment</a>,
+               <a href="#image_manifest-created">created</a>, <a href="#image_manifest-entrypoint">entrypoint</a>, <a href="#image_manifest-env">env</a>, <a href="#image_manifest-labels">labels</a>, <a href="#image_manifest-layers">layers</a>, <a href="#image_manifest-platform">platform</a>, <a href="#image_manifest-stamp">stamp</a>, <a href="#image_manifest-stop_signal">stop_signal</a>, <a href="#image_manifest-user">user</a>,
+               <a href="#image_manifest-working_dir">working_dir</a>)
 </pre>
 
 Builds a single-platform OCI container image from a set of layers.
@@ -126,6 +128,7 @@ Output groups:
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="image_manifest-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="image_manifest-annotations"></a>annotations |  This field contains arbitrary metadata for the manifest.<br><br>Subject to [template expansion](/docs/templating.md).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="image_manifest-annotations_file"></a>annotations_file |  File containing newline-delimited KEY=VALUE annotations for the manifest.<br><br>The file should contain one annotation per line in KEY=VALUE format. Empty lines are ignored. Annotations from this file are merged with annotations specified via the `annotations` attribute.<br><br>Example file content: <pre><code>version=1.0.0&#10;build.date=2024-01-15&#10;source.url=https://github.com/...</code></pre><br><br>Each annotation is subject to [template expansion](/docs/templating.md).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="image_manifest-base"></a>base |  Base image to inherit layers from. Should provide ImageManifestInfo or ImageIndexInfo.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="image_manifest-build_settings"></a>build_settings |  Build settings for template expansion.<br><br>Maps template variable names to string_flag targets. These values can be used in env, labels, and annotations attributes using `{{.VARIABLE_NAME}}` syntax (Go template).<br><br>Example: <pre><code class="language-python">build_settings = {&#10;    "REGISTRY": "//settings:docker_registry",&#10;    "VERSION": "//settings:app_version",&#10;}</code></pre><br><br>See [template expansion](/docs/templating.md) for more details.   | Dictionary: String -> Label | optional |  `{}`  |
 | <a id="image_manifest-cmd"></a>cmd |  Default arguments to the entrypoint of the container. These values act as defaults and may be replaced by any specified when creating a container. If an Entrypoint value is not specified, then the first entry of the Cmd array SHOULD be interpreted as the executable to run.   | List of strings | optional |  `[]`  |

--- a/docs/layer.md
+++ b/docs/layer.md
@@ -9,8 +9,8 @@ Public API for container image layer rules.
 <pre>
 load("@rules_img//img:layer.bzl", "image_layer")
 
-image_layer(<a href="#image_layer-name">name</a>, <a href="#image_layer-srcs">srcs</a>, <a href="#image_layer-annotations">annotations</a>, <a href="#image_layer-compress">compress</a>, <a href="#image_layer-create_parent_directories">create_parent_directories</a>, <a href="#image_layer-default_metadata">default_metadata</a>, <a href="#image_layer-estargz">estargz</a>,
-            <a href="#image_layer-file_metadata">file_metadata</a>, <a href="#image_layer-include_runfiles">include_runfiles</a>, <a href="#image_layer-symlinks">symlinks</a>)
+image_layer(<a href="#image_layer-name">name</a>, <a href="#image_layer-srcs">srcs</a>, <a href="#image_layer-annotations">annotations</a>, <a href="#image_layer-annotations_file">annotations_file</a>, <a href="#image_layer-compress">compress</a>, <a href="#image_layer-create_parent_directories">create_parent_directories</a>,
+            <a href="#image_layer-default_metadata">default_metadata</a>, <a href="#image_layer-estargz">estargz</a>, <a href="#image_layer-file_metadata">file_metadata</a>, <a href="#image_layer-include_runfiles">include_runfiles</a>, <a href="#image_layer-symlinks">symlinks</a>)
 </pre>
 
 Creates a container image layer from files, executables, and directories.
@@ -73,6 +73,7 @@ image_layer(
 | <a id="image_layer-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="image_layer-srcs"></a>srcs |  Files to include in the layer. Keys are paths in the image (e.g., "/app/bin/server"), values are labels to files or executables. Executables automatically include their runfiles unless include_runfiles is set to False.   | Dictionary: String -> Label | optional |  `{}`  |
 | <a id="image_layer-annotations"></a>annotations |  Annotations to add to the layer metadata as key-value pairs.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="image_layer-annotations_file"></a>annotations_file |  File containing newline-delimited KEY=VALUE annotations for the layer.<br><br>The file should contain one annotation per line in KEY=VALUE format. Empty lines are ignored. Annotations from this file are merged with annotations specified via the `annotations` attribute.<br><br>Example file content: <pre><code>version=1.0.0&#10;build.date=2024-01-15&#10;source.url=https://github.com/...</code></pre>   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="image_layer-compress"></a>compress |  Compression algorithm to use. If set to 'auto', uses the global default compression setting.   | String | optional |  `"auto"`  |
 | <a id="image_layer-create_parent_directories"></a>create_parent_directories |  Whether to automatically create parent directory entries in the tar file for all files. If set to 'auto', uses the global default create_parent_directories setting. When enabled, parent directories will be created automatically for all files in the layer.   | String | optional |  `"auto"`  |
 | <a id="image_layer-default_metadata"></a>default_metadata |  JSON-encoded default metadata to apply to all files in the layer. Can include fields like mode, uid, gid, uname, gname, mtime, and pax_records.   | String | optional |  `""`  |

--- a/e2e/generic/BUILD.bazel
+++ b/e2e/generic/BUILD.bazel
@@ -222,6 +222,36 @@ image_push(
     visibility = ["//visibility:public"],
 )
 
+# File containing annotations (one KEY=VALUE per line)
+write_file(
+    name = "manifest_annotations_file",
+    out = "manifest_annotations.txt",
+    content = [
+        "org.opencontainers.image.source=https://github.com/bazel-contrib/rules_img",
+        "org.opencontainers.image.revision=abc123",
+        "custom.build.number=42",
+        "custom.environment=test",
+    ],
+)
+
+# Edge case: Manifest with annotations from file
+image_manifest(
+    name = "manifest_with_annotations_file",
+    annotations_file = ":manifest_annotations_file",
+    layers = [":mixed_layer"],
+)
+
+# Edge case: Manifest with both inline annotations and annotations_file
+image_manifest(
+    name = "manifest_with_merged_annotations",
+    annotations = {
+        "inline.annotation": "inline value",
+        "org.opencontainers.image.title": "Test Image",
+    },
+    annotations_file = ":manifest_annotations_file",
+    layers = [":mixed_layer"],
+)
+
 # Edge case: Multi-platform image index
 image_index(
     name = "multi_platform_index",
@@ -240,6 +270,39 @@ image_push(
     visibility = ["//visibility:public"],
 )
 
+# File containing index annotations
+write_file(
+    name = "index_annotations_file",
+    out = "index_annotations.txt",
+    content = [
+        "org.opencontainers.image.ref.name=multiarch",
+        "custom.index.version=1.0",
+    ],
+)
+
+# Edge case: Image index with annotations from file
+image_index(
+    name = "index_with_annotations_file",
+    annotations_file = ":index_annotations_file",
+    manifests = [
+        ":single_layer_manifest",
+        ":multi_layer_manifest",
+    ],
+)
+
+# Edge case: Image index with both inline annotations and annotations_file
+image_index(
+    name = "index_with_merged_annotations",
+    annotations = {
+        "inline.index.annotation": "inline value",
+    },
+    annotations_file = ":index_annotations_file",
+    manifests = [
+        ":single_layer_manifest",
+        ":multi_layer_manifest",
+    ],
+)
+
 # Edge case: Layer with many annotations
 image_layer(
     name = "heavily_annotated_layer",
@@ -255,6 +318,35 @@ image_layer(
         "custom.annotation.4": "value4",
         "custom.annotation.5": "value5",
     },
+)
+
+# File containing layer annotations
+write_file(
+    name = "layer_annotations_file",
+    out = "layer_annotations.txt",
+    content = [
+        "org.opencontainers.image.authors=rules_img team",
+        "layer.build.tool=bazel",
+        "layer.optimized=true",
+    ],
+)
+
+# Edge case: Layer with annotations from file
+image_layer(
+    name = "layer_with_annotations_file",
+    srcs = {"data.txt": ":large_file"},
+    annotations_file = ":layer_annotations_file",
+)
+
+# Edge case: Layer with both inline annotations and annotations_file
+image_layer(
+    name = "layer_with_merged_annotations",
+    srcs = {"data.txt": ":unicode_file"},
+    annotations = {
+        "inline.layer.annotation": "inline value",
+        "layer.priority": "high",
+    },
+    annotations_file = ":layer_annotations_file",
 )
 
 # Edge case: Manifest with complex configuration
@@ -357,6 +449,8 @@ build_test(
         ":special_chars_layer",
         ":metadata_layer",
         ":heavily_annotated_layer",
+        ":layer_with_annotations_file",
+        ":layer_with_merged_annotations",
     ],
 )
 
@@ -366,6 +460,8 @@ build_test(
         ":single_layer_manifest",
         ":multi_layer_manifest",
         ":annotated_manifest",
+        ":manifest_with_annotations_file",
+        ":manifest_with_merged_annotations",
         ":complex_manifest",
         ":manifest_with_created",
     ],
@@ -375,6 +471,8 @@ build_test(
     name = "index_tests",
     targets = [
         ":multi_platform_index",
+        ":index_with_annotations_file",
+        ":index_with_merged_annotations",
     ],
 )
 

--- a/img/private/manifest.bzl
+++ b/img/private/manifest.bzl
@@ -328,12 +328,19 @@ def _image_manifest_impl(ctx):
         "annotations": ctx.attr.annotations,
     }
 
+    # Prepare newline_delimited_lists_files if annotations_file is provided
+    newline_delimited_lists_files = None
+    if ctx.attr.annotations_file != None:
+        annotations_file = ctx.file.annotations_file
+        newline_delimited_lists_files = {"annotations": annotations_file}
+
     # Try to expand templates - this will return None if no templates need expansion
     config_json = expand_or_write(
         ctx = ctx,
         templates = templates,
         output_name = ctx.label.name + "_config_templates.json",
         only_if_stamping = True,
+        newline_delimited_lists_files = newline_delimited_lists_files,
     )
 
     if config_json != None:
@@ -509,6 +516,23 @@ Subject to [template expansion](/docs/templating.md).
 Subject to [template expansion](/docs/templating.md).
 """,
             default = {},
+        ),
+        "annotations_file": attr.label(
+            doc = """File containing newline-delimited KEY=VALUE annotations for the manifest.
+
+The file should contain one annotation per line in KEY=VALUE format. Empty lines are ignored.
+Annotations from this file are merged with annotations specified via the `annotations` attribute.
+
+Example file content:
+```
+version=1.0.0
+build.date=2024-01-15
+source.url=https://github.com/...
+```
+
+Each annotation is subject to [template expansion](/docs/templating.md).
+""",
+            allow_single_file = True,
         ),
         "stop_signal": attr.string(
             doc = "This field contains the system call signal that will be sent to the container to exit. The signal can be a signal name in the format SIGNAME, for instance SIGKILL or SIGRTMIN+3.",

--- a/img/private/stamp.bzl
+++ b/img/private/stamp.bzl
@@ -73,8 +73,8 @@ def expand_or_write(*, ctx, templates, output_name, only_if_stamping = False, ne
     build_settings = get_build_settings(ctx)
     stamp_settings = should_stamp(ctx = ctx, template_strings = [json.encode(v) for v in templates.values()])
 
-    # If only_if_stamping is True and no stamping is needed, return None
-    if only_if_stamping and not stamp_settings.want_stamp:
+    # If only_if_stamping is True and no stamping is needed and no newline-delimited files provided, return None
+    if only_if_stamping and not stamp_settings.want_stamp and not newline_delimited_lists_files:
         return None
 
     final_json = ctx.actions.declare_file(output_name)


### PR DESCRIPTION
This adds support for specifying annotations via an external file
to image_manifest, image_index, and image_layer rules, similar to
the existing tag_file attribute in image_push and image_load.

The annotations_file attribute accepts a KEY=VALUE newline-delimited
file format, where each line contains one annotation in the form
KEY=VALUE. Empty lines are ignored. Annotations from the file are
merged with annotations specified via the inline annotations attribute.

This is useful for dynamically generating annotations from build
metadata or external sources without hardcoding them in BUILD files.

Example usage:

```
  image_layer(
      name = "app_layer",
      srcs = {"/app/bin": ":app"},
      annotations_file = ":layer_annotations.txt",
  )

  image_manifest(
      name = "app",
      annotations_file = ":annotations.txt",
      layers = [":app_layer"],
  )

  image_index(
      name = "multiarch",
      annotations_file = ":index_annotations.txt",
      manifests = [...],
  )
```

Fixes #246