### PR TITLE
export DeployInfo provider

### DIFF
--- a/img/BUILD.bazel
+++ b/img/BUILD.bazel
@@ -22,6 +22,7 @@ bzl_library(
     srcs = ["providers.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        "//img/private/providers:deploy_info",
         "//img/private/providers:index_info",
         "//img/private/providers:layer_info",
         "//img/private/providers:manifest_info",

--- a/img/providers.bzl
+++ b/img/providers.bzl
@@ -1,9 +1,13 @@
 """Provider definitions"""
 
+load("//img/private/providers:deploy_info.bzl", _DeployInfo = "DeployInfo")
 load("//img/private/providers:index_info.bzl", _ImageIndexInfo = "ImageIndexInfo")
 load("//img/private/providers:layer_info.bzl", _LayerInfo = "LayerInfo")
 load("//img/private/providers:manifest_info.bzl", _ImageManifestInfo = "ImageManifestInfo")
 load("//img/private/providers:pull_info.bzl", _PullInfo = "PullInfo")
+
+# providers with metadata about image pushes
+DeployInfo = _DeployInfo
 
 # providers describing images and their components
 LayerInfo = _LayerInfo


### PR DESCRIPTION
This allows writing rules that consume providers from `image_push` targets. For example, rules that want to generate data based on the image push registry/repository.