### PR TITLE
[feat] Add configurable push parallelism

### DIFF
--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -32,3 +32,8 @@ build --experimental_rule_extension_api
 # enable protobuf toolchain resolution
 # docs: https://bazel.build/reference/command-line-reference#common_options-flag--incompatible_enable_proto_toolchain_resolution
 common --incompatible_enable_proto_toolchain_resolution
+
+# Point tools such as coursier (used in rules_jvm_external) to Bazel's downloaded JDK
+# suggested in https://github.com/bazelbuild/rules_jvm_external/issues/445
+common --repo_env=JAVA_HOME=../bazel_tools/jdk
+common --action_env=JAVA_HOME=../bazel_tools/jdk

--- a/docs/push-strategies.md
+++ b/docs/push-strategies.md
@@ -226,5 +226,25 @@ bazel build //your:image_target
 | Simple deployments | Eager | No infrastructure requirements |
 | Air-gapped environments | Eager | Works without external dependencies |
 
+## Tuning Push Parallelism
+
+By default, `rules_img` uses 4 parallel threads for push operations (the go-containerregistry default). You can tune this with the `push_jobs` setting or the `--jobs` deploy flag.
+
+### Via Bazel setting (applies to all push targets)
+
+```bash
+# Use 8 parallel push threads
+common --@rules_img//img/settings:push_jobs=8
+```
+
+### Via deploy CLI flag (one-off override)
+
+```bash
+# Override for a single run
+bazel run //your:push_target -- --jobs=8
+```
+
+The CLI `--jobs` flag takes precedence over the `push_jobs` setting. A value of `0` (the default) means "use the setting or fall back to the go-containerregistry default".
+
 
 [reapi-spec-cas-lifetime]: https://github.com/bazelbuild/remote-apis/blob/e95641649b5b4d3c582c89daabfaabeb8189dd77/build/bazel/remote/execution/v2/remote_execution.proto#L305-L308

--- a/e2e/generic/.bazelrc
+++ b/e2e/generic/.bazelrc
@@ -1,8 +1,3 @@
 import %workspace%/.bazelrc.common
 
 try-import %workspace%/.bazelrc.user
-
-# Point tools such as coursier (used in rules_jvm_external) to Bazel's downloaded JDK
-# suggested in https://github.com/bazelbuild/rules_jvm_external/issues/445
-common --repo_env=JAVA_HOME=../bazel_tools/jdk
-common --action_env=JAVA_HOME=../bazel_tools/jdk

--- a/e2e/generic/.bazelrc
+++ b/e2e/generic/.bazelrc
@@ -1,3 +1,8 @@
 import %workspace%/.bazelrc.common
 
 try-import %workspace%/.bazelrc.user
+
+# Point tools such as coursier (used in rules_jvm_external) to Bazel's downloaded JDK
+# suggested in https://github.com/bazelbuild/rules_jvm_external/issues/445
+common --repo_env=JAVA_HOME=../bazel_tools/jdk
+common --action_env=JAVA_HOME=../bazel_tools/jdk

--- a/img/private/BUILD.bazel
+++ b/img/private/BUILD.bazel
@@ -303,6 +303,7 @@ bzl_library(
         "//img/private/providers:deploy_info",
         "//img/private/providers:load_config_info",
         "//img/private/providers:push_config_info",
+        "//img/private/providers:push_settings_info",
     ],
 )
 

--- a/img/private/multi_deploy.bzl
+++ b/img/private/multi_deploy.bzl
@@ -51,6 +51,9 @@ def _compute_multi_deploy_metadata(*, ctx):
     args.add("deploy-merge")
     args.add("--push-strategy", _multi_deploy_strategy(ctx, "push"))
     args.add("--load-strategy", _multi_deploy_strategy(ctx, "load"))
+    push_jobs = ctx.attr._push_settings[PushSettingsInfo].push_jobs
+    if push_jobs > 0:
+        args.add("--push-jobs", push_jobs)
 
     # Add layer hints inputs and output if any exist
     layer_hints_out = None

