### PR TITLE
image_layer: use correct symlink target for links from root

### DIFF
--- a/e2e/generic/BUILD.bazel
+++ b/e2e/generic/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:copy_directory.bzl", "copy_directory")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_img//img:image.bzl", "image_index", "image_manifest")
 load("@rules_img//img:layer.bzl", "file_metadata", "image_layer")
@@ -32,6 +33,12 @@ write_file(
     out = "script.sh",
     content = ["#!/bin/bash\necho 'Hello World'\n"],
     is_executable = True,
+)
+
+copy_directory(
+    name = "tree_artifact_source",
+    src = "some_directory",
+    out = "tree_artifact",
 )
 
 gen_dir_link(
@@ -105,6 +112,15 @@ image_layer(
     name = "symlinks_layer",
     srcs = {
         "bin/script": ":executable_script_with_runfiles",
+    },
+)
+
+# Edge case: Layer with tree artifact
+image_layer(
+    name = "tree_artifact_layer",
+    srcs = {
+        "a_directory": ":tree_artifact_source",
+        "some_other/nested_path": ":tree_artifact_source",
     },
 )
 

--- a/e2e/generic/some_directory/some_file
+++ b/e2e/generic/some_directory/some_file
@@ -1,0 +1,1 @@
+Some file contents

--- a/img_tool/pkg/tree/recorder.go
+++ b/img_tool/pkg/tree/recorder.go
@@ -265,6 +265,10 @@ func (r Recorder) Symlink(target, linkName string) error {
 
 func relativeSymlinkTarget(target, linkName string) string {
 	sourceDir := path.Dir(linkName)
+	if sourceDir == "." {
+		// special case: symlinks from the root should use target as-is
+		return target
+	}
 	sourceParts := strings.Split(path.Clean(sourceDir), "/")
 	targetParts := strings.Split(path.Clean(target), "/")
 


### PR DESCRIPTION
The calculation of the relative symlink path doesn't work correctly when symlinking from the root. We should use the target path as-is if path.Dir() returns ".".