### PR TITLE
Add layer hints for lazy deploy strategy to optimize data transfer

### DIFF
--- a/img/private/BUILD.bazel
+++ b/img/private/BUILD.bazel
@@ -40,10 +40,17 @@ bzl_library(
 )
 
 bzl_library(
+    name = "layer_path_hints",
+    srcs = ["layer_path_hints.bzl"],
+    visibility = ["//img:__subpackages__"],
+)
+
+bzl_library(
     name = "push",
     srcs = ["push.bzl"],
     visibility = ["//img:__subpackages__"],
     deps = [
+        ":layer_path_hints",
         ":root_symlinks",
         ":stamp",
         "//img:providers",
@@ -67,6 +74,7 @@ bzl_library(
     srcs = ["load.bzl"],
     visibility = ["//img:__subpackages__"],
     deps = [
+        ":layer_path_hints",
         ":root_symlinks",
         ":stamp",
         "//img/private/common:build",

--- a/img/private/layer_path_hints.bzl
+++ b/img/private/layer_path_hints.bzl
@@ -1,0 +1,63 @@
+"""Layer path hints for deploy metadata to support lazy push/load fallback."""
+
+def layer_hints_for_deploy_metadata(ctx, *, index_info, manifest_info, strategy, args, inputs, outputs):
+    """Generates layer path hints for deploy metadata when using lazy push strategy.
+
+    This function creates a hints file that maps layer blobs to their metadata files,
+    which is used to avoid "split brain" scenarios where some layers exist only in
+    remote cache and others only locally when using the lazy push strategy.
+
+    Args:
+        ctx: The rule context.
+        index_info: ImageIndexInfo provider for multi-platform images, or None.
+        manifest_info: ImageManifestInfo provider for single-platform images, or None.
+        strategy: Push strategy name. Only "lazy" strategy generates hints.
+        args: List to append hint flags to.
+        inputs: List of input files to append layer blobs to.
+        outputs: List of output files.
+
+    Returns:
+        File object containing layer hints, or None if strategy is not "lazy".
+    """
+    if strategy != "lazy":
+        # Only the lazy strategy has the risk of "split brain" where
+        # some layers only exist in the remote cache, and some only locally.
+        # For all other strategies, no hints are needed.
+        return None
+    layer_hints_args_file = ctx.actions.args()
+    layer_hints_args_file.set_param_file_format("multiline")
+    layer_hints_args_file.use_param_file("--layer-hints-paths-file-input=%s", use_always = True)
+
+    # File format of the params file:
+    # One line per layer blob path that may exist locally (hence the word hint).
+    # (even if layer.blob != None, there's no guarantee it exists locally due to BwoB)
+    #
+    # Each line looks like this:
+    # /path/to/layer/blob.tar.gz\0/path/to/layer/metadata.json
+    layers_with_local_blobs = []
+
+    if index_info != None:
+        for manifest in index_info.manifests:
+            for layer in manifest.layers:
+                if layer.blob != None:
+                    layers_with_local_blobs.append(layer)
+    if manifest_info != None:
+        for layer in manifest_info.layers:
+            if layer.blob != None:
+                layers_with_local_blobs.append(layer)
+
+    for layer in layers_with_local_blobs:
+        layer_hints_args_file.add_joined(
+            [layer.blob, layer.metadata],
+            join_with = "\0",
+            uniquify = True,
+        )
+        inputs.append(layer.metadata)
+
+    layer_hints_file = ctx.actions.declare_file(ctx.label.name + ".layer_path_hints")
+    output_args = ctx.actions.args()
+    output_args.add("--layer-hints-paths-output", layer_hints_file)
+    outputs.append(layer_hints_file)
+    args.append(layer_hints_args_file)
+    args.append(output_args)
+    return layer_hints_file

--- a/img/private/providers/deploy_info.bzl
+++ b/img/private/providers/deploy_info.bzl
@@ -8,6 +8,7 @@ container runtime.
 FIELDS = dict(
     image = "ImageManifestInfo or ImageIndexInfo of the image or image index to push or load.",
     deploy_manifest = "File containing the deploy manifest (JSON).",
+    layer_hints = "File containing layer path hints (or None).",
 )
 
 DeployInfo = provider(

--- a/img_tool/cmd/deploymetadata/BUILD.bazel
+++ b/img_tool/cmd/deploymetadata/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library")
 go_library(
     name = "deploymetadata",
     srcs = [
+        "layerhints.go",
         "merge.go",
         "metadata.go",
     ],

--- a/img_tool/cmd/deploymetadata/layerhints.go
+++ b/img_tool/cmd/deploymetadata/layerhints.go
@@ -1,0 +1,191 @@
+package deploymetadata
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+)
+
+func processLayerHints(inputPath, outputPath string) error {
+	// 1. Setup - open input and output files
+	inputFile, err := os.Open(inputPath)
+	if err != nil {
+		return fmt.Errorf("opening input file: %w", err)
+	}
+	defer inputFile.Close()
+
+	outputFile, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("creating output file: %w", err)
+	}
+	defer outputFile.Close()
+
+	// 2. Process input file and build digest map
+	digestMap, err := processInputFile(inputFile)
+	if err != nil {
+		return fmt.Errorf("processing input file: %w", err)
+	}
+
+	// 3. Write output in sorted format
+	if err := writeOutputFile(outputFile, digestMap); err != nil {
+		return fmt.Errorf("writing output file: %w", err)
+	}
+
+	return nil
+}
+
+// processInputFile reads the input file line by line and builds a map of digest -> blob paths
+func processInputFile(inputFile *os.File) (map[string][]string, error) {
+	digestMap := make(map[string][]string)
+	scanner := bufio.NewScanner(inputFile)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue // skip empty lines
+		}
+
+		// Split by null byte to get blob path and metadata path
+		parts := strings.Split(line, "\x00")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid line format: expected 2 parts separated by null byte, got %d", len(parts))
+		}
+
+		blobPath := parts[0]
+		metadataPath := parts[1]
+
+		// Get digest from metadata file
+		digest, err := getDigestFromMetadata(metadataPath)
+		if err != nil {
+			return nil, fmt.Errorf("getting digest from metadata file %s: %w", metadataPath, err)
+		}
+
+		// Add blob path to the list for this digest
+		digestMap[digest] = append(digestMap[digest], blobPath)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading input file: %w", err)
+	}
+
+	return digestMap, nil
+}
+
+// getDigestFromMetadata reads a metadata file and extracts the digest
+func getDigestFromMetadata(metadataPath string) (string, error) {
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		return "", fmt.Errorf("reading metadata file: %w", err)
+	}
+
+	var descriptor api.Descriptor
+	if err := json.Unmarshal(data, &descriptor); err != nil {
+		return "", fmt.Errorf("unmarshaling metadata JSON: %w", err)
+	}
+
+	if descriptor.Digest == "" {
+		return "", fmt.Errorf("digest field is empty in metadata")
+	}
+
+	return descriptor.Digest, nil
+}
+
+// writeOutputFile writes the digest map to the output file in sorted format
+func writeOutputFile(outputFile *os.File, digestMap map[string][]string) error {
+	// Get digests in sorted order
+	digests := make([]string, 0, len(digestMap))
+	for digest := range digestMap {
+		digests = append(digests, digest)
+	}
+	slices.Sort(digests)
+
+	// Write each digest with its blob paths
+	for _, digest := range digests {
+		blobPaths := digestMap[digest]
+
+		// Build line: digest followed by null-byte-separated blob paths
+		var buf bytes.Buffer
+		buf.WriteString(digest)
+		slices.Sort(blobPaths)
+		blobPaths = slices.Compact(blobPaths)
+		for _, blobPath := range blobPaths {
+			buf.WriteByte('\x00')
+			buf.WriteString(blobPath)
+		}
+		buf.WriteByte('\n')
+
+		if _, err := outputFile.Write(buf.Bytes()); err != nil {
+			return fmt.Errorf("writing output line: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// mergeLayerHintsFiles merges multiple layer hints output files into a single file.
+// Each input file has format: digest\0blobpath1\0blobpath2\0...\n
+// The output file will have the same format with all unique blob paths per digest.
+func mergeLayerHintsFiles(inputPaths []string, outputPath string) error {
+	digestMap := make(map[string][]string)
+
+	// Read all input files and merge into digestMap
+	for _, inputPath := range inputPaths {
+		if err := readLayerHintsOutput(inputPath, digestMap); err != nil {
+			return fmt.Errorf("reading layer hints file %s: %w", inputPath, err)
+		}
+	}
+
+	// Write merged output
+	outputFile, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("creating output file: %w", err)
+	}
+	defer outputFile.Close()
+
+	if err := writeOutputFile(outputFile, digestMap); err != nil {
+		return fmt.Errorf("writing output file: %w", err)
+	}
+
+	return nil
+}
+
+// readLayerHintsOutput reads a layer hints output file and adds entries to digestMap
+func readLayerHintsOutput(inputPath string, digestMap map[string][]string) error {
+	inputFile, err := os.Open(inputPath)
+	if err != nil {
+		return fmt.Errorf("opening input file: %w", err)
+	}
+	defer inputFile.Close()
+
+	scanner := bufio.NewScanner(inputFile)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue // skip empty lines
+		}
+
+		// Split by null byte to get digest and blob paths
+		parts := strings.Split(line, "\x00")
+		if len(parts) < 1 {
+			return fmt.Errorf("invalid line format: expected at least 1 part")
+		}
+
+		digest := parts[0]
+		blobPaths := parts[1:]
+
+		// Add blob paths to the map for this digest
+		digestMap[digest] = append(digestMap[digest], blobPaths...)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading input file: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Implements a layer hints mechanism that allows lazy push/load strategies to check for undeclared locally available blobs before streaming them from remote cache.
This enables lazy strategy to work with --noremote_upload_local_results by providing paths to local layer artifacts that may exist in the output base.

This provides a nice performance optimization. By trying to locate a blob locally first, we can avoid streaming blobs on this path:
  CAS → local machine → container registry

Instead, whenever possible, we do:
  local machine → container registry

Closes #323