### PR TITLE
pull: configurable Docker config path for lazy layer download

### DIFF
--- a/img/private/BUILD.bazel
+++ b/img/private/BUILD.bazel
@@ -144,6 +144,7 @@ bzl_library(
     deps = [
         "//img/private/common:build",
         "//img/private/common:transitions",
+        "@bazel_skylib//rules:common_settings",
     ],
 )
 
@@ -176,6 +177,7 @@ bzl_library(
         "//img/private/providers:load_settings_info",
         "//img/private/providers:push_settings_info",
         "//img/private/providers:stamp_setting_info",
+        "@bazel_skylib//rules:common_settings",
         "@platforms//host:constraints_lib",
     ],
 )

--- a/img/settings/BUILD.bazel
+++ b/img/settings/BUILD.bazel
@@ -75,6 +75,12 @@ string_flag(
 )
 
 string_flag(
+    name = "docker_config_path",
+    build_setting_default = "",
+    visibility = ["//img/private:__subpackages__"],
+)
+
+string_flag(
     name = "shallow_oci_layout",
     build_setting_default = "forbidden",
     values = [


### PR DESCRIPTION
Lazy layer downloads run in Bazel's sandbox, and by default, most environment variables are unset. This leads to issues with authenticated container registries: we need to locate the user's Docker config for authentication, but Bazel hides the username, $HOME, etc.

With this change, users can set the location of the Docker config for lazy image pulls in multiple ways:

* `--@rules_img//img/settings:docker_config_path=/home/<USERNAME>/.docker/config.json`
* `--action_env=DOCKER_CONFIG=/home/<USERNAME>/.docker`

Work towards #266