### PR TITLE
Add "scratch" and "incompatible" base image

### DIFF
--- a/e2e/generic/index_with_selected_base/BUILD.bazel
+++ b/e2e/generic/index_with_selected_base/BUILD.bazel
@@ -7,8 +7,9 @@ load("@rules_img//img:push.bzl", "image_push")
 alias(
     name = "base",
     actual = select({
+        "@platforms//os:linux": "@distroless_static",
         "@platforms//os:windows": "@nanoserver",
-        "//conditions:default": "@distroless_static",
+        "//conditions:default": "@rules_img//img/base:incompatible",
     }),
 )
 

--- a/e2e/generic/platform/BUILD.bazel
+++ b/e2e/generic/platform/BUILD.bazel
@@ -26,6 +26,14 @@ platform(
     ],
 )
 
+platform(
+    name = "darwin_arm64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
 # define a platform for the container runtime on your host.
 # It uses the same CPU architecture as Bazel itself (i.e. arm64 on an Apple Silicon Mac), but always target Linux.
 platform(

--- a/img/base/BUILD.bazel
+++ b/img/base/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@rules_img//img:image.bzl", "image_manifest")
+
+package(default_visibility = ["//visibility:public"])
+
+# This is equivalent to "FROM scratch" in a Dockerfile.
+# Note that you can also set `base = None` for the same effect.
+image_manifest(name = "scratch")
+
+# This is a dummy target that can be selected, but cannot be built.
+# It is useful as a default select arm of the `base` attribute:
+#
+# image_manifest(
+#     ...
+#     base = select({
+#         "@platforms//os:linux": "@distroless_static",
+#         "@platforms//os:windows": "@nanoserver",
+#         "//conditions:default": "@rules_img//img/base:incompatible",
+#     }),
+#     ...
+# )
+#
+# In effect, you can always cquery this target, but never build it.
+image_manifest(
+    name = "incompatible",
+    target_compatible_with = ["@platforms//:incompatible"],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//img/private/release:__subpackages__"],
+)

--- a/img/private/release/source_files/BUILD.bazel
+++ b/img/private/release/source_files/BUILD.bazel
@@ -4,6 +4,7 @@
 release_files = [
     "//:all_files",
     "//img:all_files",
+    "//img/base:all_files",
     "//img/constraints:all_files",
     "//img/constraints/amd64:all_files",
     "//img/constraints/arm:all_files",


### PR DESCRIPTION
The target `@rules_img//img/base:incompatible` can be used in the `base` attribute of `image_manifest` as part of a `//conditions:default` select arm to ensure that `bazel cquery` works on the target, but it is never built:

```starlark
image_manifest(
    # ...
    base = select({
        "@platforms//os:linux": "@distroless_static",
        "@platforms//os:windows": "@nanoserver",
        "//conditions:default": "@rules_img//img/base:incompatible",
    }),
    # ...
)
```