### PR TITLE
refactor: use sparse OCI layout for deploy root symlinks

### DIFF
--- a/img/private/BUILD.bazel
+++ b/img/private/BUILD.bazel
@@ -13,6 +13,8 @@ bzl_library(
     deps = [
         ":manifest_media_type",
         "//img:providers",
+        "//img/private/common:build",
+        "//img/private/common:sparse_oci_layout",
         "//img/private/common:transitions",
     ],
 )

--- a/img/private/common/BUILD.bazel
+++ b/img/private/common/BUILD.bazel
@@ -81,6 +81,13 @@ bzl_library(
 )
 
 bzl_library(
+    name = "sparse_oci_layout",
+    srcs = ["sparse_oci_layout.bzl"],
+    visibility = ["//img:__subpackages__"],
+    deps = [":build"],
+)
+
+bzl_library(
     name = "tar_layer",
     srcs = ["tar_layer.bzl"],
     visibility = ["//img:__subpackages__"],

--- a/img/private/common/sparse_oci_layout.bzl
+++ b/img/private/common/sparse_oci_layout.bzl
@@ -1,0 +1,84 @@
+"""Shared sparse OCI layout builder functions."""
+
+load(":build.bzl", "TOOLCHAIN")
+
+def build_sparse_oci_layout_for_manifest(ctx, manifest_out, config_out, layers, suffix = ""):
+    """Build a sparse OCI layout tree artifact for a single-platform manifest.
+
+    Args:
+        ctx: Rule context.
+        manifest_out: The manifest file.
+        config_out: The config file.
+        layers: List of SingleLayerInfo providers.
+        suffix: Optional suffix for the output directory name (to avoid conflicts).
+
+    Returns:
+        Tree artifact containing the sparse OCI layout.
+    """
+    output = ctx.actions.declare_directory(ctx.label.name + "_sparse_oci_layout" + suffix)
+
+    args = ctx.actions.args()
+    args.add("sparse-oci-layout")
+    args.add("--format", "directory")
+    args.add("--manifest", manifest_out.path)
+    args.add("--config", config_out.path)
+    args.add("--output", output.path)
+
+    inputs = [manifest_out, config_out]
+
+    for layer in layers:
+        args.add("--layer", layer.metadata.path)
+        inputs.append(layer.metadata)
+
+    img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
+    ctx.actions.run(
+        inputs = inputs,
+        outputs = [output],
+        executable = img_toolchain_info.tool_exe,
+        arguments = [args],
+        mnemonic = "SparseOCILayout",
+    )
+
+    return output
+
+def build_sparse_oci_layout_for_index(ctx, index_out, manifests):
+    """Build a sparse OCI layout tree artifact for a multi-platform image index.
+
+    Args:
+        ctx: Rule context.
+        index_out: The index file.
+        manifests: List of ImageManifestInfo providers.
+
+    Returns:
+        Tree artifact containing the sparse OCI layout.
+    """
+    output = ctx.actions.declare_directory(ctx.label.name + "_sparse_oci_layout")
+
+    args = ctx.actions.args()
+    args.add("sparse-oci-layout")
+    args.add("--format", "directory")
+    args.add("--index", index_out.path)
+    args.add("--output", output.path)
+
+    inputs = [index_out]
+
+    for manifest in manifests:
+        args.add("--manifest-path", manifest.manifest.path)
+        args.add("--config-path", manifest.config.path)
+        inputs.append(manifest.manifest)
+        inputs.append(manifest.config)
+
+        for layer in manifest.layers:
+            args.add("--layer", layer.metadata.path)
+            inputs.append(layer.metadata)
+
+    img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
+    ctx.actions.run(
+        inputs = inputs,
+        outputs = [output],
+        executable = img_toolchain_info.tool_exe,
+        arguments = [args],
+        mnemonic = "SparseOCIIndexLayout",
+    )
+
+    return output

--- a/img/private/conversion/BUILD.bazel
+++ b/img/private/conversion/BUILD.bazel
@@ -7,6 +7,7 @@ bzl_library(
     deps = [
         "//img/private/common:build",
         "//img/private/common:media_types",
+        "//img/private/common:sparse_oci_layout",
         "//img/private/providers:manifest_info",
         "//img/private/providers:single_layer_info",
     ],
@@ -19,6 +20,7 @@ bzl_library(
     deps = [
         "//img/private/common:build",
         "//img/private/common:media_types",
+        "//img/private/common:sparse_oci_layout",
         "//img/private/providers:index_info",
         "//img/private/providers:manifest_info",
         "//img/private/providers:single_layer_info",

--- a/img/private/conversion/index_from_oci_layout.bzl
+++ b/img/private/conversion/index_from_oci_layout.bzl
@@ -2,6 +2,7 @@
 
 load("//img/private/common:build.bzl", "TOOLCHAIN", "TOOLCHAINS")
 load("//img/private/common:media_types.bzl", "GZIP_LAYER", "LAYER_TYPES", "UNCOMPRESSED_LAYER", "ZSTD_LAYER")
+load("//img/private/common:sparse_oci_layout.bzl", "build_sparse_oci_layout_for_index", "build_sparse_oci_layout_for_manifest")
 load("//img/private/providers:index_info.bzl", "ImageIndexInfo")
 load("//img/private/providers:manifest_info.bzl", "ImageManifestInfo")
 load("//img/private/providers:single_layer_info.bzl", "SingleLayerInfo")
@@ -156,6 +157,7 @@ def _image_index_from_oci_layout(ctx):
     manifest_infos = []
     for idx_str in sorted(manifest_platforms.keys()):
         info = manifest_outputs[idx_str]
+        sparse_layout = build_sparse_oci_layout_for_manifest(ctx, info["manifest"], info["config"], all_layer_infos[idx_str], suffix = "_" + idx_str)
         manifest_infos.append(ImageManifestInfo(
             descriptor = info["descriptor"],
             manifest = info["manifest"],
@@ -166,7 +168,10 @@ def _image_index_from_oci_layout(ctx):
             variant = info["variant"],
             layers = all_layer_infos[idx_str],
             missing_blobs = [],
+            sparse_oci_layout = sparse_layout,
         ))
+
+    index_sparse_layout = build_sparse_oci_layout_for_index(ctx, output_index, manifest_infos)
 
     return [
         DefaultInfo(files = depset([output_index])),
@@ -178,6 +183,7 @@ def _image_index_from_oci_layout(ctx):
             descriptor = output_descriptor,
             index = output_index,
             manifests = manifest_infos,
+            sparse_oci_layout = index_sparse_layout,
         ),
     ]
 

--- a/img/private/conversion/manifest_from_oci_layout.bzl
+++ b/img/private/conversion/manifest_from_oci_layout.bzl
@@ -2,6 +2,7 @@
 
 load("//img/private/common:build.bzl", "TOOLCHAIN", "TOOLCHAINS")
 load("//img/private/common:media_types.bzl", "GZIP_LAYER", "LAYER_TYPES", "UNCOMPRESSED_LAYER", "ZSTD_LAYER")
+load("//img/private/common:sparse_oci_layout.bzl", "build_sparse_oci_layout_for_manifest")
 load("//img/private/providers:manifest_info.bzl", "ImageManifestInfo")
 load("//img/private/providers:single_layer_info.bzl", "SingleLayerInfo")
 
@@ -97,6 +98,8 @@ def _image_manifest_from_oci_layout(ctx):
         progress_message = "Converting OCI layout at {} to image manifest {}".format(src_dir.path, output_manifest.path),
     )
 
+    sparse_layout = build_sparse_oci_layout_for_manifest(ctx, output_manifest, output_config, layer_infos)
+
     return [
         DefaultInfo(files = depset([output_manifest, output_config])),
         OutputGroupInfo(
@@ -114,6 +117,7 @@ def _image_manifest_from_oci_layout(ctx):
             variant = variant,
             layers = layer_infos,
             missing_blobs = [],
+            sparse_oci_layout = sparse_layout,
         ),
     ]
 

--- a/img/private/import.bzl
+++ b/img/private/import.bzl
@@ -1,5 +1,7 @@
 """rule to import OCI images from a local directory."""
 
+load("//img/private/common:build.bzl", "TOOLCHAIN")
+load("//img/private/common:sparse_oci_layout.bzl", "build_sparse_oci_layout_for_index", "build_sparse_oci_layout_for_manifest")
 load("//img/private/common:transitions.bzl", "reset_platform_transition")
 load("//img/private/providers:index_info.bzl", "ImageIndexInfo")
 load("//img/private/providers:manifest_info.bzl", "ImageManifestInfo")
@@ -118,16 +120,26 @@ def _build_manifest_info(ctx, digest, descriptor = None, index_position = None, 
         if layer_info.blob == None:
             missing_blobs.append(layer["digest"].removeprefix("sha256:"))
         layers.append(layer_info)
+
+    manifest_file = _digest_to_file(ctx, digest)
+    config_file = _digest_to_file(ctx, config_digest)
+
+    if index_position == None:
+        sparse_layout = build_sparse_oci_layout_for_manifest(ctx, manifest_file, config_file, layers)
+    else:
+        sparse_layout = build_sparse_oci_layout_for_manifest(ctx, manifest_file, config_file, layers, suffix = "_" + str(index_position))
+
     return ImageManifestInfo(
         descriptor = _write_manifest_descriptor(ctx, digest, manifest, platform, descriptor, index_position),
-        manifest = _digest_to_file(ctx, digest),
-        config = _digest_to_file(ctx, config_digest),
+        manifest = manifest_file,
+        config = config_file,
         structured_config = config,
         architecture = platform.get("architecture", "unknown"),
         os = platform.get("os", "unknown"),
         variant = variant,
         layers = layers,
         missing_blobs = missing_blobs,
+        sparse_oci_layout = sparse_layout,
     )
 
 def _image_import_impl(ctx):
@@ -161,10 +173,13 @@ def _image_import_impl(ctx):
             digest = ctx.attr.digest,
         )
         ctx.actions.write(index_descriptor_file, json.encode(index_descriptor))
+        index_file = _digest_to_file(ctx, ctx.attr.digest)
+        sparse_layout = build_sparse_oci_layout_for_index(ctx, index_file, manifests)
         providers.append(ImageIndexInfo(
             descriptor = index_descriptor_file,
-            index = _digest_to_file(ctx, ctx.attr.digest),
+            index = index_file,
             manifests = manifests,
+            sparse_oci_layout = sparse_layout,
         ))
     return providers
 
@@ -187,6 +202,7 @@ image_import = rule(
         ),
     },
     cfg = reset_platform_transition,
+    toolchains = [TOOLCHAIN],
 )
 
 MEDIA_TYPE_INDEX = "application/vnd.oci.image.index.v1+json"

