### PR TITLE
Add remote_instance_name setting for REAPI CAS requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ common --@rules_img//img/settings:load_daemon=docker
 # Falls back to $IMG_REAPI_ENDPOINT env var.
 common --@rules_img//img/settings:remote_cache=grpcs://remote.buildbuddy.io
 
+# Remote instance name for REAPI requests.
+# Same format as Bazel's --remote_instance_name flag.
+# Set as instance_name in CAS RPCs and as path prefix in ByteStream resource names.
+# Falls back to $IMG_REAPI_INSTANCE_NAME env var.
+# Required by some RBE backends.
+common --@rules_img//img/settings:remote_instance_name=my-instance-name
+
 # Credential helper to use for authenticating gRPC connections during push operations
 # in some push strategies.
 # This can be the same as Bazel's credential helper.

--- a/docs/push-strategies.md
+++ b/docs/push-strategies.md
@@ -79,6 +79,9 @@ common --@rules_img//img/settings:push_strategy=lazy
 # instead of environment variables:
 common --@rules_img//img/settings:remote_cache=grpc://your-cache-server:9092
 common --@rules_img//img/settings:credential_helper=tweag-credential-helper
+
+# If your remote cache requires a remote instance name, set it here:
+common --@rules_img//img/settings:remote_instance_name=my-instance-name
 ```
 
 3. Run your push target:
@@ -86,6 +89,8 @@ common --@rules_img//img/settings:credential_helper=tweag-credential-helper
 # Configure the push utility via environment variables:
 export IMG_REAPI_ENDPOINT=grpc://your-cache-server:9092
 export IMG_CREDENTIAL_HELPER=tweag-credential-helper
+# Set the remote instance name if required by your RBE backend:
+export IMG_REAPI_INSTANCE_NAME=my-instance-name
 bazel run //your:push_target
 
 # Or use the settings flags (if configured above):

--- a/img/private/load.bzl
+++ b/img/private/load.bzl
@@ -161,10 +161,12 @@ def _image_load_impl(ctx):
     # Build environment for RunEnvironmentInfo
     environment = {
         "IMG_REAPI_ENDPOINT": ctx.attr._load_settings[LoadSettingsInfo].remote_cache,
+        "IMG_REAPI_INSTANCE_NAME": ctx.attr._load_settings[LoadSettingsInfo].remote_instance_name,
         "IMG_CREDENTIAL_HELPER": ctx.attr._load_settings[LoadSettingsInfo].credential_helper,
     }
     inherited_environment = [
         "IMG_REAPI_ENDPOINT",
+        "IMG_REAPI_INSTANCE_NAME",
         "IMG_CREDENTIAL_HELPER",
         "DOCKER_CONFIG",
         "LOADER_BINARY",

--- a/img/private/multi_deploy.bzl
+++ b/img/private/multi_deploy.bzl
@@ -173,6 +173,10 @@ def _multi_deploy_impl(ctx):
         environment["IMG_REAPI_ENDPOINT"] = push_settings.remote_cache or load_settings.remote_cache
         inherited_environment.append("IMG_REAPI_ENDPOINT")
 
+    if push_settings.remote_instance_name or load_settings.remote_instance_name:
+        environment["IMG_REAPI_INSTANCE_NAME"] = push_settings.remote_instance_name or load_settings.remote_instance_name
+        inherited_environment.append("IMG_REAPI_INSTANCE_NAME")
+
     if push_settings.credential_helper or load_settings.credential_helper:
         environment["IMG_CREDENTIAL_HELPER"] = push_settings.credential_helper or load_settings.credential_helper
         inherited_environment.append("IMG_CREDENTIAL_HELPER")

--- a/img/private/providers/load_settings_info.bzl
+++ b/img/private/providers/load_settings_info.bzl
@@ -8,6 +8,7 @@ FIELDS = dict(
     strategy = "The default load strategy to use",
     daemon = "The daemon to target by default",
     remote_cache = "Bazel remote cache to use for the push rule as part of the lazy push strategy. Uses the same format as Bazel's --remote_cache flag. Uses $IMG_REAPI_ENDPOINT env var if not set.",
+    remote_instance_name = "Remote instance name for REAPI CAS requests. Set as instance_name field in CAS RPCs and as path prefix in ByteStream resource names. Uses $IMG_REAPI_INSTANCE_NAME env var if not set.",
     credential_helper = "Credential helper to use for the push rule. This can be the same as Bazel's credential helper. Uses $IMG_CREDENTIAL_HELPER env var or tools/credential-helper if not set.",
 )
 

--- a/img/private/providers/push_settings_info.bzl
+++ b/img/private/providers/push_settings_info.bzl
@@ -7,6 +7,7 @@ Collection of active push settings.
 FIELDS = dict(
     strategy = "The strategy of the push rule. This can be one of the following: 'eager', 'lazy', 'cas_registry', or 'bes'.",
     remote_cache = "Bazel remote cache to use for the push rule as part of the lazy push strategy. Uses the same format as Bazel's --remote_cache flag. Uses $IMG_REAPI_ENDPOINT env var if not set.",
+    remote_instance_name = "Remote instance name for REAPI CAS requests. Set as instance_name field in CAS RPCs and as path prefix in ByteStream resource names. Uses $IMG_REAPI_INSTANCE_NAME env var if not set.",
     credential_helper = "Credential helper to use for the push rule. This can be the same as Bazel's credential helper. Uses $IMG_CREDENTIAL_HELPER env var or tools/credential-helper if not set.",
     cross_mount = "Cross-mount configuration. Either 'same_registry', 'cross_registry' or 'disabled'.",
 )

--- a/img/private/push.bzl
+++ b/img/private/push.bzl
@@ -138,10 +138,12 @@ def _image_push_impl(ctx):
     # Build environment for RunEnvironmentInfo
     environment = {
         "IMG_REAPI_ENDPOINT": ctx.attr._push_settings[PushSettingsInfo].remote_cache,
+        "IMG_REAPI_INSTANCE_NAME": ctx.attr._push_settings[PushSettingsInfo].remote_instance_name,
         "IMG_CREDENTIAL_HELPER": ctx.attr._push_settings[PushSettingsInfo].credential_helper,
     }
     inherited_environment = [
         "IMG_REAPI_ENDPOINT",
+        "IMG_REAPI_INSTANCE_NAME",
         "IMG_CREDENTIAL_HELPER",
         "DOCKER_CONFIG",
     ]

--- a/img/private/settings/load.bzl
+++ b/img/private/settings/load.bzl
@@ -8,6 +8,7 @@ def _load_settings_impl(ctx):
         strategy = ctx.attr._load_strategy[BuildSettingInfo].value,
         daemon = ctx.attr._load_daemon[BuildSettingInfo].value,
         remote_cache = ctx.attr._remote_cache[BuildSettingInfo].value,
+        remote_instance_name = ctx.attr._remote_instance_name[BuildSettingInfo].value,
         credential_helper = ctx.attr._credential_helper[BuildSettingInfo].value,
     )]
 
@@ -24,6 +25,10 @@ load_settings = rule(
         ),
         "_remote_cache": attr.label(
             default = Label("//img/settings:remote_cache"),
+            providers = [BuildSettingInfo],
+        ),
+        "_remote_instance_name": attr.label(
+            default = Label("//img/settings:remote_instance_name"),
             providers = [BuildSettingInfo],
         ),
         "_credential_helper": attr.label(

--- a/img/private/settings/settings.bzl
+++ b/img/private/settings/settings.bzl
@@ -6,12 +6,14 @@ load("//img/private/providers:push_settings_info.bzl", "PushSettingsInfo")
 def _push_settings_impl(ctx):
     strategy = ctx.attr._push_strategy[BuildSettingInfo].value
     remote_cache = ctx.attr._remote_cache[BuildSettingInfo].value
+    remote_instance_name = ctx.attr._remote_instance_name[BuildSettingInfo].value
     credential_helper = ctx.attr._credential_helper[BuildSettingInfo].value
     cross_mount = ctx.attr._cross_mount[BuildSettingInfo].value
 
     return [PushSettingsInfo(
         strategy = strategy,
         remote_cache = remote_cache,
+        remote_instance_name = remote_instance_name,
         credential_helper = credential_helper,
         cross_mount = cross_mount,
     )]
@@ -25,6 +27,10 @@ push_settings = rule(
         ),
         "_remote_cache": attr.label(
             default = Label("//img/settings:remote_cache"),
+            providers = [BuildSettingInfo],
+        ),
+        "_remote_instance_name": attr.label(
+            default = Label("//img/settings:remote_instance_name"),
             providers = [BuildSettingInfo],
         ),
         "_credential_helper": attr.label(

--- a/img/settings/BUILD.bazel
+++ b/img/settings/BUILD.bazel
@@ -72,6 +72,12 @@ string_flag(
 )
 
 string_flag(
+    name = "remote_instance_name",
+    build_setting_default = "",
+    visibility = ["//img/private:__subpackages__"],
+)
+
+string_flag(
     name = "credential_helper",
     build_setting_default = "",
     visibility = ["//img/private:__subpackages__"],

--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -94,6 +94,7 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, additionalTags []s
 	}
 
 	reapiEndpoint := os.Getenv("IMG_REAPI_ENDPOINT")
+	reapiInstanceName := os.Getenv("IMG_REAPI_INSTANCE_NAME")
 	blobcacheEndpoint := os.Getenv("IMG_BLOB_CACHE_ENDPOINT")
 	credentialHelperPath := credentialHelperPath()
 	var credentialHelper credential.Helper
@@ -129,7 +130,7 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, additionalTags []s
 		if err != nil {
 			return fmt.Errorf("Failed to create gRPC client connection: %w", err)
 		}
-		casReader, err = cas.New(grpcClientConn)
+		casReader, err = cas.New(grpcClientConn, cas.WithInstanceName(reapiInstanceName))
 		if err != nil {
 			return fmt.Errorf("creating CAS client: %w", err)
 		}

--- a/img_tool/pkg/cas/read.go
+++ b/img_tool/pkg/cas/read.go
@@ -18,6 +18,7 @@ type CAS struct {
 	casClient        remoteexecution_proto.ContentAddressableStorageClient
 	byteStreamClient bytestream_proto.ByteStreamClient
 	capabilities     capabilities
+	instanceName     string
 }
 
 func New(clientConn *grpc.ClientConn, opts ...casOption) (*CAS, error) {
@@ -39,7 +40,7 @@ func New(clientConn *grpc.ClientConn, opts ...casOption) (*CAS, error) {
 	if casOpts.learnCapabilities {
 		capabilitiesClient := remoteexecution_proto.NewCapabilitiesClient(clientConn)
 		var err error
-		capabilities, err = learnCapabilities(context.Background(), capabilitiesClient)
+		capabilities, err = learnCapabilities(context.Background(), capabilitiesClient, casOpts.instanceName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to learn capabilities: %w", err)
 		}
@@ -52,6 +53,7 @@ func New(clientConn *grpc.ClientConn, opts ...casOption) (*CAS, error) {
 		casClient:        casClient,
 		byteStreamClient: byteStreamClient,
 		capabilities:     capabilities,
+		instanceName:     casOpts.instanceName,
 	}, nil
 }
 
@@ -74,6 +76,7 @@ func (c *CAS) FindMissingBlobs(ctx context.Context, digests []Digest) ([]Digest,
 		protoDigests = append(protoDigests, d.protoDigest())
 	}
 	resp, err := c.casClient.FindMissingBlobs(ctx, &remoteexecution_proto.FindMissingBlobsRequest{
+		InstanceName:   c.instanceName,
 		BlobDigests:    protoDigests,
 		DigestFunction: digestFunction,
 	})
@@ -139,6 +142,7 @@ func (c *CAS) ReaderForBlob(ctx context.Context, digest Digest) (io.ReadCloser, 
 
 func (c *CAS) batchReadOne(ctx context.Context, digest Digest) ([]byte, error) {
 	resp, err := c.casClient.BatchReadBlobs(ctx, &remoteexecution_proto.BatchReadBlobsRequest{
+		InstanceName:   c.instanceName,
 		Digests:        []*remoteexecution_proto.Digest{digest.protoDigest()},
 		DigestFunction: digest.protoDigestFunction(),
 	})
@@ -159,8 +163,12 @@ func (c *CAS) batchReadOne(ctx context.Context, digest Digest) ([]byte, error) {
 
 func (c *CAS) streamReadOne(ctx context.Context, digest Digest) (io.ReadCloser, error) {
 	ctx, cancel := context.WithCancel(ctx)
+	resourceName := fmt.Sprintf("blobs/%x/%d", digest.Hash, digest.SizeBytes)
+	if c.instanceName != "" {
+		resourceName = c.instanceName + "/" + resourceName
+	}
 	resp, err := c.byteStreamClient.Read(ctx, &bytestream_proto.ReadRequest{
-		ResourceName: fmt.Sprintf("blobs/%x/%d", digest.Hash, digest.SizeBytes),
+		ResourceName: resourceName,
 		ReadOffset:   0,
 	})
 	if err != nil {
@@ -248,8 +256,10 @@ func (c capabilities) supportedDigestFunction(algorithm string) bool {
 	return false
 }
 
-func learnCapabilities(ctx context.Context, capabilitiesClient remoteexecution_proto.CapabilitiesClient) (capabilities, error) {
-	resp, err := capabilitiesClient.GetCapabilities(ctx, &remoteexecution_proto.GetCapabilitiesRequest{})
+func learnCapabilities(ctx context.Context, capabilitiesClient remoteexecution_proto.CapabilitiesClient, instanceName string) (capabilities, error) {
+	resp, err := capabilitiesClient.GetCapabilities(ctx, &remoteexecution_proto.GetCapabilitiesRequest{
+		InstanceName: instanceName,
+	})
 	if err != nil {
 		return capabilities{}, casErr(err)
 	}
@@ -371,6 +381,7 @@ func (b *byteStreamReadCloser) nilOrEOF() error {
 type casOptions struct {
 	capabilities      capabilities
 	learnCapabilities bool
+	instanceName      string
 }
 
 type casOption func(*casOptions)
@@ -396,5 +407,11 @@ func WithSHA256(supprted bool) casOption {
 func WithSHA512(supported bool) casOption {
 	return func(opts *casOptions) {
 		opts.capabilities.DigestFunctionSHA512 = supported
+	}
+}
+
+func WithInstanceName(instanceName string) casOption {
+	return func(opts *casOptions) {
+		opts.instanceName = instanceName
 	}
 }

--- a/img_tool/pkg/cas/write.go
+++ b/img_tool/pkg/cas/write.go
@@ -33,6 +33,7 @@ func (c *CAS) WriteBlob(ctx context.Context, digest Digest, r io.Reader) error {
 
 func (c *CAS) batchUploadOne(ctx context.Context, digest Digest, data []byte) error {
 	resp, err := c.casClient.BatchUpdateBlobs(ctx, &remoteexecution_proto.BatchUpdateBlobsRequest{
+		InstanceName: c.instanceName,
 		Requests: []*remoteexecution_proto.BatchUpdateBlobsRequest_Request{{
 			Digest: digest.protoDigest(),
 			Data:   data,
@@ -58,6 +59,9 @@ func (c *CAS) streamUploadOne(ctx context.Context, digest Digest, r io.Reader) e
 	}
 
 	resourceName := fmt.Sprintf("uploads/%s/blobs/%x/%d", uuid.NewString(), digest.Hash, digest.SizeBytes)
+	if c.instanceName != "" {
+		resourceName = c.instanceName + "/" + resourceName
+	}
 	buf := make([]byte, c.capabilities.MaxBatchTotalSizeBytes)
 	var offset int64
 	var eof bool


### PR DESCRIPTION
Support configuring the REAPI instance_name via
--@rules_img//img/settings:remote_instance_name flag. The value is forwarded as IMG_REAPI_INSTANCE_NAME env var to push/load/multi_deploy rules and used in all CAS RPC requests (FindMissingBlobs, BatchReadBlobs, BatchUpdateBlobs, GetCapabilities) and as a path prefix in ByteStream Read/Write resource names, following the remote execution proto spec.