### PR TITLE
Add Bazel Credential Helper to `go-containerregistry` keychain

### DIFF
--- a/img_tool/pkg/auth/credential/BUILD.bazel
+++ b/img_tool/pkg/auth/credential/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
 
 go_test(
     name = "credential_test",
+    size = "small",
     srcs = ["credentialhelper_test.go"],
     embed = [":credential"],
 )

--- a/img_tool/pkg/auth/credential/credentialhelper.go
+++ b/img_tool/pkg/auth/credential/credentialhelper.go
@@ -3,7 +3,10 @@ package credential
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
@@ -138,3 +141,51 @@ type cacheEntry struct {
 }
 
 var _ http.RoundTripper = &AuthenticatingRoundTripper{}
+
+// ContainerRegistryHelper conforms to `go-containerregistry#authn.Helper`
+type containerRegistryHelper struct {
+	helper Helper
+}
+
+func ContainerRegistryHelper(helper Helper) *containerRegistryHelper {
+	return &containerRegistryHelper{
+		helper: helper,
+	}
+}
+
+func (c *containerRegistryHelper) Get(serverURL string) (string, string, error) {
+	headers, _, err := c.helper.Get(context.Background(), serverURL)
+	if err != nil {
+		return "", "", err
+	} else if headers == nil {
+		return "", "", errors.New("no HTTP headers found")
+	}
+
+	values, ok := headers["Authorization"]
+	if !ok {
+		return "", "", errors.New("no `Authorization` header")
+	}
+
+	for _, header := range values {
+		kind, value, found := strings.Cut(header, " ")
+		if !found {
+			return "", "", fmt.Errorf("no authorization scheme: %s", header)
+		} else if kind == "Basic" {
+			decoded, err := base64.StdEncoding.DecodeString(value)
+			if err != nil {
+				return "", "", fmt.Errorf("decode authorisation header: %s: %w", header, err)
+			}
+			username, password, found := strings.Cut(string(decoded), ":")
+			if !found {
+				return "", "", fmt.Errorf("no semi-colon in basic auth: %s", decoded)
+			}
+			return username, password, nil
+		} else if kind == "Bearer" {
+			return "<token>", value, nil
+		} else {
+			return "", "", fmt.Errorf("unknown authorization scheme: %s", header)
+		}
+	}
+
+	return "", "", fmt.Errorf("no `Authorization` headers")
+}

--- a/img_tool/pkg/auth/credential/credentialhelper_test.go
+++ b/img_tool/pkg/auth/credential/credentialhelper_test.go
@@ -1,8 +1,12 @@
 package credential
 
 import (
+	"context"
+	"encoding/base64"
 	"os"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestNew_ReplacesWorkspacePlaceholder(t *testing.T) {
@@ -35,5 +39,148 @@ func TestNew_WithoutWorkspacePlaceholder(t *testing.T) {
 	expected := "/usr/local/bin/helper"
 	if extHelper.helperBinary != expected {
 		t.Errorf("expected helperBinary to be %q, got %q", expected, extHelper.helperBinary)
+	}
+}
+
+type TestHelper struct {
+	Headers map[string][]string
+}
+
+func (t *TestHelper) Get(_ context.Context, _ string) (headers map[string][]string, expiresAt time.Time, err error) {
+	return t.Headers, time.Time{}, nil
+}
+
+func TestContainerRegistryHelper_WithNilHeaders(t *testing.T) {
+	helper := TestHelper{}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); msg != "no HTTP headers found" {
+		t.Fatalf(`expected error to be "no HTTP headers found", got %s`, msg)
+	}
+}
+
+func TestContainerRegistryHelper_WithNoHeaders(t *testing.T) {
+	helper := TestHelper{
+		Headers: map[string][]string{},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); msg != "no `Authorization` header" {
+		t.Fatalf("expected error to be \"no `Authorization` header\", got %s", msg)
+	}
+}
+
+func TestContainerRegistryHelper_WithNoScheme(t *testing.T) {
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{"no-space-here"},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); msg != "no authorization scheme: no-space-here" {
+		t.Fatalf("expected error to be \"no authorization scheme: no-space-here\", got %s", msg)
+	}
+}
+
+func TestContainerRegistryHelper_WithBasicAuthIncorrectData(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("no-semi-colon"))
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{"Basic " + encoded},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); msg != "no semi-colon in basic auth: no-semi-colon" {
+		t.Fatalf("expected error to be \"no semi-colon in basic auth: no-semi-colon\", got %s", msg)
+	}
+}
+
+func TestContainerRegistryHelper_WithBasicAuthIncorrectEncoding(t *testing.T) {
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{"Basic !"},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); !strings.HasPrefix(msg, "decode authorisation header: Basic !") {
+		t.Fatalf("expected error to be \"decode authorisation header: Basic !\", got %s", msg)
+	}
+}
+
+func TestContainerRegistryHelper_WithBasicAuth(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("test:pass"))
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{"Basic " + encoded},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	username, password, err := crh.Get("")
+	if err != nil {
+		t.Fatalf("expected err to be nil, got %v", err)
+	} else if username != "test" {
+		t.Fatalf(`expected username to be "test", got %s`, username)
+	} else if password != "pass" {
+		t.Fatalf(`expected username to be "pass", got %s`, password)
+	}
+}
+
+func TestContainerRegistryHelper_WithBearerAuth(t *testing.T) {
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{"Bearer <token>"},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	username, password, err := crh.Get("")
+	if err != nil {
+		t.Fatalf("expected err to be nil, got %v", err)
+	} else if username != "<token>" {
+		t.Fatalf(`expected username to be "<token>", got %s`, username)
+	} else if password != "<token>" {
+		t.Fatalf(`expected username to be "<token>", got %s`, password)
+	}
+}
+
+func TestContainerRegistryHelper_WithUnknownScheme(t *testing.T) {
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{"Unknown ..."},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); msg != "unknown authorization scheme: Unknown ..." {
+		t.Fatalf("expected error to be \"unknown authorization scheme: Unknown ...\", got %s", msg)
+	}
+}
+
+func TestContainerRegistryHelper_WithEmptyAuthHeader(t *testing.T) {
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); msg != "no `Authorization` headers" {
+		t.Fatalf("expected error to be \"no `Authorization` headers\", got %s", msg)
 	}
 }

