### PR TITLE
image_load: enable use of loader as data dependency in test

### DIFF
--- a/docs/load.md
+++ b/docs/load.md
@@ -68,7 +68,7 @@ bazel run //path/to:load_target -- --platform linux/amd64
 <pre>
 load("@rules_img//img:load.bzl", "image_load")
 
-image_load(<a href="#image_load-name">name</a>, <a href="#image_load-build_settings">build_settings</a>, <a href="#image_load-daemon">daemon</a>, <a href="#image_load-image">image</a>, <a href="#image_load-stamp">stamp</a>, <a href="#image_load-strategy">strategy</a>, <a href="#image_load-tag">tag</a>, <a href="#image_load-tag_file">tag_file</a>, <a href="#image_load-tag_list">tag_list</a>)
+image_load(<a href="#image_load-name">name</a>, <a href="#image_load-build_settings">build_settings</a>, <a href="#image_load-daemon">daemon</a>, <a href="#image_load-image">image</a>, <a href="#image_load-stamp">stamp</a>, <a href="#image_load-strategy">strategy</a>, <a href="#image_load-tag">tag</a>, <a href="#image_load-tag_file">tag_file</a>, <a href="#image_load-tag_list">tag_list</a>, <a href="#image_load-tool_cfg">tool_cfg</a>)
 </pre>
 
 Loads container images into a local daemon (Docker, containerd, or Podman).
@@ -159,5 +159,6 @@ Performance notes:
 | <a id="image_load-tag"></a>tag |  Tag to apply when loading the image.<br><br>Optional - if omitted, the image is loaded without a tag.<br><br>Subject to [template expansion](/docs/templating.md).   | String | optional |  `""`  |
 | <a id="image_load-tag_file"></a>tag_file |  File containing newline-delimited tags to apply when loading the image.<br><br>The file should contain one tag per line. Empty lines are ignored. Tags from this file are merged with tags specified via `tag` or `tag_list` attributes.<br><br>Example file content: <pre><code>latest&#10;v1.0.0&#10;stable</code></pre><br><br>Can be combined with `tag` or `tag_list` to merge tags from multiple sources. Each tag is subject to [template expansion](/docs/templating.md).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="image_load-tag_list"></a>tag_list |  List of tags to apply when loading the image.<br><br>Useful for applying multiple tags in a single load:<br><br><pre><code class="language-python">tag_list = ["latest", "v1.0.0", "stable"]</code></pre><br><br>Cannot be used together with `tag`. Can be combined with `tag_file` to merge tags from both sources. Each tag is subject to [template expansion](/docs/templating.md).   | List of strings | optional |  `[]`  |
+| <a id="image_load-tool_cfg"></a>tool_cfg |  **Experimental**: This attribute may be removed if we find a way to automatically select the correct loader platform based on the context of use. Configuration of the loader executable. By default, the loader executable is always chosen for the host platform, regardless of the value of `--platforms`. Setting this attribute to 'target' makes the loader match the target platform instead. The `"target"` option is useful when the "image_load" target is used as a data dependency of an integration test.<br><br>Available options: - **`host`** (default): Loader executable matches the host platform. - **`target`**: Loader executable matches the target platform(s) specified via `--platforms`.   | String | optional |  `"host"`  |
 
 

--- a/img/BUILD.bazel
+++ b/img/BUILD.bazel
@@ -11,6 +11,11 @@ toolchain_type(
     visibility = ["//visibility:public"],
 )
 
