### PR TITLE
upgrade vulnerable dependency urllib3 in integration test

### DIFF
--- a/e2e/generic/integrationtest/testcontainers/requirements.in
+++ b/e2e/generic/integrationtest/testcontainers/requirements.in
@@ -2,3 +2,5 @@ docker==7.1.0
 pytest==8.4.2
 testcontainers==4.13.2
 requests==2.32.5
+# CVE-2025-66471 and CVE-2025-66418
+urllib3>=2.6.0

--- a/e2e/generic/integrationtest/testcontainers/requirements_lock.txt
+++ b/e2e/generic/integrationtest/testcontainers/requirements_lock.txt
@@ -171,10 +171,11 @@ typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
     # via testcontainers
-urllib3==2.5.0 \
-    --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
-    --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
+urllib3==2.6.1 \
+    --hash=sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f \
+    --hash=sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b
     # via
+    #   -r integrationtest/testcontainers/requirements.in
     #   docker
     #   requests
     #   testcontainers


### PR DESCRIPTION
Patches CVE-2025-66418 and CVE-2025-66471.