--- a/img_tool/pkg/auth/registry/BUILD.bazel
+++ b/img_tool/pkg/auth/registry/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/bazel-contrib/rules_img/img_tool/pkg/auth/registry",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/auth/credential",
         "@com_github_malt3_go_containerregistry//pkg/authn",
         "@com_github_malt3_go_containerregistry//pkg/v1/google",
         "@com_github_malt3_go_containerregistry//pkg/v1/remote",

--- a/img_tool/pkg/auth/registry/registry.go
+++ b/img_tool/pkg/auth/registry/registry.go
@@ -1,6 +1,9 @@
 package registry
 
 import (
+	"os"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/credential"
 	"github.com/malt3/go-containerregistry/pkg/authn"
 	"github.com/malt3/go-containerregistry/pkg/v1/google"
 	"github.com/malt3/go-containerregistry/pkg/v1/remote"
@@ -8,12 +11,23 @@ import (
 
 // WithAuthFromMultiKeychain returns a remote.Option that uses a MultiKeychain
 // combining the default keychain and the Google keychain for authentication.
-// WARNING: keep in sync with the same function in img_tool/pkg/auth/registry/registry.go.
+// If `IMG_CREDENTIAL_HELPER` is set in the environment, the Bazel credential helper will
+// contribute to the keychain.
+// WARNING: keep in sync with the same function in pull_tool/pkg/auth/registry/registry.go.
 func WithAuthFromMultiKeychain() remote.Option {
-	kc := authn.NewMultiKeychain(
+	keychains := []authn.Keychain{
 		authn.DefaultKeychain,
 		google.Keychain,
-	)
+	}
+
+	if value, ok := os.LookupEnv("IMG_CREDENTIAL_HELPER"); ok {
+		bazel := credential.New(value)
+		docker := credential.ContainerRegistryHelper(bazel)
+		keychain := authn.NewKeychainFromHelper(docker)
+		keychains = append(keychains, keychain)
+	}
+
+	kc := authn.NewMultiKeychain(keychains...)
 
 	return remote.WithAuthFromKeychain(kc)
 }

--- a/pull_tool/pkg/auth/credential/BUILD.bazel
+++ b/pull_tool/pkg/auth/credential/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "credential",
+    srcs = ["credentialhelper.go"],
+    importpath = "github.com/bazel-contrib/rules_img/pull_tool/pkg/auth/credential",
+    visibility = ["//pkg/auth:__subpackages__"],
+)
+
+go_test(
+    name = "credential_test",
+    size = "small",
+    srcs = ["credentialhelper_test.go"],
+    embed = [":credential"],
+)

--- a/pull_tool/pkg/auth/credential/credentialhelper.go
+++ b/pull_tool/pkg/auth/credential/credentialhelper.go
@@ -1,0 +1,191 @@
+package credential
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Helper is the interface for a credential helper.
+type Helper interface {
+	Get(ctx context.Context, uri string) (headers map[string][]string, expiresAt time.Time, err error)
+}
+
+type externalCredentialHelper struct {
+	helperBinary string
+	cache        map[string]cacheEntry
+	mux          sync.RWMutex
+}
+
+func New(credentialHelperBinary string) Helper {
+	workingDirectory := os.Getenv("BUILD_WORKSPACE_DIRECTORY")
+	if workingDirectory != "" {
+		credentialHelperBinary = strings.Replace(credentialHelperBinary, "%workspace%", workingDirectory, 1)
+	}
+	return &externalCredentialHelper{
+		helperBinary: credentialHelperBinary,
+		cache:        make(map[string]cacheEntry),
+	}
+}
+
+func (e *externalCredentialHelper) Get(ctx context.Context, uri string) (headers map[string][]string, expiresAt time.Time, err error) {
+	if headers, ok := e.getFromCache(uri); ok {
+		return headers, expiresAt, nil
+	}
+	cmd := exec.CommandContext(ctx, e.helperBinary, "get")
+	stdin, err := json.Marshal(externalRequest{URI: uri})
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = bytes.NewReader(stdin)
+	stdout, err := cmd.Output()
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	var resp externalResponse
+	if err := json.Unmarshal(stdout, &resp); err != nil {
+		return nil, time.Time{}, err
+	}
+
+	if resp.Expires != "" {
+		expiresAt, err = time.Parse(time.RFC3339, resp.Expires)
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+	}
+	e.putToCache(uri, resp.Headers, expiresAt)
+	return resp.Headers, expiresAt, nil
+}
+
+func (e *externalCredentialHelper) getFromCache(uri string) (headers map[string][]string, ok bool) {
+	e.mux.RLock()
+	defer e.mux.RUnlock()
+	entry, ok := e.cache[uri]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		return nil, false
+	}
+	return entry.headers, true
+}
+
+func (e *externalCredentialHelper) putToCache(uri string, headers map[string][]string, expiresAt time.Time) {
+	e.mux.Lock()
+	defer e.mux.Unlock()
+	if expiresAt.IsZero() {
+		// TODO: make this configurable
+		expiresAt = time.Now().Add(5 * time.Minute)
+	}
+	e.cache[uri] = cacheEntry{
+		headers:   headers,
+		expiresAt: expiresAt,
+	}
+}
+
+type nopHelper struct{}
+
+func NopHelper() Helper {
+	return nopHelper{}
+}
+
+func (nopHelper) Get(ctx context.Context, uri string) (map[string][]string, time.Time, error) {
+	return nil, time.Time{}, nil
+}
+
+type AuthenticatingRoundTripper struct {
+	helper Helper
+}
+
+func RoundTripper(helper Helper) *AuthenticatingRoundTripper {
+	return &AuthenticatingRoundTripper{
+		helper: helper,
+	}
+}
+
+func (a *AuthenticatingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	headers, _, err := a.helper.Get(req.Context(), req.URL.String())
+	if err != nil {
+		return nil, err
+	}
+	for key, values := range headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+type externalRequest struct {
+	URI string `json:"uri"`
+}
+
+type externalResponse struct {
+	Expires string              `json:"expires,omitempty"`
+	Headers map[string][]string `json:"headers,omitempty"`
+}
+
+type cacheEntry struct {
+	headers   map[string][]string
+	expiresAt time.Time
+}
+
+var _ http.RoundTripper = &AuthenticatingRoundTripper{}
+
+// ContainerRegistryHelper conforms to `go-containerregistry#authn.Helper`
+type containerRegistryHelper struct {
+	helper Helper
+}
+
+func ContainerRegistryHelper(helper Helper) *containerRegistryHelper {
+	return &containerRegistryHelper{
+		helper: helper,
+	}
+}
+
+func (c *containerRegistryHelper) Get(serverURL string) (string, string, error) {
+	headers, _, err := c.helper.Get(context.Background(), serverURL)
+	if err != nil {
+		return "", "", err
+	} else if headers == nil {
+		return "", "", errors.New("no HTTP headers found")
+	}
+
+	values, ok := headers["Authorization"]
+	if !ok {
+		return "", "", errors.New("no `Authorization` header")
+	}
+
+	for _, header := range values {
+		kind, value, found := strings.Cut(header, " ")
+		if !found {
+			return "", "", fmt.Errorf("no authorization scheme: %s", header)
+		} else if kind == "Basic" {
+			decoded, err := base64.StdEncoding.DecodeString(value)
+			if err != nil {
+				return "", "", fmt.Errorf("decode authorisation header: %s: %w", header, err)
+			}
+			username, password, found := strings.Cut(string(decoded), ":")
+			if !found {
+				return "", "", fmt.Errorf("no semi-colon in basic auth: %s", decoded)
+			}
+			return username, password, nil
+		} else if kind == "Bearer" {
+			return "<token>", value, nil
+		} else {
+			return "", "", fmt.Errorf("unknown authorization scheme: %s", header)
+		}
+	}
+
+	return "", "", fmt.Errorf("no `Authorization` headers")
+}

--- a/pull_tool/pkg/auth/credential/credentialhelper_test.go
+++ b/pull_tool/pkg/auth/credential/credentialhelper_test.go
@@ -1,0 +1,186 @@
+package credential
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNew_ReplacesWorkspacePlaceholder(t *testing.T) {
+	// Set up environment variable
+	orig := os.Getenv("BUILD_WORKSPACE_DIRECTORY")
+	defer os.Setenv("BUILD_WORKSPACE_DIRECTORY", orig)
+	os.Setenv("BUILD_WORKSPACE_DIRECTORY", "/tmp/workspace")
+
+	helper := New("%workspace%/bin/helper")
+	extHelper, ok := helper.(*externalCredentialHelper)
+	if !ok {
+		t.Fatalf("expected *externalCredentialHelper, got %T", helper)
+	}
+	expected := "/tmp/workspace/bin/helper"
+	if extHelper.helperBinary != expected {
+		t.Errorf("expected helperBinary to be %q, got %q", expected, extHelper.helperBinary)
+	}
+}
+
+func TestNew_WithoutWorkspacePlaceholder(t *testing.T) {
+	orig := os.Getenv("BUILD_WORKSPACE_DIRECTORY")
+	defer os.Setenv("BUILD_WORKSPACE_DIRECTORY", orig)
+	os.Setenv("BUILD_WORKSPACE_DIRECTORY", "/tmp/workspace")
+
+	helper := New("/usr/local/bin/helper")
+	extHelper, ok := helper.(*externalCredentialHelper)
+	if !ok {
+		t.Fatalf("expected *externalCredentialHelper, got %T", helper)
+	}
+	expected := "/usr/local/bin/helper"
+	if extHelper.helperBinary != expected {
+		t.Errorf("expected helperBinary to be %q, got %q", expected, extHelper.helperBinary)
+	}
+}
+
+type TestHelper struct {
+	Headers map[string][]string
+}
+
+func (t *TestHelper) Get(_ context.Context, _ string) (headers map[string][]string, expiresAt time.Time, err error) {
+	return t.Headers, time.Time{}, nil
+}
+
+func TestContainerRegistryHelper_WithNilHeaders(t *testing.T) {
+	helper := TestHelper{}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); msg != "no HTTP headers found" {
+		t.Fatalf(`expected error to be "no HTTP headers found", got %s`, msg)
+	}
+}
+
+func TestContainerRegistryHelper_WithNoHeaders(t *testing.T) {
+	helper := TestHelper{
+		Headers: map[string][]string{},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); msg != "no `Authorization` header" {
+		t.Fatalf("expected error to be \"no `Authorization` header\", got %s", msg)
+	}
+}
+
+func TestContainerRegistryHelper_WithNoScheme(t *testing.T) {
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{"no-space-here"},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); msg != "no authorization scheme: no-space-here" {
+		t.Fatalf("expected error to be \"no authorization scheme: no-space-here\", got %s", msg)
+	}
+}
+
+func TestContainerRegistryHelper_WithBasicAuthIncorrectData(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("no-semi-colon"))
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{"Basic " + encoded},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); msg != "no semi-colon in basic auth: no-semi-colon" {
+		t.Fatalf("expected error to be \"no semi-colon in basic auth: no-semi-colon\", got %s", msg)
+	}
+}
+
+func TestContainerRegistryHelper_WithBasicAuthIncorrectEncoding(t *testing.T) {
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{"Basic !"},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); !strings.HasPrefix(msg, "decode authorisation header: Basic !") {
+		t.Fatalf("expected error to be \"decode authorisation header: Basic !\", got %s", msg)
+	}
+}
+
+func TestContainerRegistryHelper_WithBasicAuth(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("test:pass"))
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{"Basic " + encoded},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	username, password, err := crh.Get("")
+	if err != nil {
+		t.Fatalf("expected err to be nil, got %v", err)
+	} else if username != "test" {
+		t.Fatalf(`expected username to be "test", got %s`, username)
+	} else if password != "pass" {
+		t.Fatalf(`expected username to be "pass", got %s`, password)
+	}
+}
+
+func TestContainerRegistryHelper_WithBearerAuth(t *testing.T) {
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{"Bearer <token>"},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	username, password, err := crh.Get("")
+	if err != nil {
+		t.Fatalf("expected err to be nil, got %v", err)
+	} else if username != "<token>" {
+		t.Fatalf(`expected username to be "<token>", got %s`, username)
+	} else if password != "<token>" {
+		t.Fatalf(`expected username to be "<token>", got %s`, password)
+	}
+}
+
+func TestContainerRegistryHelper_WithUnknownScheme(t *testing.T) {
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{"Unknown ..."},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); msg != "unknown authorization scheme: Unknown ..." {
+		t.Fatalf("expected error to be \"unknown authorization scheme: Unknown ...\", got %s", msg)
+	}
+}
+
+func TestContainerRegistryHelper_WithEmptyAuthHeader(t *testing.T) {
+	helper := TestHelper{
+		Headers: map[string][]string{
+			"Authorization": []string{},
+		},
+	}
+	crh := ContainerRegistryHelper(&helper)
+	_, _, err := crh.Get("")
+	if err == nil {
+		t.Fatalf("expected err to be not nil")
+	} else if msg := err.Error(); msg != "no `Authorization` headers" {
+		t.Fatalf("expected error to be \"no `Authorization` headers\", got %s", msg)
+	}
+}

