### PR TITLE
Support username:password in gRPC URL for remote_cache

### DIFF
--- a/img_tool/pkg/auth/protohelper/BUILD.bazel
+++ b/img_tool/pkg/auth/protohelper/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "protohelper",
@@ -12,4 +12,10 @@ go_library(
         "@org_golang_google_grpc//credentials",
         "@org_golang_google_grpc//credentials/insecure",
     ],
+)
+
+go_test(
+    name = "protohelper_test",
+    srcs = ["protohelper_test.go"],
+    embed = [":protohelper"],
 )

--- a/img_tool/pkg/auth/protohelper/protohelper_test.go
+++ b/img_tool/pkg/auth/protohelper/protohelper_test.go
@@ -1,0 +1,172 @@
+package protohelper
+
+import (
+	"context"
+	"net/url"
+	"testing"
+)
+
+func TestBasicAuthCredentials(t *testing.T) {
+	tests := []struct {
+		name             string
+		username         string
+		password         string
+		expectedAuth     string
+		expectedEncoding string
+	}{
+		{
+			name:             "simple credentials",
+			username:         "user",
+			password:         "pass",
+			expectedAuth:     "Basic dXNlcjpwYXNz",
+			expectedEncoding: "user:pass",
+		},
+		{
+			name:             "empty password",
+			username:         "user",
+			password:         "",
+			expectedAuth:     "Basic dXNlcjo=",
+			expectedEncoding: "user:",
+		},
+		{
+			name:             "special characters",
+			username:         "bazel",
+			password:         "secret$key!",
+			expectedAuth:     "Basic YmF6ZWw6c2VjcmV0JGtleSE=",
+			expectedEncoding: "bazel:secret$key!",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds := &basicAuthCredentials{
+				username: tt.username,
+				password: tt.password,
+			}
+
+			metadata, err := creds.GetRequestMetadata(context.Background())
+			if err != nil {
+				t.Fatalf("GetRequestMetadata returned error: %v", err)
+			}
+
+			auth, ok := metadata["authorization"]
+			if !ok {
+				t.Fatal("authorization header not found in metadata")
+			}
+
+			if auth != tt.expectedAuth {
+				t.Errorf("expected authorization %q, got %q", tt.expectedAuth, auth)
+			}
+
+			if creds.RequireTransportSecurity() {
+				t.Error("RequireTransportSecurity should return false")
+			}
+		})
+	}
+}
+
+func TestBasicAuthFromUserinfo(t *testing.T) {
+	tests := []struct {
+		name         string
+		url          string
+		wantUsername string
+		wantPassword string
+	}{
+		{
+			name:         "username and password",
+			url:          "grpc://user:pass@host:9092",
+			wantUsername: "user",
+			wantPassword: "pass",
+		},
+		{
+			name:         "username only",
+			url:          "grpc://user@host:9092",
+			wantUsername: "user",
+			wantPassword: "",
+		},
+		{
+			name:         "url-encoded password",
+			url:          "grpc://bazel:secret%24key@host:9092",
+			wantUsername: "bazel",
+			wantPassword: "secret$key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := url.Parse(tt.url)
+			if err != nil {
+				t.Fatalf("failed to parse URL: %v", err)
+			}
+
+			creds := basicAuthFromUserinfo(parsed.User)
+
+			if creds.username != tt.wantUsername {
+				t.Errorf("expected username %q, got %q", tt.wantUsername, creds.username)
+			}
+			if creds.password != tt.wantPassword {
+				t.Errorf("expected password %q, got %q", tt.wantPassword, creds.password)
+			}
+		})
+	}
+}
+
+func TestParseGRPCURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		wantHost   string
+		wantScheme string
+		hasUser    bool
+	}{
+		{
+			name:       "simple grpc URL",
+			url:        "grpc://host.example.com:9092",
+			wantHost:   "host.example.com:9092",
+			wantScheme: "grpc",
+			hasUser:    false,
+		},
+		{
+			name:       "grpcs URL",
+			url:        "grpcs://host.example.com:443",
+			wantHost:   "host.example.com:443",
+			wantScheme: "grpcs",
+			hasUser:    false,
+		},
+		{
+			name:       "grpc URL with userinfo",
+			url:        "grpc://bazel:secret@host.amazonaws.com:9092",
+			wantHost:   "host.amazonaws.com:9092",
+			wantScheme: "grpc",
+			hasUser:    true,
+		},
+		{
+			name:       "grpcs URL with userinfo",
+			url:        "grpcs://user:pass@host.example.com:443",
+			wantHost:   "host.example.com:443",
+			wantScheme: "grpcs",
+			hasUser:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := url.Parse(tt.url)
+			if err != nil {
+				t.Fatalf("failed to parse URL: %v", err)
+			}
+
+			if parsed.Host != tt.wantHost {
+				t.Errorf("expected host %q, got %q", tt.wantHost, parsed.Host)
+			}
+			if parsed.Scheme != tt.wantScheme {
+				t.Errorf("expected scheme %q, got %q", tt.wantScheme, parsed.Scheme)
+			}
+
+			hasUser := parsed.User != nil && parsed.User.String() != ""
+			if hasUser != tt.hasUser {
+				t.Errorf("expected hasUser=%v, got %v", tt.hasUser, hasUser)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The gRPC client now properly parses URLs with userinfo (username:password@host:port)
and uses the credentials for Basic authentication.

Previously, URLs like `grpc://user:pass@host:9092` would fail because the parser
didn't handle the userinfo portion correctly.

Fixes #379