### PR TITLE
Add manifest annotations to oci-layout index.json

### DIFF
--- a/img_tool/cmd/manifest/manifest.go
+++ b/img_tool/cmd/manifest/manifest.go
@@ -199,6 +199,7 @@ func ManifestProcess(_ context.Context, args []string) {
 			OS:           operatingSystem,
 			Variant:      variant,
 		},
+		Annotations: manifest.Annotations,
 	}
 	descriptorRaw, err := json.Marshal(descriptor)
 	if err != nil {

--- a/img_tool/cmd/ocilayout/ocilayout.go
+++ b/img_tool/cmd/ocilayout/ocilayout.go
@@ -213,9 +213,10 @@ func assembleOCILayout(manifestPath, configPath, outputPath, format string, laye
 		MediaType:     "application/vnd.oci.image.index.v1+json",
 		Manifests: []v1.Descriptor{
 			{
-				MediaType: manifest.MediaType,
-				Digest:    manifestDigest,
-				Size:      int64(len(manifestData)),
+				MediaType:   manifest.MediaType,
+				Digest:      manifestDigest,
+				Size:        int64(len(manifestData)),
+				Annotations: manifest.Annotations,
 			},
 		},
 	}


### PR DESCRIPTION
`umoci unpack` requires the org.opencontainers.image.ref.name annotation on the manifests directly in index.json in the oci-layout output.