--- a/img/private/providers/push_settings_info.bzl
+++ b/img/private/providers/push_settings_info.bzl
@@ -10,6 +10,7 @@ FIELDS = dict(
     remote_instance_name = "Remote instance name for REAPI CAS requests. Set as instance_name field in CAS RPCs and as path prefix in ByteStream resource names. Uses $IMG_REAPI_INSTANCE_NAME env var if not set.",
     credential_helper = "Credential helper to use for the push rule. This can be the same as Bazel's credential helper. Uses $IMG_CREDENTIAL_HELPER env var or tools/credential-helper if not set.",
     cross_mount = "Cross-mount configuration. Either 'same_registry', 'cross_registry' or 'disabled'.",
+    push_jobs = "Number of parallel threads for push operations. 0 means use the go-containerregistry default (currently 4).",
 )
 
 PushSettingsInfo = provider(

--- a/img/private/push_metadata.bzl
+++ b/img/private/push_metadata.bzl
@@ -187,7 +187,7 @@ def expand_manifest_tags_for_child(
         stamp_settings_override = stamp_settings_override,
     )
 
-def merge_deploy_manifests(ctx, *, deploy_infos, push_strategy = "auto", load_strategy = "auto"):
+def merge_deploy_manifests(ctx, *, deploy_infos, push_strategy = "auto", load_strategy = "auto", push_jobs = 0):
     """Merge multiple deploy manifests using the deploy-merge tool.
 
     Args:
@@ -195,6 +195,7 @@ def merge_deploy_manifests(ctx, *, deploy_infos, push_strategy = "auto", load_st
         deploy_infos: List of struct(metadata=File, layer_hints=File-or-None).
         push_strategy: Push strategy string for the merge.
         load_strategy: Load strategy string for the merge.
+        push_jobs: Number of parallel push threads (0 = use default).
 
     Returns:
         Tuple of (merged_metadata_file, merged_layer_hints_file).
@@ -204,6 +205,8 @@ def merge_deploy_manifests(ctx, *, deploy_infos, push_strategy = "auto", load_st
     args.add("deploy-merge")
     args.add("--push-strategy", push_strategy)
     args.add("--load-strategy", load_strategy)
+    if push_jobs > 0:
+        args.add("--push-jobs", push_jobs)
 
     layer_hints_files = []
     for info in deploy_infos:
@@ -469,6 +472,7 @@ def process_deploy_specs(
         deploy_infos = deploy_infos,
         push_strategy = first_push_strategy,
         load_strategy = first_load_strategy,
+        push_jobs = ctx.attr._push_settings[PushSettingsInfo].push_jobs,
     )
     return DeployInfo(
         image = image_info,

--- a/img/private/push_metadata.bzl
+++ b/img/private/push_metadata.bzl
@@ -10,6 +10,7 @@ load("//img/private/common:build.bzl", "TOOLCHAIN")
 load("//img/private/providers:deploy_info.bzl", "DeployInfo")
 load("//img/private/providers:load_config_info.bzl", "LoadConfigInfo")
 load("//img/private/providers:push_config_info.bzl", "PushConfigInfo")
+load("//img/private/providers:push_settings_info.bzl", "PushSettingsInfo")
 
 def compute_push_metadata(
         ctx,

--- a/img/private/settings/settings.bzl
+++ b/img/private/settings/settings.bzl
@@ -9,6 +9,7 @@ def _push_settings_impl(ctx):
     remote_instance_name = ctx.attr._remote_instance_name[BuildSettingInfo].value
     credential_helper = ctx.attr._credential_helper[BuildSettingInfo].value
     cross_mount = ctx.attr._cross_mount[BuildSettingInfo].value
+    push_jobs = ctx.attr._push_jobs[BuildSettingInfo].value
 
     return [PushSettingsInfo(
         strategy = strategy,
@@ -16,6 +17,7 @@ def _push_settings_impl(ctx):
         remote_instance_name = remote_instance_name,
         credential_helper = credential_helper,
         cross_mount = cross_mount,
+        push_jobs = push_jobs,
     )]
 
 push_settings = rule(
@@ -39,6 +41,10 @@ push_settings = rule(
         ),
         "_cross_mount": attr.label(
             default = Label("//img/settings:cross_mount"),
+            providers = [BuildSettingInfo],
+        ),
+        "_push_jobs": attr.label(
+            default = Label("//img/settings:push_jobs"),
             providers = [BuildSettingInfo],
         ),
     },

--- a/img/settings/BUILD.bazel
+++ b/img/settings/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "int_flag", "string_flag")
 
 string_flag(
     name = "compress",
@@ -86,6 +86,12 @@ string_flag(
 string_flag(
     name = "docker_config_path",
     build_setting_default = "",
+    visibility = ["//img/private:__subpackages__"],
+)
+
+int_flag(
+    name = "push_jobs",
+    build_setting_default = 0,
     visibility = ["//img/private:__subpackages__"],
 )
 

--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -37,6 +37,7 @@ func DeployProcess(ctx context.Context, args []string) {
 	var overrideRegistry string
 	var overrideRepository string
 	var platforms string
+	var pushJobs int
 
 	flagSet := flag.NewFlagSet("deploy", flag.ContinueOnError)
 	flagSet.StringVar(&requestFile, "request-file", "", "Deploy manifest JSON request file")
@@ -46,6 +47,7 @@ func DeployProcess(ctx context.Context, args []string) {
 	flagSet.StringVar(&overrideRegistry, "registry", "", "Override registry to push to")
 	flagSet.StringVar(&overrideRepository, "repository", "", "Override repository to push to")
 	flagSet.StringVar(&platforms, "platform", "", "Comma-separated list of platforms to load (e.g., linux/amd64). If not set, loads the platform closest to the host (or the single available platform). Use 'all' to load the full multi-platform index. Doesn't affect push, only load.")
+	flagSet.IntVar(&pushJobs, "jobs", 0, "Number of parallel push threads (overrides push_jobs setting; 0 means use setting or default)")
 
 	if err := flagSet.Parse(args); err != nil {
 		flagSet.Usage()
@@ -79,13 +81,13 @@ func DeployProcess(ctx context.Context, args []string) {
 		}
 	}
 
-	if err := DeployWithExtras(ctx, rawRequest, []string(additionalTags), overrideRegistry, overrideRepository, platformList, runfilesRootSymlinksPrefix); err != nil {
+	if err := DeployWithExtras(ctx, rawRequest, []string(additionalTags), overrideRegistry, overrideRepository, platformList, runfilesRootSymlinksPrefix, pushJobs); err != nil {
 		fmt.Fprintf(os.Stderr, "Error during deploy: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func DeployWithExtras(ctx context.Context, rawRequest []byte, additionalTags []string, overrideRegistry, overrideRepository string, platformList []string, runfilesRootSymlinksPrefix string) error {
+func DeployWithExtras(ctx context.Context, rawRequest []byte, additionalTags []string, overrideRegistry, overrideRepository string, platformList []string, runfilesRootSymlinksPrefix string, pushJobsOverride int) error {
 	var req api.DeployManifest
 	decoder := json.NewDecoder(bytes.NewReader(rawRequest))
 	decoder.DisallowUnknownFields()
@@ -179,6 +181,14 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, additionalTags []s
 		}
 		if len(additionalTags) > 0 {
 			uploadBuilder = uploadBuilder.WithExtraTags(additionalTags)
+		}
+		// CLI flag takes precedence over settings value; 0 means "use default"
+		pushJobs := pushJobsOverride
+		if pushJobs == 0 {
+			pushJobs = req.Settings.PushJobs
+		}
+		if pushJobs > 0 {
+			uploadBuilder = uploadBuilder.WithJobs(pushJobs)
 		}
 		uploadBuilder.WithRemoteOptions(registry.WithAuthFromMultiKeychain())
 		uploader := uploadBuilder.Build()

--- a/img_tool/cmd/deploymetadata/merge.go
+++ b/img_tool/cmd/deploymetadata/merge.go
@@ -13,6 +13,7 @@ import (
 var (
 	pushStrategy              string
 	loadStrategy              string
+	pushJobs                  int
 	mergeLayerHintsInputPaths []string
 	mergeLayerHintsOutputPath string
 )
@@ -34,6 +35,7 @@ func DeployMergeProcess(ctx context.Context, args []string) {
 	}
 	flagSet.StringVar(&pushStrategy, "push-strategy", "lazy", `Push strategy to use for all push operations. One of "eager", "lazy", "cas_registry", or "bes".`)
 	flagSet.StringVar(&loadStrategy, "load-strategy", "lazy", `Load strategy to use for all load operations. One of "eager", "lazy".`)
+	flagSet.IntVar(&pushJobs, "push-jobs", 0, `Number of parallel push threads. 0 means use the default.`)
 	flagSet.Func("layer-hints-input", `(Optional) path to layer hints file to merge. Can be specified multiple times.`, func(value string) error {
 		mergeLayerHintsInputPaths = append(mergeLayerHintsInputPaths, value)
 		return nil
@@ -119,6 +121,7 @@ func MergeDeployManifests(ctx context.Context, inputPaths []string, outputPath s
 		Settings: api.DeploySettings{
 			PushStrategy: pushStrategy,
 			LoadStrategy: loadStrategy,
+			PushJobs:     pushJobs,
 		},
 	}
 

--- a/img_tool/pkg/api/deploy.go
+++ b/img_tool/pkg/api/deploy.go
@@ -103,6 +103,7 @@ func (dm *DeployManifest) LoadOperations() ([]IndexedLoadDeployOperation, error)
 type DeploySettings struct {
 	PushStrategy string `json:"push_strategy,omitempty"`
 	LoadStrategy string `json:"load_strategy,omitempty"`
+	PushJobs     int    `json:"push_jobs,omitempty"`
 }
 
 type BaseCommandOperation struct {

--- a/img_tool/pkg/push/push.go
+++ b/img_tool/pkg/push/push.go
@@ -26,6 +26,7 @@ type builder struct {
 	overrideRepository string
 	extraTags          []string
 	remoteOptions      []remote.Option
+	jobs               int
 }
 
 func NewBuilder(vfs vfs) *builder {
@@ -57,6 +58,11 @@ func (b *builder) WithRemoteOptions(opts ...remote.Option) *builder {
 	return b
 }
 
+func (b *builder) WithJobs(jobs int) *builder {
+	b.jobs = jobs
+	return b
+}
+
 func (b *builder) Build() *uploader {
 	return &uploader{
 		blobcacheClient:    b.blobcacheClient,
@@ -65,6 +71,7 @@ func (b *builder) Build() *uploader {
 		overrideRepository: b.overrideRepository,
 		extraTags:          b.extraTags,
 		remoteOptions:      b.remoteOptions,
+		jobs:               b.jobs,
 	}
 }
 
@@ -75,6 +82,7 @@ type uploader struct {
 	overrideRepository string
 	extraTags          []string
 	remoteOptions      []remote.Option
+	jobs               int
 }
 
 func (u *uploader) PushAll(ctx context.Context, ops []api.IndexedPushDeployOperation, strategy string) (tags []string, retErr error) {
@@ -134,6 +142,9 @@ func (u *uploader) PushAll(ctx context.Context, ops []api.IndexedPushDeployOpera
 
 	// push all collected tags in parallel
 	opts := append(u.remoteOptions, remote.WithProgress(progCh))
+	if u.jobs > 0 {
+		opts = append(opts, remote.WithJobs(u.jobs))
+	}
 	return allTags, remote.MultiWrite(todo, opts...)
 }
 


### PR DESCRIPTION
By default, `go-containerregistry`'s `remote.MultiWrite` uses 4 parallel threads when uploading blobs to a registry. This PR exposes that setting so users can tune it for their environment — either globally via a Bazel flag or per-invocation via the deploy CLI.

### Motivation

Images with many layers can saturate a single upload thread, leaving registry bandwidth underutilised. Conversely, CI environments behind rate-limited registries may need fewer threads. Neither was previously configurable without patching the tool.

### Usage

**Bazel flag (global default for all push targets):**
```bash
# .bazelrc
common --@rules_img//img/settings:push_jobs=8
```

**CLI flag (single-run override):**
```bash
bazel run //my:push_target -- --jobs=8
```

The `--jobs` CLI flag takes precedence over the Bazel setting. A value of `0` (the default for both) falls through to the go-containerregistry default of 4 threads.
