### PR TITLE
feat: add linux/s390x platform support

### DIFF
--- a/img/private/config/BUILD.bazel
+++ b/img/private/config/BUILD.bazel
@@ -10,6 +10,7 @@ os_cpu(
         "@platforms//cpu:mips64": "mips64",
         "@platforms//cpu:ppc64le": "ppc64le",
         "@platforms//cpu:riscv64": "riscv64",
+        "@platforms//cpu:s390x": "s390x",
         "@platforms//cpu:x86_32": "386",
         "@platforms//cpu:x86_64": "amd64",
     }),

--- a/img/private/platforms/platforms.bzl
+++ b/img/private/platforms/platforms.bzl
@@ -119,6 +119,7 @@ _tuples = [
     # linux
     (LINUX, AMD64),
     (LINUX, ARM64),
+    (LINUX, S390X),
 
     # darwin
     (DARWIN, AMD64),

--- a/img/private/prebuilt/prebuilt.bzl
+++ b/img/private/prebuilt/prebuilt.bzl
@@ -167,7 +167,7 @@ _prebuilt_attrs = {
     "version": attr.string(mandatory = True),
     "integrity": attr.string(mandatory = True),
     "os": attr.string(values = ["darwin", "linux", "windows"]),
-    "cpu": attr.string(values = ["amd64", "arm64"]),
+    "cpu": attr.string(values = ["amd64", "arm64", "s390x"]),
     "url_templates": attr.string_list(
         default = ["https://github.com/bazel-contrib/rules_img/releases/download/{version}/img_{os}_{cpu}{dot}{extension}"],
     ),
@@ -177,7 +177,7 @@ _prebuilt_pull_tool_attrs = {
     "version": attr.string(mandatory = True),
     "integrity": attr.string(mandatory = True),
     "os": attr.string(values = ["darwin", "linux", "windows"]),
-    "cpu": attr.string(values = ["amd64", "arm64"]),
+    "cpu": attr.string(values = ["amd64", "arm64", "s390x"]),
     "url_templates": attr.string_list(
         default = ["https://github.com/bazel-contrib/rules_img/releases/download/{version}/pull_tool_{os}_{cpu}{dot}{extension}"],
     ),

--- a/img/private/release/defs.bzl
+++ b/img/private/release/defs.bzl
@@ -15,6 +15,7 @@ GOOS_WINDOWS = "windows"
 
 GOARCH_AMD64 = "amd64"
 GOARCH_ARM64 = "arm64"
+GOARCH_S390X = "s390x"
 GOARCH_RISCV64 = "riscv64"
 
 go_to_constraint_value = {
@@ -23,6 +24,7 @@ go_to_constraint_value = {
     GOOS_WINDOWS: "@platforms//os:windows",
     GOARCH_AMD64: "@platforms//cpu:x86_64",
     GOARCH_ARM64: "@platforms//cpu:arm64",
+    GOARCH_S390X: "@platforms//cpu:s390x",
     GOARCH_RISCV64: "@platforms//cpu:riscv64",
 }
 
@@ -36,13 +38,14 @@ _goos_list = [
 _goarch_list = [
     GOARCH_AMD64,
     GOARCH_ARM64,
+    GOARCH_S390X,
     # TODO: fix rules_go upstream:
     # add riscv64 to BAZEL_GOARCH_CONSTRAINTS
     GOARCH_RISCV64,
 ]
 
 _os_to_arches = {
-    GOOS_LINUX: [GOARCH_AMD64, GOARCH_ARM64],
+    GOOS_LINUX: [GOARCH_AMD64, GOARCH_ARM64, GOARCH_S390X],
     GOOS_DARWIN: [GOARCH_AMD64, GOARCH_ARM64],
     GOOS_WINDOWS: [GOARCH_AMD64, GOARCH_ARM64],
 }

--- a/img/repositories.bzl
+++ b/img/repositories.bzl
@@ -57,6 +57,7 @@ def img_register_prebuilt_toolchains(
         platforms = [
             ("linux", "amd64"),
             ("linux", "arm64"),
+            ("linux", "s390x"),
             ("darwin", "amd64"),
             ("darwin", "arm64"),
             ("windows", "amd64"),
@@ -167,6 +168,7 @@ def pull_tool_register_prebuilt_repositories(
         platforms = [
             ("linux", "amd64"),
             ("linux", "arm64"),
+            ("linux", "s390x"),
             ("darwin", "amd64"),
             ("darwin", "arm64"),
             ("windows", "amd64"),

--- a/img_tool/cmd/img/BUILD.bazel
+++ b/img_tool/cmd/img/BUILD.bazel
@@ -35,6 +35,7 @@ go_binary(
 platform_tuples = [
     ("linux", "amd64"),
     ("linux", "arm64"),
+    ("linux", "s390x"),
     ("darwin", "amd64"),
     ("darwin", "arm64"),
     ("windows", "amd64"),

--- a/img_tool/toolchain/def.bzl
+++ b/img_tool/toolchain/def.bzl
@@ -8,6 +8,7 @@ This module provides utilities for mapping between Go platform identifiers
 platform_tuples = [
     ("linux", "amd64"),
     ("linux", "arm64"),
+    ("linux", "s390x"),
     ("darwin", "amd64"),
     ("darwin", "arm64"),
     ("windows", "amd64"),
@@ -45,5 +46,7 @@ def goarch_to_constraint(goarch):
         return "@platforms//cpu:x86_64"
     elif goarch == "arm64":
         return "@platforms//cpu:aarch64"
+    elif goarch == "s390x":
+        return "@platforms//cpu:s390x"
     else:
         fail("Unknown goarch: {}".format(goarch))


### PR DESCRIPTION
Add s390x (IBM Z) as a supported platform for toolchain resolution, prebuilt binary downloads, and release cross-compilation.