### PR TITLE
image_load: tarball compatible with "docker save" and oci layout

### DIFF
--- a/docs/load.md
+++ b/docs/load.md
@@ -87,7 +87,9 @@ Key features:
 The rule produces an executable that can be run with `bazel run`.
 
 Output groups:
-- `tarball`: Docker save compatible tarball (only available for single-platform images)
+- `tarball`: "docker save" compatible tarball with OCI layout (available for both single and multi-platform images).
+  For multi-platform images, the first manifest is used as the default in `manifest.json`,
+  and all manifests are included in `index.json`.
 
 Example:
 

--- a/e2e/go/multiarch/BUILD.bazel
+++ b/e2e/go/multiarch/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_img//img:image.bzl", "image_index", "image_manifest")
 load("@rules_img//img:layer.bzl", "image_layer")
+load("@rules_img//img:load.bzl", "image_load")
 load("@rules_img//img:push.bzl", "image_push")
 
 image_layer(
@@ -38,6 +39,12 @@ image_push(
     repository = "malt3/rules_img/go",
     tag = "multiarch",
     visibility = ["//:__pkg__"],
+)
+
+image_load(
+    name = "load",
+    image = ":multiarch_image",
+    tag = "go-multiarch:latest",
 )
 
 build_test(

--- a/img/private/load.bzl
+++ b/img/private/load.bzl
@@ -123,37 +123,66 @@ def _compute_load_metadata(*, ctx, configuration_json):
     )
     return metadata_out, layer_hints_file
 
-def _build_docker_tarball(ctx, configuration_json, manifest_info):
+def _build_docker_tarball(ctx, configuration_json, manifest_info = None, index_info = None):
     """Build the Docker save tarball for the image.
+
+    The tarball is compatible with both Docker save format (manifest.json)
+    and OCI layout (index.json + oci-layout), following the containerd c8d format.
 
     Args:
         ctx: Rule context.
         configuration_json: The configuration file with expanded templates.
-        manifest_info: The ImageManifestInfo provider.
+        manifest_info: The ImageManifestInfo provider (for single-platform).
+        index_info: The ImageIndexInfo provider (for multi-platform).
 
     Returns:
         The Docker save tarball file.
     """
+    if manifest_info == None and index_info == None:
+        fail("_build_docker_tarball requires manifest_info or index_info")
+    if manifest_info != None and index_info != None:
+        fail("_build_docker_tarball: provide manifest_info or index_info, not both")
+
     tarball_output = ctx.actions.declare_file(ctx.label.name + "_docker.tar")
 
     args = ctx.actions.args()
     args.add("docker-save")
-    args.add("--manifest", manifest_info.manifest.path)
-    args.add("--config", manifest_info.config.path)
     args.add("--output", tarball_output.path)
     args.add("--format", "tar")
     args.add("--configuration-file", configuration_json.path)
     if ctx.attr._oci_layout_settings[OCILayoutSettingsInfo].allow_shallow_oci_layout:
         args.add("--allow-missing-blobs")
 
-    inputs = [manifest_info.manifest, manifest_info.config, configuration_json]
+    inputs = [configuration_json]
 
-    # Add layers with metadata=blob mapping
-    for layer in manifest_info.layers:
-        if layer.blob != None:
-            args.add("--layer", "{}={}".format(layer.metadata.path, layer.blob.path))
-            inputs.append(layer.metadata)
-            inputs.append(layer.blob)
+    if manifest_info != None:
+        args.add("--manifest", manifest_info.manifest.path)
+        args.add("--config", manifest_info.config.path)
+        inputs.append(manifest_info.manifest)
+        inputs.append(manifest_info.config)
+
+        # Add layers with metadata=blob mapping
+        for layer in manifest_info.layers:
+            if layer.blob != None:
+                args.add("--layer", "{}={}".format(layer.metadata.path, layer.blob.path))
+                inputs.append(layer.metadata)
+                inputs.append(layer.blob)
+
+    if index_info != None:
+        args.add("--index", index_info.index.path)
+        inputs.append(index_info.index)
+
+        for manifest in index_info.manifests:
+            args.add("--manifest-path", manifest.manifest.path)
+            args.add("--config-path", manifest.config.path)
+            inputs.append(manifest.manifest)
+            inputs.append(manifest.config)
+
+            for layer in manifest.layers:
+                if layer.blob != None:
+                    args.add("--layer", "{}={}".format(layer.metadata.path, layer.blob.path))
+                    inputs.append(layer.metadata)
+                    inputs.append(layer.blob)
 
     img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
     ctx.actions.run(
@@ -247,10 +276,11 @@ def _image_load_impl(ctx):
         deploy_manifest = depset([deploy_metadata]),
     )
 
-    # Add tarball output group only for single-platform images (manifest_info)
-    # Index info (multi-platform) is not supported by docker-save command
     if manifest_info != None:
-        tarball = _build_docker_tarball(ctx, configuration_json, manifest_info)
+        tarball = _build_docker_tarball(ctx, configuration_json, manifest_info = manifest_info)
+        output_groups["tarball"] = depset([tarball])
+    elif index_info != None:
+        tarball = _build_docker_tarball(ctx, configuration_json, index_info = index_info)
         output_groups["tarball"] = depset([tarball])
 
     return [
@@ -294,7 +324,9 @@ Key features:
 The rule produces an executable that can be run with `bazel run`.
 
 Output groups:
-- `tarball`: Docker save compatible tarball (only available for single-platform images)
+- `tarball`: "docker save" compatible tarball with OCI layout (available for both single and multi-platform images).
+  For multi-platform images, the first manifest is used as the default in `manifest.json`,
+  and all manifests are included in `index.json`.
 
 Example:
 

--- a/img_tool/cmd/dockersave/dockersave.go
+++ b/img_tool/cmd/dockersave/dockersave.go
@@ -1,6 +1,7 @@
 package dockersave
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -34,11 +35,26 @@ If you explicitly want to opt in to Docker save tarballs with missing blobs, use
 	return fmt.Sprintf("missing blobs: %s", strings.Join(e.MissingBlobs, ", "))
 }
 
+const OCILayoutVersion = "1.0.0"
+
 // DockerManifest represents the Docker save manifest format
 type DockerManifest struct {
 	Config   string   `json:"Config"`
 	RepoTags []string `json:"RepoTags"`
 	Layers   []string `json:"Layers"`
+}
+
+func hashBytes(data []byte) v1.Hash {
+	h, _, _ := v1.SHA256(bytes.NewReader(data))
+	return h
+}
+
+func writeJSONWithSink(sink DockerSaveSink, path string, v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", path, err)
+	}
+	return sink.WriteFile(path, data, 0o644)
 }
 
 // readTagsFromConfigFile reads the tags field from a configuration file
