### PR TITLE
ci: only use RBE if credentials are available

### DIFF
--- a/.github/actions/generate-buildbuddy-bazelrc/action.yml
+++ b/.github/actions/generate-buildbuddy-bazelrc/action.yml
@@ -11,7 +11,7 @@ inputs:
     default: '.github/workflows/.bazelrc.buildbuddy.generated'
   api-key:
     description: 'BuildBuddy API key to inject into the bazelrc file'
-    required: true
+    required: false
 runs:
   using: 'node20'
   main: 'index.js'

--- a/.github/actions/generate-buildbuddy-bazelrc/index.js
+++ b/.github/actions/generate-buildbuddy-bazelrc/index.js
@@ -18,7 +18,30 @@ function main() {
   try {
     const templatePath = getInput('template-path', true);
     const outputPath = getInput('output-path', true);
-    const apiKey = getInput('api-key', true);
+    const apiKey = getInput('api-key', false);
+
+    // If api-key is not provided or empty, create an empty bazelrc file
+    if (!apiKey) {
+      console.log('No API key provided, generating empty bazelrc file');
+
+      // Ensure the output directory exists
+      const outputDir = path.dirname(outputPath);
+      if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+      }
+
+      console.log(`Writing empty bazelrc to: ${outputPath}`);
+
+      try {
+        fs.writeFileSync(outputPath, '', 'utf8');
+      } catch (error) {
+        setFailed(`Failed to write output file: ${error.message}`);
+        return;
+      }
+
+      console.log('Successfully generated empty bazelrc file');
+      return;
+    }
 
     console.log(`Reading template from: ${templatePath}`);
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       matrix:
         runner: [macos-15-intel, macos-15, ubuntu-22.04, windows-2025]
     runs-on: ${{ matrix.runner }}
+    if: ${{ github.event_name == 'merge_group' }}
     steps:
     - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
     - name: Generate BuildBuddy bazelrc
@@ -61,6 +62,7 @@ jobs:
       matrix:
         runner: [macos-15-intel, macos-15, ubuntu-22.04, windows-2025]
     runs-on: ${{ matrix.runner }}
+    if: ${{ github.event_name == 'merge_group' }}
     permissions:
       id-token: write
       contents: read

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -225,7 +225,7 @@
     "@@rules_bazel_integration_test+//:extensions.bzl%bazel_binaries": {
       "general": {
         "bzlTransitiveDigest": "XC9nqZ31LIbq8N7cEK+rYa2iXNQLcJ3cyGWw+zPZlc0=",
-        "usagesDigest": "Bx531KeQZGsSbMVEFQvHlz3EWacuLoslN3MfkrvDHbw=",
+        "usagesDigest": "+GAY5kVjTqf5Rjba2aH2TkmS3oLlioGLEkpN5HqKsc8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},


### PR DESCRIPTION
When users open PRs from forks, GitHub Actions will not give us access to secrets. This prevents access to BuildBuddy.

For now, we allow running without BuildBuddy access and we also go back to running GHA only on the merge queue (but on on PR branches).