### PR TITLE
[feat] push in waves for cross-repository layer dedup

### DIFF
--- a/img_tool/cmd/deploy/BUILD.bazel
+++ b/img_tool/cmd/deploy/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "deploy",
-    srcs = ["deploy.go"],
+    srcs = [
+        "deploy.go",
+        "waves.go",
+    ],
     importpath = "github.com/bazel-contrib/rules_img/img_tool/cmd/deploy",
     visibility = ["//visibility:public"],
     deps = [

--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -157,6 +157,21 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, additionalTags []s
 	if casReader != nil {
 		vfsBuilder = vfsBuilder.WithCASReader(casReader)
 	}
+	// Partition push operations into sequential waves so that shared layers are
+	// uploaded exactly once and later waves can cross-mount them rather than
+	// re-uploading.  Hints are passed into the VFS builder so the VFS is
+	// immutable after Build(), and base-image cross-mount hints retain priority.
+	// Wave planning only has effect with two or more push operations.
+	var wg waveGroup
+	if len(pushOperations) > 1 {
+		wg = planPushWaves(pushOperations, overrideRegistry, overrideRepository)
+		if len(wg.crossMountHints) > 0 {
+			vfsBuilder = vfsBuilder.WithCrossMountHints(wg.crossMountHints)
+		}
+	} else if len(pushOperations) == 1 {
+		wg = waveGroup{waves: [][]api.IndexedPushDeployOperation{pushOperations}}
+	}
+
 	vfs, err := vfsBuilder.Build()
 	if err != nil {
 		return fmt.Errorf("building VFS: %w", err)
@@ -184,11 +199,16 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, additionalTags []s
 		uploader := uploadBuilder.Build()
 
 		g.Go(func() error {
-			tags, err := uploader.PushAll(groupCtx, pushOperations, req.Settings.PushStrategy)
-			if err != nil {
-				return err
+			// Push wave by wave.  Operations within a wave run concurrently via
+			// remote.MultiWrite; waves are sequential so that cross-mount hints
+			// from wave N are satisfied before wave N+1 begins.
+			for _, wave := range wg.waves {
+				tags, err := uploader.PushAll(groupCtx, wave, req.Settings.PushStrategy)
+				if err != nil {
+					return err
+				}
+				pushedTags = append(pushedTags, tags...)
 			}
-			pushedTags = tags
 			return nil
 		})
 	}

--- a/img_tool/cmd/deploy/waves.go
+++ b/img_tool/cmd/deploy/waves.go
@@ -1,0 +1,164 @@
+package deploy
+
+import "github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+
+// waveGroup is the result of planPushWaves.
+type waveGroup struct {
+	// waves is the ordered list of push-operation batches.  Operations within a
+	// single wave are pushed concurrently by remote.MultiWrite; waves are
+	// executed sequentially so that layers uploaded in wave N are available for
+	// cross-mounting by wave N+1 and beyond.
+	waves [][]api.IndexedPushDeployOperation
+
+	// crossMountHints maps each shared layer digest to the repository of the
+	// first operation that will upload it.  These hints are applied to the VFS
+	// before any wave runs so that later waves receive MountableLayer objects
+	// and can skip re-uploading shared blobs.
+	crossMountHints map[string]api.CrossMountSource
+}
+
+// planPushWaves partitions push operations into sequential waves so that each
+// shared layer is uploaded exactly once and all later operations can cross-mount
+// it from the first uploader's repository instead of re-uploading.
+//
+// Algorithm (single-pass greedy, O(ops × layers)):
+//
+//  1. For each operation in manifest order, find the latest wave W among all
+//     operations that have already claimed a layer this operation also needs —
+//     but only when both operations share the same registry host (cross-registry
+//     blob mounts are not guaranteed by the OCI Distribution Specification).
+//
+//  2. Assign this operation to wave W+1.
+//
+//  3. Claim ownership of any layer not yet owned by an earlier operation.
+//
+// Result:
+//   - Every shared layer is uploaded by exactly one operation (its first
+//     claimant in manifest order).
+//   - Each subsequent operation that needs the layer is placed in a later wave
+//     and can cross-mount it server-side, transferring zero bytes.
+//   - Operations that share layers with ops on different registries form no
+//     dependency and execute concurrently in wave 1.
+func planPushWaves(
+	ops []api.IndexedPushDeployOperation,
+	overrideRegistry, overrideRepository string,
+) waveGroup {
+	if len(ops) == 0 {
+		return waveGroup{}
+	}
+
+	type layerOwner struct {
+		wave     int    // 1-based wave of the first owner
+		registry string // registry of the first owner
+		repo     string // repository of the first owner
+	}
+
+	// Pre-compute total layer count for accurate map capacity hints.
+	totalLayers := 0
+	for _, op := range ops {
+		for _, manifest := range op.Manifests {
+			totalLayers += len(manifest.LayerBlobs)
+		}
+	}
+
+	owned := make(map[string]layerOwner, totalLayers) // digest → first owner
+	waveOf := make(map[int]int, len(ops))             // op.I → 1-based wave
+
+	// Count how many distinct operations on each registry reference each digest.
+	// This lets us suppress cross-mount hints for layers only shared across
+	// different registries: OCI cross-registry mounts are not standardised, and
+	// emitting a hint in that case would cause a wasted failed-mount round trip.
+	digestRegistryCount := make(map[string]map[string]int, totalLayers)
+	for _, op := range ops {
+		opReg := op.Registry
+		if overrideRegistry != "" {
+			opReg = overrideRegistry
+		}
+		seen := make(map[string]struct{})
+		for _, manifest := range op.Manifests {
+			for _, layer := range manifest.LayerBlobs {
+				if _, dup := seen[layer.Digest]; !dup {
+					seen[layer.Digest] = struct{}{}
+					if digestRegistryCount[layer.Digest] == nil {
+						digestRegistryCount[layer.Digest] = make(map[string]int, 2)
+					}
+					digestRegistryCount[layer.Digest][opReg]++
+				}
+			}
+		}
+	}
+
+	for _, op := range ops {
+		opRegistry := op.Registry
+		if overrideRegistry != "" {
+			opRegistry = overrideRegistry
+		}
+		opRepo := op.Repository
+		if overrideRepository != "" {
+			opRepo = overrideRepository
+		}
+
+		// Find the latest wave this op must wait for.
+		waitUntil := 0
+		for _, manifest := range op.Manifests {
+			for _, layer := range manifest.LayerBlobs {
+				if o, found := owned[layer.Digest]; found &&
+					o.registry == opRegistry && o.repo != opRepo {
+					// Same registry, different repository: we can cross-mount
+					// after o's wave completes.  Same-repo operations need no
+					// wave dependency because remote.MultiWrite deduplicates
+					// blobs within a repository via HEAD checks.
+					if o.wave > waitUntil {
+						waitUntil = o.wave
+					}
+				}
+			}
+		}
+
+		myWave := waitUntil + 1
+		waveOf[op.I] = myWave
+
+		// Claim ownership of any layer not yet owned.
+		for _, manifest := range op.Manifests {
+			for _, layer := range manifest.LayerBlobs {
+				if _, found := owned[layer.Digest]; !found {
+					owned[layer.Digest] = layerOwner{
+						wave:     myWave,
+						registry: opRegistry,
+						repo:     opRepo,
+					}
+				}
+			}
+		}
+	}
+
+	// Build the ordered wave slices.
+	maxWave := 0
+	for _, w := range waveOf {
+		if w > maxWave {
+			maxWave = w
+		}
+	}
+	waves := make([][]api.IndexedPushDeployOperation, maxWave)
+	for _, op := range ops {
+		idx := waveOf[op.I] - 1 // convert to 0-based index
+		waves[idx] = append(waves[idx], op)
+	}
+
+	// Emit a cross-mount hint for every layer where at least two operations on
+	// the same registry share it.  The empty Registry field follows the
+	// same-registry convention used by the existing cross-mount infrastructure.
+	// Hints for layers only shared across different registries are suppressed:
+	// the OCI Distribution Specification does not require cross-registry mount
+	// support, so the hint would only produce a wasted failed-mount round trip.
+	crossMountHints := make(map[string]api.CrossMountSource, len(owned))
+	for digest, o := range owned {
+		if digestRegistryCount[digest][o.registry] >= 2 {
+			crossMountHints[digest] = api.CrossMountSource{
+				Repository: o.repo,
+			}
+		}
+	}
+
+	return waveGroup{waves: waves, crossMountHints: crossMountHints}
+}

--- a/img_tool/cmd/deploy/waves_test.go
+++ b/img_tool/cmd/deploy/waves_test.go
@@ -1,0 +1,290 @@
+package deploy
+
+import (
+	"testing"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+)
+
+// op is a convenience constructor for test operations.
+func op(i int, registry, repo string, layerDigests ...string) api.IndexedPushDeployOperation {
+	var blobs []api.Descriptor
+	for _, d := range layerDigests {
+		blobs = append(blobs, api.Descriptor{Digest: d, Size: 1})
+	}
+	return api.IndexedPushDeployOperation{
+		I: i,
+		PushDeployOperation: api.PushDeployOperation{
+			BaseCommandOperation: api.BaseCommandOperation{
+				Manifests: []api.ManifestDeployInfo{{LayerBlobs: blobs}},
+			},
+			PushTarget: api.PushTarget{Registry: registry, Repository: repo},
+		},
+	}
+}
+
+// opIdx is like op but with multiple manifests (simulating an image index).
+func opIdx(i int, registry, repo string, perManifestDigests ...[]string) api.IndexedPushDeployOperation {
+	var manifests []api.ManifestDeployInfo
+	for _, digests := range perManifestDigests {
+		var blobs []api.Descriptor
+		for _, d := range digests {
+			blobs = append(blobs, api.Descriptor{Digest: d, Size: 1})
+		}
+		manifests = append(manifests, api.ManifestDeployInfo{LayerBlobs: blobs})
+	}
+	return api.IndexedPushDeployOperation{
+		I: i,
+		PushDeployOperation: api.PushDeployOperation{
+			BaseCommandOperation: api.BaseCommandOperation{Manifests: manifests},
+			PushTarget:           api.PushTarget{Registry: registry, Repository: repo},
+		},
+	}
+}
+
+const (
+	digestA = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	digestB = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	digestC = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	digestD = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+)
+
+// waveOps extracts, for each wave index, the set of operation indices (op.I).
+func waveOps(wg waveGroup) [][]int {
+	result := make([][]int, len(wg.waves))
+	for i, wave := range wg.waves {
+		for _, op := range wave {
+			result[i] = append(result[i], op.I)
+		}
+	}
+	return result
+}
+
+func TestPlanPushWaves(t *testing.T) {
+	tests := []struct {
+		name               string
+		ops                []api.IndexedPushDeployOperation
+		overrideRegistry   string
+		overrideRepository string
+		// wantWaves is the expected wave assignment: wantWaves[i] is the set of
+		// op.I values in wave i.  Order within a wave does not matter.
+		wantWaves [][]int
+		// wantHints is the expected cross-mount hints map.
+		wantHints map[string]api.CrossMountSource
+	}{
+		{
+			name:      "no operations",
+			ops:       nil,
+			wantWaves: nil,
+			wantHints: map[string]api.CrossMountSource{},
+		},
+		{
+			name:      "single operation, no sharing",
+			ops:       []api.IndexedPushDeployOperation{op(0, "r.io", "proj/a", digestA)},
+			wantWaves: [][]int{{0}},
+			wantHints: map[string]api.CrossMountSource{},
+		},
+		{
+			// 6 images all share one base layer → wave 1 = first image,
+			// wave 2 = remaining 5 (cross-mount base).
+			name: "6 images share one layer",
+			ops: []api.IndexedPushDeployOperation{
+				op(0, "r.io", "proj/svc-a", digestA, digestB),
+				op(1, "r.io", "proj/svc-b", digestA, digestC),
+				op(2, "r.io", "proj/svc-c", digestA, digestD),
+				op(3, "r.io", "proj/svc-d", digestA),
+				op(4, "r.io", "proj/svc-e", digestA),
+				op(5, "r.io", "proj/svc-f", digestA),
+			},
+			wantWaves: [][]int{
+				{0},             // wave 1: uploads digestA (and digestB)
+				{1, 2, 3, 4, 5}, // wave 2: cross-mount digestA from proj/svc-a
+			},
+			wantHints: map[string]api.CrossMountSource{
+				digestA: {Repository: "proj/svc-a"},
+			},
+		},
+		{
+			// Two images with entirely disjoint layers → both in wave 1, no hints.
+			name: "two images no shared layers",
+			ops: []api.IndexedPushDeployOperation{
+				op(0, "r.io", "proj/a", digestA),
+				op(1, "r.io", "proj/b", digestB),
+			},
+			wantWaves: [][]int{{0, 1}},
+			wantHints: map[string]api.CrossMountSource{},
+		},
+		{
+			// A={X,Y}, B={X,Z}, C={Y,Z}
+			// A owns X,Y (wave 1); B needs X from A (wave 2, claims Z);
+			// C needs Y from A (wave 2) and Z from B (wave 3) → wave 3.
+			name: "transitive dependency chain",
+			ops: []api.IndexedPushDeployOperation{
+				op(0, "r.io", "proj/a", digestA, digestB),
+				op(1, "r.io", "proj/b", digestA, digestC),
+				op(2, "r.io", "proj/c", digestB, digestC),
+			},
+			wantWaves: [][]int{
+				{0},
+				{1},
+				{2},
+			},
+			wantHints: map[string]api.CrossMountSource{
+				digestA: {Repository: "proj/a"},
+				digestB: {Repository: "proj/a"},
+				digestC: {Repository: "proj/b"},
+			},
+		},
+		{
+			// Different registries: no wave dependency, all in wave 1.
+			// No hint is emitted: OCI cross-registry mounts are not standardised,
+			// so a hint would only produce a wasted failed-mount round trip.
+			name:      "different registries no dependency",
+			ops: []api.IndexedPushDeployOperation{
+				op(0, "reg1.io", "proj/a", digestA),
+				op(1, "reg2.io", "proj/b", digestA),
+			},
+			wantWaves: [][]int{{0, 1}},
+			wantHints: map[string]api.CrossMountSource{},
+		},
+		{
+			// Same registry AND same repo → no dependency (mount from self),
+			// all in wave 1, but a hint is emitted (harmless self-mount attempt).
+			name: "same registry same repo",
+			ops: []api.IndexedPushDeployOperation{
+				op(0, "r.io", "proj/img", digestA),
+				op(1, "r.io", "proj/img", digestA),
+			},
+			wantWaves: [][]int{{0, 1}},
+			wantHints: map[string]api.CrossMountSource{
+				digestA: {Repository: "proj/img"},
+			},
+		},
+		{
+			// Override registry collapses two "different-registry" ops onto the
+			// same registry, creating a wave dependency.
+			name: "override registry creates dependency",
+			ops: []api.IndexedPushDeployOperation{
+				op(0, "old1.io", "proj/a", digestA),
+				op(1, "old2.io", "proj/b", digestA),
+			},
+			overrideRegistry: "new.io",
+			wantWaves: [][]int{
+				{0},
+				{1},
+			},
+			wantHints: map[string]api.CrossMountSource{
+				digestA: {Repository: "proj/a"},
+			},
+		},
+		{
+			// Image index: two manifests per op share a layer with another op.
+			name: "index with shared layer across ops",
+			ops: []api.IndexedPushDeployOperation{
+				opIdx(0, "r.io", "proj/multi", []string{digestA}, []string{digestB}),
+				op(1, "r.io", "proj/single", digestA),
+			},
+			wantWaves: [][]int{
+				{0},
+				{1},
+			},
+			wantHints: map[string]api.CrossMountSource{
+				digestA: {Repository: "proj/multi"},
+			},
+		},
+		{
+			// overrideRepository collapses two distinct repos into one → same-repo
+			// rule applies, no wave dependency, both in wave 1.
+			name: "override repository creates same-repo, no dependency",
+			ops: []api.IndexedPushDeployOperation{
+				op(0, "r.io", "proj/a", digestA),
+				op(1, "r.io", "proj/b", digestA),
+			},
+			overrideRepository: "proj/unified",
+			wantWaves:          [][]int{{0, 1}},
+			wantHints: map[string]api.CrossMountSource{
+				digestA: {Repository: "proj/unified"},
+			},
+		},
+		{
+			// A single multi-manifest op (image index) where the same digest
+			// appears in more than one of its own manifests.  The per-op dedup
+			// must ensure digestRefCount stays at 1, so no spurious hint is
+			// emitted for a layer that is not actually shared across operations.
+			name: "same digest in multiple manifests of one op, no hint",
+			ops: []api.IndexedPushDeployOperation{
+				opIdx(0, "r.io", "proj/multi", []string{digestA, digestB}, []string{digestA, digestC}),
+			},
+			wantWaves: [][]int{{0}},
+			wantHints: map[string]api.CrossMountSource{},
+		},
+		{
+			// An operation with no layers at all goes to wave 1 without error.
+			name: "op with no layers",
+			ops: []api.IndexedPushDeployOperation{
+				op(0, "r.io", "proj/scratch"),
+			},
+			wantWaves: [][]int{{0}},
+			wantHints: map[string]api.CrossMountSource{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := planPushWaves(tc.ops, tc.overrideRegistry, tc.overrideRepository)
+
+			// Check wave structure.
+			gotWaves := waveOps(got)
+			if len(gotWaves) != len(tc.wantWaves) {
+				t.Errorf("got %d waves, want %d\ngot:  %v\nwant: %v", len(gotWaves), len(tc.wantWaves), gotWaves, tc.wantWaves)
+			} else {
+				for i := range tc.wantWaves {
+					gotSet := intSet(gotWaves[i])
+					wantSet := intSet(tc.wantWaves[i])
+					for id := range wantSet {
+						if !gotSet[id] {
+							t.Errorf("wave %d: want op %d but not present; got %v", i, id, gotWaves[i])
+						}
+					}
+					for id := range gotSet {
+						if !wantSet[id] {
+							t.Errorf("wave %d: unexpected op %d; got %v, want %v", i, id, gotWaves[i], tc.wantWaves[i])
+						}
+					}
+				}
+			}
+
+			// Check hints.
+			wantHints := tc.wantHints
+			if wantHints == nil {
+				wantHints = map[string]api.CrossMountSource{}
+			}
+			if len(got.crossMountHints) != len(wantHints) {
+				t.Errorf("got %d hints, want %d\ngot:  %v\nwant: %v", len(got.crossMountHints), len(wantHints), got.crossMountHints, wantHints)
+			}
+			for digest, wantHint := range wantHints {
+				gotHint, ok := got.crossMountHints[digest]
+				if !ok {
+					t.Errorf("missing hint for %s", digest)
+					continue
+				}
+				if gotHint != wantHint {
+					t.Errorf("digest %s: got hint %+v, want %+v", digest, gotHint, wantHint)
+				}
+			}
+			for digest := range got.crossMountHints {
+				if _, ok := wantHints[digest]; !ok {
+					t.Errorf("unexpected hint for %s: %+v", digest, got.crossMountHints[digest])
+				}
+			}
+		})
+	}
+}
+
+func intSet(ids []int) map[int]bool {
+	s := make(map[int]bool, len(ids))
+	for _, id := range ids {
+		s[id] = true
+	}
+	return s
+}

--- a/img_tool/pkg/deployvfs/deployvfs.go
+++ b/img_tool/pkg/deployvfs/deployvfs.go
@@ -262,6 +262,7 @@ type vfsBuilder struct {
 	containerRegistryOptions   []remote.Option
 	runfilesRootSymlinksPrefix string
 	layerHints                 map[string][]string // digest -> []paths
+	extraCrossMountHints       map[string]api.CrossMountSource
 	stats                      *Stats
 }
 
@@ -287,6 +288,15 @@ func (b *vfsBuilder) WithRunfilesRootSymlinksPrefix(prefix string) *vfsBuilder {
 	return b
 }
 
+// WithCrossMountHints supplies additional cross-mount hints to merge into the
+// VFS at build time.  Hints already derived from the deploy manifest (i.e.
+// base-image cross-mount hints populated during ingest) take priority and are
+// not overwritten; see Build() for details.
+func (b *vfsBuilder) WithCrossMountHints(hints map[string]api.CrossMountSource) *vfsBuilder {
+	b.extraCrossMountHints = hints
+	return b
+}
+
 // rlocation wraps runfiles.Rlocation and adds the runfiles root symlinks prefix if configured.
 func (b *vfsBuilder) rlocation(runfilesPath string) (string, error) {
 	fullPath := runfilesPath
@@ -307,6 +317,15 @@ func (b *vfsBuilder) Build() (*VFS, error) {
 	blobs, manifests, crossMountHints, err := b.ingest()
 	if err != nil {
 		return nil, err
+	}
+	// Merge intra-deploy cross-mount hints (e.g. from planPushWaves) after the
+	// base-image hints from ingest.  Base-image hints take priority because they
+	// originate from the image's own metadata and may point to a specific
+	// external registry — at least as authoritative as an intra-deploy hint.
+	for digest, hint := range b.extraCrossMountHints {
+		if _, exists := crossMountHints[digest]; !exists {
+			crossMountHints[digest] = hint
+		}
 	}
 	return &VFS{
 		dm:              b.dm,

--- a/img_tool/pkg/deployvfs/deployvfs_test.go
+++ b/img_tool/pkg/deployvfs/deployvfs_test.go
@@ -1,0 +1,83 @@
+package deployvfs
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+)
+
+func TestWithCrossMountHints(t *testing.T) {
+	const (
+		digestA = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		digestB = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		digestC = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	)
+
+	t.Run("adds hints for digests without existing hints", func(t *testing.T) {
+		// Empty manifest produces no base-image hints from ingest; extras fill in.
+		vfs, err := Builder(api.DeployManifest{}).
+			WithCrossMountHints(map[string]api.CrossMountSource{
+				digestA: {Repository: "proj/frontend"},
+				digestB: {Registry: "other.io", Repository: "proj/shared"},
+			}).Build()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := vfs.crossMountHints[digestA], (api.CrossMountSource{Repository: "proj/frontend"}); got != want {
+			t.Errorf("digestA: got %+v, want %+v", got, want)
+		}
+		if got, want := vfs.crossMountHints[digestB], (api.CrossMountSource{Registry: "other.io", Repository: "proj/shared"}); got != want {
+			t.Errorf("digestB: got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("does not overwrite existing hints", func(t *testing.T) {
+		// Build a manifest whose operation carries a CrossMountHint for digestA.
+		// Using "cas_registry" strategy avoids needing real files: layerBlob()
+		// returns a stub without touching the filesystem.
+		opJSON, err := json.Marshal(api.BaseCommandOperation{
+			Command:  "push",
+			RootKind: "manifest",
+			Root:     api.Descriptor{Digest: "sha256:" + "0000000000000000000000000000000000000000000000000000000000000000"},
+			Manifests: []api.ManifestDeployInfo{{
+				Descriptor: api.Descriptor{Digest: "sha256:" + "1111111111111111111111111111111111111111111111111111111111111111"},
+				Config:     api.Descriptor{Digest: "sha256:" + "2222222222222222222222222222222222222222222222222222222222222222"},
+				LayerBlobs: []api.Descriptor{{Digest: digestA}},
+			}},
+			CrossMountHint: &api.CrossMountSource{Registry: "base.io", Repository: "library/ubuntu"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		dm := api.DeployManifest{
+			Operations: []json.RawMessage{opJSON},
+			Settings:   api.DeploySettings{PushStrategy: "cas_registry"},
+		}
+		vfs, err := Builder(dm).
+			WithCrossMountHints(map[string]api.CrossMountSource{
+				digestA: {Repository: "proj/frontend"}, // must not overwrite base.io hint
+				digestC: {Repository: "proj/backend"},  // must be added
+			}).Build()
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantA := api.CrossMountSource{Registry: "base.io", Repository: "library/ubuntu"}
+		if got := vfs.crossMountHints[digestA]; got != wantA {
+			t.Errorf("digestA: base-image hint was overwritten; got %+v, want %+v", got, wantA)
+		}
+		if got, want := vfs.crossMountHints[digestC], (api.CrossMountSource{Repository: "proj/backend"}); got != want {
+			t.Errorf("digestC: got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("is a no-op when hints map is nil", func(t *testing.T) {
+		vfs, err := Builder(api.DeployManifest{}).WithCrossMountHints(nil).Build()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(vfs.crossMountHints) != 0 {
+			t.Errorf("expected empty crossMountHints after nil, got %v", vfs.crossMountHints)
+		}
+	})
+}


### PR DESCRIPTION
## multi_deploy: deduplicate shared layers via wave-based push scheduling

When multiple push targets in a `multi_deploy` share layers — for example, when several service images are built from the same intermediate layer — the deploy tool currently re-uploads those layers to every target repository independently.

### Problem

The OCI cross-mount mechanism (`POST /v2/{repo}/blobs/uploads/?mount={digest}&from={source}`) lets a registry copy a blob server-side from another repository on the same registry, transferring zero bytes from the client. go-containerregistry supports this via `remote.MountableLayer`, and the VFS already wraps base-image layers with mount hints derived from the pull source.

However, cross-mounting only works once the source blob is fully present in the registry. `remote.MultiWrite` processes push targets concurrently: when pushing to `reg/svc-a` and `reg/svc-b` at the same time, both issue `HEAD /v2/{repo}/blobs/{digest}` for the shared layer, both receive 404, and both fall back to a full upload before either has finished. The API has no way to express "upload this layer once and cross-mount it everywhere else" within a single call because the mount hint is advisory — if the source is not yet present the registry rejects it and the client must upload anyway.

### Solution

Introduce a **wave-based push scheduler** (`img_tool/cmd/deploy/waves.go`) that enforces the required ordering outside the library:

1. **Partition** push operations into sequential waves using a greedy single-pass algorithm. An operation is assigned to wave W+1 if any same-registry operation already in wave ≤W has claimed one of its shared layers.
2. **Wave 1** uploads each shared layer exactly once (the first claimant in manifest order). `remote.MultiWrite` still runs concurrently within the wave.
3. **Wave 2+** operations start only after wave 1 completes. By then the shared layers are present in the registry, so the `MountableLayer` hints succeed and the client transfers zero bytes.

Same-registry, same-repository operations need no wave dependency (the registry deduplicates within a repository via HEAD checks). Operations on different registries form no dependency either, since cross-registry mounting is not required by the OCI Distribution Specification.

### Changes

- **`img_tool/cmd/deploy/waves.go`** — `waveGroup` type and `planPushWaves` function
- **`img_tool/cmd/deploy/deploy.go`** — wave-based push loop; planning runs before `vfsBuilder.Build()` so hints are passed in via the builder rather than as a post-build mutation
- **`img_tool/pkg/deployvfs/deployvfs.go`** — `vfsBuilder.WithCrossMountHints()` method; hints are merged in `Build()` with base-image hints retaining priority
- **`img_tool/cmd/deploy/waves_test.go`** — 13 cases covering the wave assignment algorithm
- **`img_tool/pkg/deployvfs/deployvfs_test.go`** — 3 cases for `WithCrossMountHints` exercised through a real `Build()` call

No Bazel rule changes required.