### PR TITLE
pass deploy metadata file path via argv

### DIFF
--- a/img/private/push.bzl
+++ b/img/private/push.bzl
@@ -101,17 +101,6 @@ def _compute_push_metadata(*, ctx, configuration_json):
 
 def _image_push_impl(ctx):
     """Implementation of the push rule."""
-    pusher = ctx.actions.declare_file(ctx.label.name + ".exe")
-    img_toolchain_info = ctx.exec_groups["host"].toolchains[TOOLCHAIN].imgtoolchaininfo
-    embedded_args, transformed_args = launcher.args_from_entrypoint(executable_file = img_toolchain_info.tool_exe)
-    launcher.compile_stub(
-        ctx = ctx,
-        embedded_args = embedded_args,
-        transformed_args = transformed_args,
-        output_file = pusher,
-        cfg = "exec",
-        template_exec_group = "host",
-    )
     manifest_info = ctx.attr.image[ImageManifestInfo] if ImageManifestInfo in ctx.attr.image else None
     index_info = ctx.attr.image[ImageIndexInfo] if ImageIndexInfo in ctx.attr.image else None
     if manifest_info == None and index_info == None:
@@ -142,12 +131,27 @@ def _image_push_impl(ctx):
         newline_delimited_lists_files = newline_delimited_lists_files,
     )
 
-    dispatch_json = _compute_push_metadata(
+    deploy_metadata = _compute_push_metadata(
         ctx = ctx,
         configuration_json = configuration_json,
     )
-
-    root_symlinks["dispatch.json"] = dispatch_json
+    pusher = ctx.actions.declare_file(ctx.label.name + ".exe")
+    img_toolchain_info = ctx.exec_groups["host"].toolchains[TOOLCHAIN].imgtoolchaininfo
+    embedded_args, transformed_args = launcher.args_from_entrypoint(executable_file = img_toolchain_info.tool_exe)
+    embedded_args.extend(["deploy", "--request-file"])
+    embedded_args, transformed_args = launcher.append_runfile(
+        file = deploy_metadata,
+        embedded_args = embedded_args,
+        transformed_args = transformed_args,
+    )
+    launcher.compile_stub(
+        ctx = ctx,
+        embedded_args = embedded_args,
+        transformed_args = transformed_args,
+        output_file = pusher,
+        cfg = "exec",
+        template_exec_group = "host",
+    )
 
     # Build environment for RunEnvironmentInfo
     environment = {
@@ -167,9 +171,15 @@ def _image_push_impl(ctx):
 
     return [
         DefaultInfo(
-            files = depset([dispatch_json]),
+            files = depset([pusher]),
             executable = pusher,
-            runfiles = ctx.runfiles(files = [img_toolchain_info.tool_exe], root_symlinks = root_symlinks),
+            runfiles = ctx.runfiles(
+                files = [
+                    img_toolchain_info.tool_exe,
+                    deploy_metadata,
+                ],
+                root_symlinks = root_symlinks,
+            ),
         ),
         RunEnvironmentInfo(
             environment = environment,
@@ -177,7 +187,7 @@ def _image_push_impl(ctx):
         ),
         DeployInfo(
             image = image_provider,
-            deploy_manifest = dispatch_json,
+            deploy_manifest = deploy_metadata,
         ),
     ]
 


### PR DESCRIPTION
This gets rid of "dispatch.json" in the runfiles of "image_push", "image_load", and "multi_deploy" and embeds a runfiles path to the manifest in the embedded args of the hermetic launcher instead.

Work towards https://github.com/bazel-contrib/rules_img/issues/342