--- a/img/private/index.bzl
+++ b/img/private/index.bzl
@@ -205,10 +205,12 @@ def _image_index_impl(ctx):
         config_json = config_json,
         subject_descriptor = subject_descriptor_file,
     )
+    sparse_layout = _build_sparse_oci_layout(ctx, "directory", index_out, manifest_infos)
     index_info_provider = ImageIndexInfo(
         descriptor = descriptor_out,
         index = index_out,
         manifests = manifest_infos,
+        sparse_oci_layout = sparse_layout,
     )
     providers = [
         DefaultInfo(files = depset([index_out])),
@@ -217,7 +219,7 @@ def _image_index_impl(ctx):
             digest = depset([digest_out]),
             oci_layout = depset([_build_oci_layout(ctx, "directory", index_out, manifest_infos)]),
             oci_tarball = depset([_build_oci_layout(ctx, "tar", index_out, manifest_infos)]),
-            sparse_oci_layout = depset([_build_sparse_oci_layout(ctx, "directory", index_out, manifest_infos)]),
+            sparse_oci_layout = depset([sparse_layout]),
         ),
         index_info_provider,
     ]

--- a/img/private/manifest.bzl
+++ b/img/private/manifest.bzl
@@ -516,6 +516,7 @@ def _image_manifest_impl(ctx):
         mnemonic = "ImageManifest",
     )
 
