### PR TITLE
img_tool: add progress bar for push

### DIFF
--- a/img_tool/pkg/progress/progress.go
+++ b/img_tool/pkg/progress/progress.go
@@ -26,3 +26,24 @@ func Writer(size int64, desc string) io.Writer {
 		}),
 	)
 }
+
+type Indeterminate struct{ p *progressbar.ProgressBar }
+
+func (i *Indeterminate) SetTotal(total int64)       { i.p.ChangeMax64(total) }
+func (i *Indeterminate) SetComplete(complete int64) { i.p.Set64(complete) }
+
+func NewIndeterminate() *Indeterminate {
+	p := progressbar.NewOptions64(
+		-1,
+		progressbar.OptionSetTheme(progressbar.ThemeASCII),
+		progressbar.OptionShowCount(),
+		progressbar.OptionShowBytes(true),
+		progressbar.OptionSetWidth(60),
+		progressbar.OptionSetPredictTime(false),
+		progressbar.OptionSetWriter(os.Stderr),
+		progressbar.OptionOnCompletion(func() {
+			fmt.Fprint(os.Stderr, "\n")
+		}),
+	)
+	return &Indeterminate{p: p}
+}

--- a/img_tool/pkg/push/BUILD.bazel
+++ b/img_tool/pkg/push/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api",
+        "//pkg/progress",
         "//pkg/proto/blobcache",
         "//pkg/proto/remote-apis/build/bazel/remote/execution/v2",
         "@com_github_malt3_go_containerregistry//pkg/name",


### PR DESCRIPTION
Follow-up to #274.

This PR adds progress reporting for image push operations.

Unlike the progress reporting for image loading, we don't report per-blob progress, only a single overall progress. This is because `remote.MultiWrite` only exposes a single aggregate progress report, but the nice thing about this is that it reflects progress accurately from de-duplication.