@@ -85,6 +101,9 @@ func DockerSaveProcess(ctx context.Context, args []string) {
 	var useSymlinks bool
 	var allowMissingBlobs bool
 	var configurationFilePath string
+	var indexPath string
+	var manifestPaths stringSliceFlag
+	var configPaths stringSliceFlag
 
 	flagSet := flag.NewFlagSet("docker-save", flag.ExitOnError)
 	flagSet.Usage = func() {
@@ -111,6 +130,9 @@ func DockerSaveProcess(ctx context.Context, args []string) {
 	flagSet.BoolVar(&useSymlinks, "symlink", false, "Use symlinks instead of copying files")
 	flagSet.BoolVar(&allowMissingBlobs, "allow-missing-blobs", false, "Allow missing blobs instead of failing the build")
 	flagSet.StringVar(&configurationFilePath, "configuration-file", "", "Path to configuration file containing tag information (optional)")
+	flagSet.StringVar(&indexPath, "index", "", "Path to the image index (for multi-platform, mutually exclusive with --manifest and --config)")
+	flagSet.Var(&manifestPaths, "manifest-path", "Path to manifest file (for index, can be specified multiple times)")
+	flagSet.Var(&configPaths, "config-path", "Path to config file (for index, can be specified multiple times)")
 
 	if err := flagSet.Parse(args); err != nil {
 		flagSet.Usage()
@@ -118,16 +140,6 @@ func DockerSaveProcess(ctx context.Context, args []string) {
 	}
 
 	// Validate required flags
-	if manifestPath == "" {
-		fmt.Fprintf(os.Stderr, "Error: --manifest is required\n")
-		flagSet.Usage()
-		os.Exit(1)
-	}
-	if configPath == "" {
-		fmt.Fprintf(os.Stderr, "Error: --config is required\n")
-		flagSet.Usage()
-		os.Exit(1)
-	}
 	if outputPath == "" {
 		fmt.Fprintf(os.Stderr, "Error: --output is required\n")
 		flagSet.Usage()
@@ -158,7 +170,40 @@ func DockerSaveProcess(ctx context.Context, args []string) {
 		repoTags = []string{"image:latest"}
 	}
 
-	err := assembleDockerSave(manifestPath, configPath, outputPath, format, layerFlags, repoTags, useSymlinks, allowMissingBlobs)
+	var err error
+	if indexPath != "" {
+		// Index mode: multi-platform images
+		if manifestPath != "" || configPath != "" {
+			fmt.Fprintf(os.Stderr, "Error: cannot use --manifest or --config with --index\n")
+			os.Exit(1)
+		}
+		if len(manifestPaths) != len(configPaths) {
+			fmt.Fprintf(os.Stderr, "Error: number of --manifest-path must match --config-path\n")
+			os.Exit(1)
+		}
+		if len(manifestPaths) == 0 {
+			fmt.Fprintf(os.Stderr, "Error: --index requires at least one --manifest-path and --config-path\n")
+			os.Exit(1)
+		}
+		err = assembleDockerSaveWithIndex(indexPath, outputPath, format, manifestPaths, configPaths, layerFlags, repoTags, useSymlinks, allowMissingBlobs)
+	} else {
+		// Single manifest mode
+		if manifestPath == "" {
+			fmt.Fprintf(os.Stderr, "Error: --manifest is required\n")
+			flagSet.Usage()
+			os.Exit(1)
+		}
+		if configPath == "" {
+			fmt.Fprintf(os.Stderr, "Error: --config is required\n")
+			flagSet.Usage()
+			os.Exit(1)
+		}
+		if len(manifestPaths) > 0 || len(configPaths) > 0 {
+			fmt.Fprintf(os.Stderr, "Error: cannot use --manifest-path or --config-path without --index\n")
+			os.Exit(1)
+		}
+		err = assembleDockerSave(manifestPath, configPath, outputPath, format, layerFlags, repoTags, useSymlinks, allowMissingBlobs)
+	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -215,16 +260,12 @@ func assembleDockerSave(manifestPath, configPath, outputPath, format string, lay
 		layerBlobsByDigest[digest] = layer.blob
 	}
 
-	// Create blobs directory
-	if err := sink.CreateDir("blobs"); err != nil {
-		return fmt.Errorf("creating blobs directory: %w", err)
-	}
-	if err := sink.CreateDir(filepath.Join("blobs", "sha256")); err != nil {
-		return fmt.Errorf("creating blobs/sha256 directory: %w", err)
-	}
-
 	blobs := make(blobMap)
 	blobs[manifest.Config.Digest.Hex] = configPath
+
+	// Add manifest itself as a blob for OCI layout
+	manifestDigest := hashBytes(manifestData)
+	blobs[manifestDigest.Hex] = manifestPath
 
 	// Collect layer paths for Docker manifest and check for missing blobs
 	var dockerLayers []string
@@ -246,26 +287,64 @@ func assembleDockerSave(manifestPath, configPath, outputPath, format string, lay
 		return &MissingBlobsError{MissingBlobs: missingBlobs}
 	}
 
-	// Copy all blobs
-	if err := copyBlobs(sink, blobs, useSymlinks); err != nil {
-		return err
+	// Write metadata files first so consumers can read them without scanning the full tar.
+	// Order: oci-layout, index.json, manifest.json, then blobs.
+	if err := sink.CreateDir("."); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
 	}
 
-	// Create Docker manifest
+	// Write OCI layout file
+	ociLayout := map[string]string{"imageLayoutVersion": OCILayoutVersion}
+	if err := writeJSONWithSink(sink, "oci-layout", ociLayout); err != nil {
+		return fmt.Errorf("writing oci-layout: %w", err)
+	}
+
+	// Write OCI index.json pointing to the manifest
+	indexDesc := v1.Descriptor{
+		MediaType:   manifest.MediaType,
+		Digest:      manifestDigest,
+		Size:        int64(len(manifestData)),
+		Annotations: manifest.Annotations,
+	}
+	if manifest.Config.MediaType != "" && !manifest.Config.MediaType.IsConfig() {
+		indexDesc.ArtifactType = string(manifest.Config.MediaType)
+	}
+	ociIndex := v1.IndexManifest{
+		SchemaVersion: 2,
+		MediaType:     "application/vnd.oci.image.index.v1+json",
+		Manifests:     []v1.Descriptor{indexDesc},
+	}
+	if err := writeJSONWithSink(sink, "index.json", ociIndex); err != nil {
+		return fmt.Errorf("writing index.json: %w", err)
+	}
+
+	// Write Docker manifest.json
 	dockerManifest := DockerManifest{
 		Config:   "blobs/sha256/" + manifest.Config.Digest.Hex,
 		RepoTags: repoTags,
 		Layers:   dockerLayers,
 	}
-
-	// Write Docker manifest as array (Docker load format expects an array)
 	dockerManifestArray := []DockerManifest{dockerManifest}
 	manifestJSON, err := json.MarshalIndent(dockerManifestArray, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling Docker manifest: %w", err)
 	}
+	if err := sink.WriteFile("manifest.json", manifestJSON, 0o644); err != nil {
+		return fmt.Errorf("writing manifest.json: %w", err)
+	}
 
-	return sink.WriteFile("manifest.json", manifestJSON, 0o644)
+	// Write blobs last
+	if err := sink.CreateDir("blobs"); err != nil {
+		return fmt.Errorf("creating blobs directory: %w", err)
+	}
+	if err := sink.CreateDir(filepath.Join("blobs", "sha256")); err != nil {
+		return fmt.Errorf("creating blobs/sha256 directory: %w", err)
+	}
+	if err := copyBlobs(sink, blobs, useSymlinks); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func copyBlobs(sink DockerSaveSink, blobs blobMap, useSymlinks bool) error {
@@ -283,5 +362,127 @@ func copyBlobs(sink DockerSaveSink, blobs blobMap, useSymlinks bool) error {
 			return fmt.Errorf("copying blob %s: %w", digest, err)
 		}
 	}
+	return nil
+}
+
+func assembleDockerSaveWithIndex(indexPath, outputPath, format string, manifestPaths, configPaths []string, layers layerMappingFlag, repoTags []string, useSymlinks, allowMissingBlobs bool) error {
+	sink, err := createSink(outputPath, format)
+	if err != nil {
+		return err
+	}
+	defer sink.Close()
+
+	// Build a map of available layers by their digest
+	layerBlobsByDigest := make(map[string]string)
+	for _, layer := range layers {
+		metadataData, err := os.ReadFile(layer.metadata)
+		if err != nil {
+			return fmt.Errorf("reading layer metadata %s: %w", layer.metadata, err)
+		}
+
+		var metadata struct {
+			Digest string `json:"digest"`
+		}
+		if err := json.Unmarshal(metadataData, &metadata); err != nil {
+			return fmt.Errorf("unmarshaling layer metadata %s: %w", layer.metadata, err)
+		}
+
+		digest := strings.TrimPrefix(metadata.Digest, "sha256:")
+		layerBlobsByDigest[digest] = layer.blob
+	}
+
+	blobs := make(blobMap)
+	var allMissingBlobs []string
+
+	// Track the first manifest's data for the Docker manifest.json
+	var firstManifest *v1.Manifest
+	var firstConfigDigestHex string
+
+	for i := range manifestPaths {
+		manifestData, err := os.ReadFile(manifestPaths[i])
+		if err != nil {
+			return fmt.Errorf("reading manifest %d: %w", i, err)
+		}
+
+		var manifest v1.Manifest
+		if err := json.Unmarshal(manifestData, &manifest); err != nil {
+			return fmt.Errorf("unmarshaling manifest %d: %w", i, err)
+		}
+
+		// Add manifest blob
+		manifestDigest := hashBytes(manifestData)
+		blobs[manifestDigest.Hex] = manifestPaths[i]
+
+		// Add config blob
+		blobs[manifest.Config.Digest.Hex] = configPaths[i]
+
+		// Check for missing layer blobs
+		for _, layerDesc := range manifest.Layers {
+			if blobPath, ok := layerBlobsByDigest[layerDesc.Digest.Hex]; ok {
+				blobs[layerDesc.Digest.Hex] = blobPath
+			} else if !allowMissingBlobs {
+				allMissingBlobs = append(allMissingBlobs, layerDesc.Digest.String())
+			}
+		}
+
+		// Remember first manifest for Docker manifest.json
+		if i == 0 {
+			firstManifest = &manifest
+			firstConfigDigestHex = manifest.Config.Digest.Hex
+		}
+	}
+
+	if len(allMissingBlobs) > 0 {
+		return &MissingBlobsError{MissingBlobs: allMissingBlobs}
+	}
+
+	// Write metadata files first so consumers can read them without scanning the full tar.
+	// Order: oci-layout, index.json, manifest.json, then blobs.
+	if err := sink.CreateDir("."); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	// Write OCI layout file
+	ociLayout := map[string]string{"imageLayoutVersion": OCILayoutVersion}
+	if err := writeJSONWithSink(sink, "oci-layout", ociLayout); err != nil {
+		return fmt.Errorf("writing oci-layout: %w", err)
+	}
+
+	// Copy pre-built index.json (already generated by Bazel)
+	if err := sink.CopyFile("index.json", indexPath, false); err != nil {
+		return fmt.Errorf("copying index file: %w", err)
+	}
+
+	// Build Docker manifest.json from the FIRST manifest (the "default" for docker load)
+	var dockerLayers []string
+	for _, layerDesc := range firstManifest.Layers {
+		dockerLayers = append(dockerLayers, "blobs/sha256/"+layerDesc.Digest.Hex)
+	}
+
+	dockerManifest := DockerManifest{
+		Config:   "blobs/sha256/" + firstConfigDigestHex,
+		RepoTags: repoTags,
+		Layers:   dockerLayers,
+	}
+	dockerManifestArray := []DockerManifest{dockerManifest}
+	manifestJSON, err := json.MarshalIndent(dockerManifestArray, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling Docker manifest: %w", err)
+	}
+	if err := sink.WriteFile("manifest.json", manifestJSON, 0o644); err != nil {
+		return fmt.Errorf("writing manifest.json: %w", err)
+	}
+
+	// Write blobs last
+	if err := sink.CreateDir("blobs"); err != nil {
+		return fmt.Errorf("creating blobs directory: %w", err)
+	}
+	if err := sink.CreateDir(filepath.Join("blobs", "sha256")); err != nil {
+		return fmt.Errorf("creating blobs/sha256 directory: %w", err)
+	}
+	if err := copyBlobs(sink, blobs, useSymlinks); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/tests/img_toolchain/testcases/dockersave_directory.ini
+++ b/tests/img_toolchain/testcases/dockersave_directory.ini
@@ -58,9 +58,17 @@ expect_exit = 0
 
 [assert]
 file_exists = docker-save/manifest.json
+file_exists = docker-save/index.json
+file_exists = docker-save/oci-layout
 file_exists = docker-save/blobs/sha256/b5b2b2c5072406148de34c2e87b1b0d4e98a8e99e4b1a4d8b48adf2e07f9b2c5
 file_exists = docker-save/blobs/sha256/a1a1a1c507240614ade34c2e87b1b0d4e98a8e99e4b1a4d8b48adf2e07f9a1a1
+file_exists = docker-save/blobs/sha256/e506db6f7420017a5800a9f16dee4192dd4b907249cb1301e431376d50592eb3
 file_valid_json = docker-save/manifest.json
+file_valid_json = docker-save/index.json
+file_valid_json = docker-save/oci-layout
 file_contains = docker-save/manifest.json, "my/image:latest"
 file_contains = docker-save/manifest.json, "blobs/sha256/b5b2b2c5072406148de34c2e87b1b0d4e98a8e99e4b1a4d8b48adf2e07f9b2c5"
 file_contains = docker-save/manifest.json, "blobs/sha256/a1a1a1c507240614ade34c2e87b1b0d4e98a8e99e4b1a4d8b48adf2e07f9a1a1"
+file_contains = docker-save/oci-layout, "1.0.0"
+file_contains = docker-save/index.json, "application/vnd.oci.image.manifest.v1+json"
+file_contains = docker-save/index.json, "e506db6f7420017a5800a9f16dee4192dd4b907249cb1301e431376d50592eb3"

--- a/tests/img_toolchain/testcases/dockersave_index_directory.ini
+++ b/tests/img_toolchain/testcases/dockersave_index_directory.ini
@@ -1,0 +1,139 @@
+[test]
+name = dockersave_index_directory
+description = Docker save format assembly with index (multi-platform) and directory format
+
+[file]
+name = manifest_amd64.json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "size": 100,
+    "digest": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "size": 1024,
+      "digest": "sha256:d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+    }
+  ]
+}
+
+[file]
+name = config_amd64.json
+{
+  "architecture": "amd64",
+  "os": "linux"
+}
+
+[file]
+name = manifest_arm64.json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "size": 100,
+    "digest": "sha256:e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "size": 2048,
+      "digest": "sha256:f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1"
+    }
+  ]
+}
+
+[file]
+name = config_arm64.json
+{
+  "architecture": "arm64",
+  "os": "linux"
+}
+
+[file]
+name = layer1_metadata.json
+{
+  "name": "layer1",
+  "digest": "sha256:d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1",
+  "size": 1024,
+  "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip"
+}
+
+[file]
+name = layer1.tar.gz
+fake amd64 layer content
+
+[file]
+name = layer2_metadata.json
+{
+  "name": "layer2",
+  "digest": "sha256:f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1",
+  "size": 2048,
+  "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip"
+}
+
+[file]
+name = layer2.tar.gz
+fake arm64 layer content
+
+[file]
+name = index.json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:0a6230c7f60edf206b84d75bddaf9135fc478abd0967329a2fdc2e4261bc9f14",
+      "size": 427,
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:2883c23ecede9b60b8cc40d54f2465b08f24c3ce16bf02eefca87b0ff84058fb",
+      "size": 427,
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux"
+      }
+    }
+  ]
+}
+
+[command]
+subcommand = docker-save
+args = --index index.json --manifest-path manifest_amd64.json --config-path config_amd64.json --manifest-path manifest_arm64.json --config-path config_arm64.json --layer layer1_metadata.json=layer1.tar.gz --layer layer2_metadata.json=layer2.tar.gz --repo-tag my/image:latest --format directory --output docker-save
+expect_exit = 0
+
+[assert]
+# Docker save format
+file_exists = docker-save/manifest.json
+file_valid_json = docker-save/manifest.json
+# manifest.json should reference the FIRST manifest (amd64) config and layers
+file_contains = docker-save/manifest.json, "my/image:latest"
+file_contains = docker-save/manifest.json, "blobs/sha256/c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+file_contains = docker-save/manifest.json, "blobs/sha256/d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+# OCI layout
+file_exists = docker-save/oci-layout
+file_exists = docker-save/index.json
+file_valid_json = docker-save/oci-layout
+file_valid_json = docker-save/index.json
+file_contains = docker-save/oci-layout, "1.0.0"
+# index.json should contain both platform manifests
+file_contains = docker-save/index.json, "amd64"
+file_contains = docker-save/index.json, "arm64"
+# All blobs should be present: configs, layers, and manifest blobs
+file_exists = docker-save/blobs/sha256/c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1
+file_exists = docker-save/blobs/sha256/e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1
+file_exists = docker-save/blobs/sha256/d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1
+file_exists = docker-save/blobs/sha256/f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1
+# Manifest blobs
+file_exists = docker-save/blobs/sha256/0a6230c7f60edf206b84d75bddaf9135fc478abd0967329a2fdc2e4261bc9f14
+file_exists = docker-save/blobs/sha256/2883c23ecede9b60b8cc40d54f2465b08f24c3ce16bf02eefca87b0ff84058fb