+    sparse_layout = _build_sparse_oci_layout(ctx, "directory", manifest_out, config_out, layers)
     manifest_info_provider = ImageManifestInfo(
         descriptor = descriptor_out,
         manifest = manifest_out,
@@ -526,6 +527,7 @@ def _image_manifest_impl(ctx):
         variant = variant,
         layers = layers,
         missing_blobs = base.missing_blobs if base != None else [],
+        sparse_oci_layout = sparse_layout,
     )
     providers.extend([
         DefaultInfo(
@@ -536,7 +538,7 @@ def _image_manifest_impl(ctx):
             digest = depset([digest_out]),
             oci_layout = depset([_build_oci_layout(ctx, "directory", manifest_out, config_out, layers)]),
             oci_tarball = depset([_build_oci_layout(ctx, "tar", manifest_out, config_out, layers)]),
-            sparse_oci_layout = depset([_build_sparse_oci_layout(ctx, "directory", manifest_out, config_out, layers)]),
+            sparse_oci_layout = depset([sparse_layout]),
         ),
         manifest_info_provider,
     ])

--- a/img/private/providers/index_info.bzl
+++ b/img/private/providers/index_info.bzl
@@ -8,6 +8,7 @@ FIELDS = dict(
     descriptor = "File containing the descriptor of the index.",
     index = "File containing the raw image index (application/vnd.oci.image.index.v1+json).",
     manifests = "ImageManifestInfo of the images.",
+    sparse_oci_layout = "Tree artifact containing the sparse OCI layout for this index.",
 )
 
 ImageIndexInfo = provider(

--- a/img/private/providers/manifest_info.bzl
+++ b/img/private/providers/manifest_info.bzl
@@ -16,6 +16,7 @@ FIELDS = dict(
     missing_blobs = """List of hex-encoded sha256 hashes.
 Used to convey information lost during shallow image pulling, where the base image layers are referenced, but never materialized.
 """,
+    sparse_oci_layout = "Tree artifact containing the sparse OCI layout for this manifest.",
 )
 
 ImageManifestInfo = provider(

--- a/img/private/root_symlinks.bzl
+++ b/img/private/root_symlinks.bzl
@@ -8,51 +8,34 @@ def _layer_root_symlinks_for_manifest(manifest_info, operation_index, manifest_i
         if layer.blob != None
     }
 
-def _metadata_symlinks_for_manifest(manifest_info, operation_index, manifest_index, symlink_name_prefix):
-    base_path = "{}{}/manifests/{}/metadata".format(symlink_name_prefix, operation_index, manifest_index)
-    return {
-        "{base}/{layer_index}".format(base = base_path, layer_index = layer_index): layer.metadata
-        for (layer_index, layer) in enumerate(manifest_info.layers)
-        if layer.metadata != None
-    }
-
-def _root_symlinks_for_manifest(manifest_info, *, include_layers, symlink_name_prefix, operation_index, manifest_index):
-    base_path = "{}{}/manifests/{}/".format(symlink_name_prefix, operation_index, manifest_index)
-    root_symlinks = {
-        "{base}manifest.json".format(base = base_path): manifest_info.manifest,
-        "{base}config.json".format(base = base_path): manifest_info.config,
-    }
-    if include_layers:
-        root_symlinks.update(_layer_root_symlinks_for_manifest(manifest_info, operation_index, manifest_index, symlink_name_prefix))
-        root_symlinks.update(_metadata_symlinks_for_manifest(manifest_info, operation_index, manifest_index, symlink_name_prefix))
-    return root_symlinks
-
 def calculate_root_symlinks(index_info, manifest_info, *, include_layers, symlink_name_prefix, operation_index = 0):
     """Creates a dictionary of symlinks for container image root structure.
 
-    Generates symlinks that organize container image artifacts (manifests, configs,
-    layers, and metadata) into a standardized directory structure suitable for
-    pushing to registries or loading into container runtimes.
+    Generates symlinks that organize container image artifacts into a standardized
+    directory structure suitable for pushing to registries or loading into container
+    runtimes. Uses a single sparse OCI layout tree artifact for manifests, configs,
+    and layer descriptors, plus optional individual layer blob symlinks.
 
     Args:
         index_info: ImageIndexInfo provider for multi-platform images, or None
         manifest_info: ImageManifestInfo provider for single-platform images, or None
-        include_layers: bool, whether to include layer blob and metadata symlinks
+        include_layers: bool, whether to include layer blob symlinks
         symlink_name_prefix: str, prefix for naming symlinks
         operation_index: int, index of the operation in a batch (used for naming)
 
     Returns:
-        dict: Mapping of symlink paths to target files, creating a root directory
-              structure with index.json, manifest.json, config.json, and optionally
-              layer/ and metadata/ subdirectories
+        dict: Mapping of symlink paths to target files
     """
     root_symlinks = {}
     if index_info != None:
-        root_symlinks["{}{}/index.json".format(symlink_name_prefix, operation_index)] = index_info.index
-        for i, manifest in enumerate(index_info.manifests):
-            root_symlinks.update(_root_symlinks_for_manifest(manifest, include_layers = include_layers, symlink_name_prefix = symlink_name_prefix, operation_index = operation_index, manifest_index = i))
+        root_symlinks["{}{}/sparse_oci_layout".format(symlink_name_prefix, operation_index)] = index_info.sparse_oci_layout
+        if include_layers:
+            for i, manifest in enumerate(index_info.manifests):
+                root_symlinks.update(_layer_root_symlinks_for_manifest(manifest, operation_index, i, symlink_name_prefix))
     if manifest_info != None:
-        root_symlinks.update(_root_symlinks_for_manifest(manifest_info, include_layers = include_layers, symlink_name_prefix = symlink_name_prefix, operation_index = operation_index, manifest_index = 0))
+        root_symlinks["{}{}/sparse_oci_layout".format(symlink_name_prefix, operation_index)] = manifest_info.sparse_oci_layout
+        if include_layers:
+            root_symlinks.update(_layer_root_symlinks_for_manifest(manifest_info, operation_index, 0, symlink_name_prefix))
     return root_symlinks
 
 def symlink_name_prefix(ctx):

--- a/img_tool/pkg/deployvfs/deployvfs.go
+++ b/img_tool/pkg/deployvfs/deployvfs.go
@@ -427,8 +427,8 @@ func (b *vfsBuilder) ingest() (map[string]blobEntry, map[string]blobEntry, map[s
 			manifests[op.Root.Digest] = b.localIndex(i, op.Root)
 		}
 		for manifestIndex, manifest := range op.Manifests {
-			manifests[manifest.Descriptor.Digest] = b.localManifest(i, manifestIndex, manifest.Descriptor)
-			blobs[manifest.Config.Digest] = b.localConfig(i, manifestIndex, manifest.Config)
+			manifests[manifest.Descriptor.Digest] = b.localManifest(i, manifest.Descriptor)
+			blobs[manifest.Config.Digest] = b.localConfig(i, manifest.Config)
 			for layerIndex, layer := range manifest.LayerBlobs {
 				blob, err := b.layerBlob(i, manifestIndex, layerIndex, strategy, op.PullInfo, manifest, layer)
 				if err != nil {
@@ -630,7 +630,7 @@ func (b *vfsBuilder) localIndex(operationIndex int, desc api.Descriptor) blobEnt
 		Descriptor: desc,
 		Location:   "file",
 		Opener: func() (io.ReadCloser, error) {
-			fpath, err := b.rlocation(path.Join(fmt.Sprintf("%d", operationIndex), "index.json"))
+			fpath, err := b.rlocation(sparseLayoutBlobPath(operationIndex, desc.Digest))
 			if err != nil {
 				return nil, err
 			}
@@ -639,12 +639,12 @@ func (b *vfsBuilder) localIndex(operationIndex int, desc api.Descriptor) blobEnt
 	}
 }
 
-func (b *vfsBuilder) localManifest(operationIndex int, manifestIndex int, desc api.Descriptor) blobEntry {
+func (b *vfsBuilder) localManifest(operationIndex int, desc api.Descriptor) blobEntry {
 	return blobEntry{
 		Descriptor: desc,
 		Location:   "file",
 		Opener: func() (io.ReadCloser, error) {
-			fpath, err := b.rlocation(path.Join(fmt.Sprintf("%d", operationIndex), "manifests", fmt.Sprintf("%d", manifestIndex), "manifest.json"))
+			fpath, err := b.rlocation(sparseLayoutBlobPath(operationIndex, desc.Digest))
 			if err != nil {
 				return nil, err
 			}
@@ -653,12 +653,12 @@ func (b *vfsBuilder) localManifest(operationIndex int, manifestIndex int, desc a
 	}
 }
 
-func (b *vfsBuilder) localConfig(operationIndex int, manifestIndex int, desc api.Descriptor) blobEntry {
+func (b *vfsBuilder) localConfig(operationIndex int, desc api.Descriptor) blobEntry {
 	return blobEntry{
 		Descriptor: desc,
 		Location:   "file",
 		Opener: func() (io.ReadCloser, error) {
-			fpath, err := b.rlocation(path.Join(fmt.Sprintf("%d", operationIndex), "manifests", fmt.Sprintf("%d", manifestIndex), "config.json"))
+			fpath, err := b.rlocation(sparseLayoutBlobPath(operationIndex, desc.Digest))
 			if err != nil {
 				return nil, err
 			}
@@ -718,6 +718,11 @@ func digestFromHashAndSize(hash registryv1.Hash, sizeBytes int64) (cas.Digest, e
 		return cas.SHA512(rawHash, sizeBytes), nil
 	}
 	return cas.Digest{}, fmt.Errorf("unsupported digest algorithm: %s", hash.Algorithm)
+}
+
+func sparseLayoutBlobPath(operationIndex int, digest string) string {
+	algo, hex, _ := strings.Cut(digest, ":")
+	return path.Join(fmt.Sprintf("%d", operationIndex), "sparse_oci_layout", "blobs", algo, hex)
 }
 
 func layerRunfilesPath(operationIndex int, manifestIndex int, layerIndex int) string {


### PR DESCRIPTION
Replace the per-file runfiles symlinks (index.json, manifest.json, config.json, metadata/) with a single sparse OCI layout tree artifact symlink per operation. Layer blob symlinks are retained when include_layers is true.

Add sparse_oci_layout field to ImageManifestInfo and ImageIndexInfo providers, set it in all rules that construct these providers (manifest, index, import, conversion rules), and extract a shared sparse layout builder into img/private/common/sparse_oci_layout.bzl.

Update the Go deploy VFS to resolve manifests, configs, and index blobs from the sparse layout's blobs/ directory using content- addressable digests instead of positional file paths.