### PR TITLE
ImageManifestInfo: remove base_image field

### DIFF
--- a/img/private/conversion/index_from_oci_layout.bzl
+++ b/img/private/conversion/index_from_oci_layout.bzl
@@ -154,7 +154,6 @@ def _image_index_from_oci_layout(ctx):
     for idx_str in sorted(manifest_platforms.keys()):
         info = manifest_outputs[idx_str]
         manifest_infos.append(ImageManifestInfo(
-            base_image = None,
             descriptor = info["descriptor"],
             manifest = info["manifest"],
             config = info["config"],

--- a/img/private/conversion/manifest_from_oci_layout.bzl
+++ b/img/private/conversion/manifest_from_oci_layout.bzl
@@ -105,7 +105,6 @@ def _image_manifest_from_oci_layout(ctx):
             oci_layout = depset([src_dir]),
         ),
         ImageManifestInfo(
-            base_image = None,
             descriptor = output_descriptor,
             manifest = output_manifest,
             config = output_config,

--- a/img/private/import.bzl
+++ b/img/private/import.bzl
@@ -119,7 +119,6 @@ def _build_manifest_info(ctx, digest, descriptor = None, index_position = None, 
             missing_blobs.append(layer["digest"].removeprefix("sha256:"))
         layers.append(layer_info)
     return ImageManifestInfo(
-        base_image = None,
         descriptor = _write_manifest_descriptor(ctx, digest, manifest, platform, descriptor, index_position),
         manifest = _digest_to_file(ctx, digest),
         config = _digest_to_file(ctx, config_digest),

--- a/img/private/manifest.bzl
+++ b/img/private/manifest.bzl
@@ -415,7 +415,6 @@ def _image_manifest_impl(ctx):
             oci_tarball = depset([_build_oci_layout(ctx, "tar", manifest_out, config_out, layers)]),
         ),
         ImageManifestInfo(
-            base_image = base,
             descriptor = descriptor_out,
             manifest = manifest_out,
             config = config_out,

--- a/img/private/providers/manifest_info.bzl
+++ b/img/private/providers/manifest_info.bzl
@@ -5,7 +5,6 @@ Information about a single-platform container image (manifest, config, and layer
 """
 
 FIELDS = dict(
-    base_image = "ImageManifestInfo or ImageIndexInfo of the base image (or None).",
     descriptor = "File containing the descriptor of the manifest.",
     manifest = "File containing the raw image manifest (application/vnd.oci.image.index.v1+json).",
     config = "File containing the raw image config (application/vnd.oci.image.config.v1+json).",


### PR DESCRIPTION
The base_image field increases the memory footprint of the ImageManifestInfo to be the sum of all base images. This information is not currently used. If we need information about the base image, we can still get it using an aspect.