--- a/tests/img_toolchain/testcases/dockersave_index_tar.ini
+++ b/tests/img_toolchain/testcases/dockersave_index_tar.ini
@@ -1,0 +1,131 @@
+[test]
+name = dockersave_index_tar
+description = Docker save format assembly with index (multi-platform) and tar format
+
+[file]
+name = manifest_amd64.json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "size": 100,
+    "digest": "sha256:c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1"
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "size": 1024,
+      "digest": "sha256:d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1"
+    }
+  ]
+}
+
+[file]
+name = config_amd64.json
+{
+  "architecture": "amd64",
+  "os": "linux"
+}
+
+[file]
+name = manifest_arm64.json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "size": 100,
+    "digest": "sha256:e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1"
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "size": 2048,
+      "digest": "sha256:f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1"
+    }
+  ]
+}
+
+[file]
+name = config_arm64.json
+{
+  "architecture": "arm64",
+  "os": "linux"
+}
+
+[file]
+name = layer1_metadata.json
+{
+  "name": "layer1",
+  "digest": "sha256:d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1",
+  "size": 1024,
+  "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip"
+}
+
+[file]
+name = layer1.tar.gz
+fake amd64 layer content
+
+[file]
+name = layer2_metadata.json
+{
+  "name": "layer2",
+  "digest": "sha256:f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1",
+  "size": 2048,
+  "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip"
+}
+
+[file]
+name = layer2.tar.gz
+fake arm64 layer content
+
+[file]
+name = index.json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:0a6230c7f60edf206b84d75bddaf9135fc478abd0967329a2fdc2e4261bc9f14",
+      "size": 427,
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:2883c23ecede9b60b8cc40d54f2465b08f24c3ce16bf02eefca87b0ff84058fb",
+      "size": 427,
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux"
+      }
+    }
+  ]
+}
+
+[command]
+subcommand = docker-save
+args = --index index.json --manifest-path manifest_amd64.json --config-path config_amd64.json --manifest-path manifest_arm64.json --config-path config_arm64.json --layer layer1_metadata.json=layer1.tar.gz --layer layer2_metadata.json=layer2.tar.gz --repo-tag my/image:latest --format tar --output docker-save.tar
+expect_exit = 0
+
+[assert]
+file_exists = docker-save.tar
+file_size_gt = docker-save.tar, 100
+tar_entry_exists = docker-save.tar, manifest.json
+tar_entry_exists = docker-save.tar, index.json
+tar_entry_exists = docker-save.tar, oci-layout
+tar_entry_exists = docker-save.tar, blobs/
+tar_entry_exists = docker-save.tar, blobs/sha256/
+# Config blobs
+tar_entry_exists = docker-save.tar, blobs/sha256/c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1
+tar_entry_exists = docker-save.tar, blobs/sha256/e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1
+# Layer blobs
+tar_entry_exists = docker-save.tar, blobs/sha256/d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1
+tar_entry_exists = docker-save.tar, blobs/sha256/f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1
+# Manifest blobs
+tar_entry_exists = docker-save.tar, blobs/sha256/0a6230c7f60edf206b84d75bddaf9135fc478abd0967329a2fdc2e4261bc9f14
+tar_entry_exists = docker-save.tar, blobs/sha256/2883c23ecede9b60b8cc40d54f2465b08f24c3ce16bf02eefca87b0ff84058fb