--- a/pull_tool/pkg/auth/registry/BUILD.bazel
+++ b/pull_tool/pkg/auth/registry/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/bazel-contrib/rules_img/pull_tool/pkg/auth/registry",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/auth/credential",
         "@com_github_google_go_containerregistry//pkg/authn",
         "@com_github_google_go_containerregistry//pkg/v1/google",
         "@com_github_google_go_containerregistry//pkg/v1/remote",

--- a/pull_tool/pkg/auth/registry/registry.go
+++ b/pull_tool/pkg/auth/registry/registry.go
@@ -1,6 +1,9 @@
 package registry
 
 import (
+	"os"
+
+	"github.com/bazel-contrib/rules_img/pull_tool/pkg/auth/credential"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -8,12 +11,23 @@ import (
 
 // WithAuthFromMultiKeychain returns a remote.Option that uses a MultiKeychain
 // combining the default keychain and the Google keychain for authentication.
+// If `IMG_CREDENTIAL_HELPER` is set in the environment, the Bazel credential helper will
+// contribute to the keychain.
 // WARNING: keep in sync with the same function in img_tool/pkg/auth/registry/registry.go.
 func WithAuthFromMultiKeychain() remote.Option {
-	kc := authn.NewMultiKeychain(
+	keychains := []authn.Keychain{
 		authn.DefaultKeychain,
 		google.Keychain,
-	)
+	}
+
+	if value, ok := os.LookupEnv("IMG_CREDENTIAL_HELPER"); ok {
+		bazel := credential.New(value)
+		docker := credential.ContainerRegistryHelper(bazel)
+		keychain := authn.NewKeychainFromHelper(docker)
+		keychains = append(keychains, keychain)
+	}
+
+	kc := authn.NewMultiKeychain(keychains...)
 
 	return remote.WithAuthFromKeychain(kc)
 }


### PR DESCRIPTION
Creates a wrapper around the current Bazel credential helper to conform to [`go-containerregistry@authn.Helper`](https://github.com/google/go-containerregistry/blob/e8813dd0a00e799459cae01d8a4659b9be2fd871/pkg/authn/keychain.go#L187C1-L194C2) interface so that it can be used with `authn.NewKeychainFromHelper`:

```go
bazel := credential.New("bazel-credential-helper")
docker := credential.ContainerRegistryHelper(bazel)
keychain := authn. authn.NewKeychainFromHelper(docker)
```

The URL is passed to the Bazel credential helper, headers are retrieved and the `Authorization` is read to provide the username/password from `Basic` _or_ the token from `Bearer`.

The default keychain passed to `go-containerregistry` includes the Bazel credential helper when `IMG_CREDENTIAL_HELPER` is available in the environment.

Things needing review:

- Is `ContainerRegistryHelper` sensible naming?
- There is a commit that copies the `ContainerRegistryHelper` to `pull_tool` as I didn't want to introduce a dependency to `img_tool`. What do we do about that?
- There are unit tests but no integration tests. Guidance on if those are needed would be good to know. If so, where they go and how we expect them to be implemented would be good.
- I haven't done exhaustive real-world testing of this. It'd be good to know what we need to land this.

Fixes #453.