+toolchain_type(
+    name = "data_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
 resolved_toolchain(
     name = "resolved_toolchain",
     tags = ["manual"],

--- a/img/image_toolchain.bzl
+++ b/img/image_toolchain.bzl
@@ -1,6 +1,7 @@
 """Rules to define and register the img toolchain."""
 
-load("//img/private:image_toolchain.bzl", _TOOLCHAIN_TYPE = "TOOLCHAIN_TYPE", _image_toolchain = "image_toolchain")
+load("//img/private:image_toolchain.bzl", _DATA_TOOLCHAIN_TYPE = "DATA_TOOLCHAIN_TYPE", _TOOLCHAIN_TYPE = "TOOLCHAIN_TYPE", _image_toolchain = "image_toolchain")
 
 image_toolchain = _image_toolchain
+DATA_TOOLCHAIN_TYPE = _DATA_TOOLCHAIN_TYPE
 TOOLCHAIN_TYPE = _TOOLCHAIN_TYPE

--- a/img/private/common/build.bzl
+++ b/img/private/common/build.bzl
@@ -1,4 +1,5 @@
 """Common build utilities for container image rules."""
 
 TOOLCHAIN = str(Label("//img:toolchain_type"))
+DATA_TOOLCHAIN = str(Label("//img:data_toolchain_type"))
 TOOLCHAINS = [TOOLCHAIN]

--- a/img/private/image_toolchain.bzl
+++ b/img/private/image_toolchain.bzl
@@ -20,6 +20,7 @@ ATTRS = dict(
 )
 
 TOOLCHAIN_TYPE = str(Label("//img:toolchain_type"))
+DATA_TOOLCHAIN_TYPE = str(Label("//img:data_toolchain_type"))
 
 def _image_toolchain_impl(ctx):
     image_toolchain_info = ImageToolchainInfo(

--- a/img/private/prebuilt/prebuilt.bzl
+++ b/img/private/prebuilt/prebuilt.bzl
@@ -20,6 +20,13 @@ toolchain(
     exec_compatible_with = {constraints},
     toolchain = "img_{platform_name}",
     toolchain_type = "@rules_img//img:toolchain_type",
+)
+
+toolchain(
+    name = "img_{platform_name}_data_toolchain",
+    target_compatible_with = {constraints},
+    toolchain = "img_{platform_name}",
+    toolchain_type = "@rules_img//img:data_toolchain_type",
 )""".format(
         platform_name = platform_name,
         tool_target = tool_target,

--- a/img_tool/toolchain/BUILD.bazel
+++ b/img_tool/toolchain/BUILD.bazel
@@ -4,7 +4,7 @@ These toolchains are not registered by default.
 You need to register them explicitly if you want to build from source.
 """
 
-load("@rules_img//img:image_toolchain.bzl", "TOOLCHAIN_TYPE", "image_toolchain")
+load("@rules_img//img:image_toolchain.bzl", "DATA_TOOLCHAIN_TYPE", "TOOLCHAIN_TYPE", "image_toolchain")
 load(":def.bzl", "goarch_to_constraint", "goos_to_constraint", "platform_tuples")
 
 package(
@@ -28,6 +28,19 @@ package(
         ],
         toolchain = ":image_toolchain_{}_{}".format(os, arch),
         toolchain_type = TOOLCHAIN_TYPE,
+    )
+    for os, arch in platform_tuples
+]
+
+[
+    toolchain(
+        name = "data_toolchain_{}_{}".format(os, arch),
+        target_compatible_with = [
+            goos_to_constraint(os),
+            goarch_to_constraint(arch),
+        ],
+        toolchain = ":image_toolchain_{}_{}".format(os, arch),
+        toolchain_type = DATA_TOOLCHAIN_TYPE,
     )
     for os, arch in platform_tuples
 ]


### PR DESCRIPTION
Currently, we automatically select a loader binary for the host, regardless of the "--platforms" setting. That works great when it is used as a top-level target in "bazel run". However, if "image_load" is used as part of an integration test, we want the loader binary to be built for the target platform instead. This change enables loading a container image at the beginning of an integration test.

Users need to decide what context image_load shall be used in:

- `tool_cfg = "host"` (default) works best with `bazel run`
- `tool_cfg = "target"` makes the loader usable as a `data` dependency of another target.

Fixes #341