--- a/tests/img_toolchain/testcases/dockersave_tar.ini
+++ b/tests/img_toolchain/testcases/dockersave_tar.ini
@@ -62,3 +62,11 @@ file_not_exists = docker-save.tar/manifest.json
 file_not_exists = docker-save.tar/blobs
 # The tar file should have reasonable size (>100 bytes)
 file_size_gt = docker-save.tar, 100
+tar_entry_exists = docker-save.tar, manifest.json
+tar_entry_exists = docker-save.tar, index.json
+tar_entry_exists = docker-save.tar, oci-layout
+tar_entry_exists = docker-save.tar, blobs/
+tar_entry_exists = docker-save.tar, blobs/sha256/
+tar_entry_exists = docker-save.tar, blobs/sha256/b5b2b2c5072406148de34c2e87b1b0d4e98a8e99e4b1a4d8b48adf2e07f9b2c5
+tar_entry_exists = docker-save.tar, blobs/sha256/a1a1a1c507240614ade34c2e87b1b0d4e98a8e99e4b1a4d8b48adf2e07f9a1a1
+tar_entry_exists = docker-save.tar, blobs/sha256/e506db6f7420017a5800a9f16dee4192dd4b907249cb1301e431376d50592eb3


### PR DESCRIPTION
The special `tarball` output group of the image_layout rule used to create a tar file that is only compatible with the old "docker save" format that contains a "manifest.json" file for a single platform image. Now, we instead create a tar file that works with either:

- contains valid "mainfest.json" for old docker
- contains valid oci layout for containerd and friends

When creating the `tarball` output group for an image_index, we now add all images to the tarball and select the first image for "manifest.json".