### PR TITLE
image_index: don't fail if two base images come from the same repo

### DIFF
--- a/img/private/index.bzl
+++ b/img/private/index.bzl
@@ -97,7 +97,7 @@ def _image_index_impl(ctx):
             continue
         other = manifest[PullInfo]
         other_manifest_info = manifest[ImageManifestInfo]
-        if pull_info != None and other != pull_info:
+        if pull_info != None and (other.registries != pull_info.registries or other.repository != pull_info.repository):
             # Only fail if other has missing blobs not covered by known_missing_blobs
             unknown_blobs = ["sha256:" + b for b in other_manifest_info.missing_blobs if b not in known_missing_blobs]
             if len(unknown_blobs) > 0:


### PR DESCRIPTION
In image_index(), we make sure that all the images that we pull as dependency (for various platforms) come from the same repo. We do that by making sure they come from a single pull() target.

Although this is probably the most common case, this is not technically correct. The user may decide to pull images for different platforms using multiple pull() target (for instance if the base image is not a multi-arch image). This currently results in an invalid failure, as rules_index compares the PullInfo providers.

We're fixing that issue here by comparing the registry and repository instead.