### PR TITLE
fix: increase bufio.Scanner buffer to 1 MB in layer hints readers

### DIFF
--- a/img_tool/cmd/deploymetadata/layerhints.go
+++ b/img_tool/cmd/deploymetadata/layerhints.go
@@ -164,6 +164,7 @@ func readLayerHintsOutput(inputPath string, digestMap map[string][]string) error
 	defer inputFile.Close()
 
 	scanner := bufio.NewScanner(inputFile)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // default 64 KB is too small when many operations share a layer
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "" {

--- a/img_tool/pkg/deployvfs/deployvfs.go
+++ b/img_tool/pkg/deployvfs/deployvfs.go
@@ -346,6 +346,7 @@ func parseLayerHints(hintsPath string, workspaceDir string) (map[string][]string
 
 	hints := make(map[string][]string)
 	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // default 64 KB is too small when many operations share a layer
 
 	for scanner.Scan() {
 		line := scanner.Text()


### PR DESCRIPTION
The default 64 KB token limit causes bufio: token too long when a merged layer hints file contains many operations sharing a common base layer (each contributing one path on the same line).

This speculatively fixes an issue we are seeing where our deployment pipeline fails when too many images are deployed in one operation.