### PR TITLE
Fix migration docs for CST with docker driver

### DIFF
--- a/docs/migration-from-rules_oci.md
+++ b/docs/migration-from-rules_oci.md
@@ -705,18 +705,11 @@ container_structure_test(
 
 ```starlark
 load("@container_structure_test//:defs.bzl", "container_structure_test")
-load("@rules_img//img:load.bzl", "image_load")
-
-image_load(
-    name = "load_image",
-    image = ":app_image",
-    tag = "test:latest",
-)
 
 container_structure_test(
     name = "structure_test_docker",
     driver = "docker",
-    image = ":load_image",
+    image = ":app_image",
     configs = ["test_config.yaml"],
 )
 ```


### PR DESCRIPTION
Fix the migration docs by updating the container_structure_test with docker driver example.

Docs currently specify to use an image_load target for the `image =` kwarg, but this should actually be the actual image target.

This matches what is seen in the e2e tests: https://github.com/bazel-contrib/rules_img/blob/main/e2e/generic/integrationtest/container_structure_test/BUILD.bazel#L7