### PR TITLE
feat: refactor deploy command for multi-source VFS and persistent worker

### DIFF
--- a/img/private/deploy_tool.bzl
+++ b/img/private/deploy_tool.bzl
@@ -3,7 +3,13 @@
 load("//img/private/providers:deploy_tool_info.bzl", "DeployToolInfo")
 
 def _img_deploy_tool_impl(ctx):
+    executable = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.symlink(output = executable, target_file = ctx.file.img_deploy_exe, is_executable = True)
     return [
+        DefaultInfo(
+            executable = executable,
+            runfiles = ctx.runfiles(files = [executable]),
+        ),
         DeployToolInfo(
             img_deploy_exe = ctx.file.img_deploy_exe,
             launcher_template = ctx.file.launcher_template,
@@ -27,5 +33,6 @@ img_deploy_tool = rule(
         ),
     },
     doc = "Defines a set of tools used to deploy images.",
+    executable = True,
     provides = [DeployToolInfo],
 )

--- a/img/private/index.bzl
+++ b/img/private/index.bzl
@@ -214,13 +214,6 @@ def _image_index_impl(ctx):
     )
     providers = [
         DefaultInfo(files = depset([index_out])),
-        OutputGroupInfo(
-            descriptor = depset([descriptor_out]),
-            digest = depset([digest_out]),
-            oci_layout = depset([_build_oci_layout(ctx, "directory", index_out, manifest_infos)]),
-            oci_tarball = depset([_build_oci_layout(ctx, "tar", index_out, manifest_infos)]),
-            sparse_oci_layout = depset([sparse_layout]),
-        ),
         index_info_provider,
     ]
     if pull_info != None:
@@ -236,8 +229,18 @@ def _image_index_impl(ctx):
         load_specs = ctx.attr.load_specs,
         allow_manifest_tags = True,
     )
+
+    output_groups = dict(
+        descriptor = depset([descriptor_out]),
+        digest = depset([digest_out]),
+        oci_layout = depset([_build_oci_layout(ctx, "directory", index_out, manifest_infos)]),
+        oci_tarball = depset([_build_oci_layout(ctx, "tar", index_out, manifest_infos)]),
+        sparse_oci_layout = depset([sparse_layout]),
+    )
     if deploy_info != None:
         providers.append(deploy_info)
+        output_groups["deploy_manifest"] = depset([deploy_info.deploy_manifest])
+    providers.append(OutputGroupInfo(**output_groups))
 
     return providers
 

--- a/img/private/manifest.bzl
+++ b/img/private/manifest.bzl
@@ -533,13 +533,6 @@ def _image_manifest_impl(ctx):
         DefaultInfo(
             files = depset([manifest_out, config_out]),
         ),
-        OutputGroupInfo(
-            descriptor = depset([descriptor_out]),
-            digest = depset([digest_out]),
-            oci_layout = depset([_build_oci_layout(ctx, "directory", manifest_out, config_out, layers)]),
-            oci_tarball = depset([_build_oci_layout(ctx, "tar", manifest_out, config_out, layers)]),
-            sparse_oci_layout = depset([sparse_layout]),
-        ),
         manifest_info_provider,
     ])
 
@@ -553,8 +546,18 @@ def _image_manifest_impl(ctx):
         load_specs = ctx.attr.load_specs,
         allow_manifest_tags = False,
     )
+
+    output_groups = dict(
+        descriptor = depset([descriptor_out]),
+        digest = depset([digest_out]),
+        oci_layout = depset([_build_oci_layout(ctx, "directory", manifest_out, config_out, layers)]),
+        oci_tarball = depset([_build_oci_layout(ctx, "tar", manifest_out, config_out, layers)]),
+        sparse_oci_layout = depset([sparse_layout]),
+    )
     if deploy_info != None:
         providers.append(deploy_info)
+        output_groups["deploy_manifest"] = depset([deploy_info.deploy_manifest])
+    providers.append(OutputGroupInfo(**output_groups))
 
     return providers
 

--- a/img_tool/cmd/deploy/BUILD.bazel
+++ b/img_tool/cmd/deploy/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "deploy",
-    srcs = ["deploy.go"],
+    srcs = [
+        "deploy.go",
+        "persistentworker.go",
+    ],
     importpath = "github.com/bazel-contrib/rules_img/img_tool/cmd/deploy",
     visibility = ["//visibility:public"],
     deps = [
@@ -13,6 +16,7 @@ go_library(
         "//pkg/cas",
         "//pkg/deployvfs",
         "//pkg/load",
+        "//pkg/persistentworker",
         "//pkg/proto/blobcache",
         "//pkg/push",
         "@com_github_malt3_go_containerregistry//pkg/name",

--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -26,26 +26,49 @@ import (
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/cas"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/deployvfs"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/load"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/persistentworker"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/proto/blobcache"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/push"
 )
 
 func DeployProcess(ctx context.Context, args []string) {
-	var requestFile string
+	// Check for persistent worker mode before parsing other flags
+	processedArgs, isPersistentWorker, err := persistentworker.ParseArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing args: %v\n", err)
+		os.Exit(1)
+	}
+	if isPersistentWorker {
+		jobs := extractJobsFlag(processedArgs)
+		if err := persistentWorker(jobs); err != nil {
+			fmt.Fprintf(os.Stderr, "Error in persistent worker: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	args = processedArgs
+
+	var requestFiles stringSliceFlag
 	var runfilesRootSymlinksPrefix string
 	var additionalTags stringSliceFlag
 	var overrideRegistry string
 	var overrideRepository string
 	var platforms string
+	var ociLayouts stringSliceFlag
+	var explicitLayers stringSliceFlag
+	var jobs int
 
 	flagSet := flag.NewFlagSet("deploy", flag.ContinueOnError)
-	flagSet.StringVar(&requestFile, "request-file", "", "Deploy manifest JSON request file")
+	flagSet.Var(&requestFiles, "request-file", "Deploy manifest JSON request file (can be used multiple times)")
 	flagSet.StringVar(&runfilesRootSymlinksPrefix, "runfiles-root-symlinks-prefix", "", "Prefix for runfiles root symlinks")
 	flagSet.Var(&additionalTags, "tag", "Additional tag to apply (can be used multiple times)")
 	flagSet.Var(&additionalTags, "t", "Additional tag to apply (can be used multiple times)")
 	flagSet.StringVar(&overrideRegistry, "registry", "", "Override registry to push to")
 	flagSet.StringVar(&overrideRepository, "repository", "", "Override repository to push to")
 	flagSet.StringVar(&platforms, "platform", "", "Comma-separated list of platforms to load (e.g., linux/amd64). If not set, loads the platform closest to the host (or the single available platform). Use 'all' to load the full multi-platform index. Doesn't affect push, only load.")
+	flagSet.Var(&ociLayouts, "oci-layout", "Path to an OCI layout directory, sparse or standard (can be used multiple times)")
+	flagSet.Var(&explicitLayers, "layer", "Explicit layer in digest=path format (can be used multiple times)")
+	flagSet.IntVar(&jobs, "jobs", 16, "Maximum number of parallel push operations")
 
 	if err := flagSet.Parse(args); err != nil {
 		flagSet.Usage()
@@ -57,16 +80,21 @@ func DeployProcess(ctx context.Context, args []string) {
 		os.Exit(1)
 	}
 
-	if requestFile == "" {
-		fmt.Fprintln(os.Stderr, "Error: --request-file is required")
+	if len(requestFiles) == 0 {
+		fmt.Fprintln(os.Stderr, "Error: at least one --request-file is required")
 		flagSet.Usage()
 		os.Exit(1)
 	}
 
-	rawRequest, err := os.ReadFile(requestFile)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading request file %s: %v\n", requestFile, err)
-		os.Exit(1)
+	// Parse explicit layers into a map
+	layerMap := make(map[string]string)
+	for _, layerFlag := range explicitLayers {
+		digest, filePath, ok := strings.Cut(layerFlag, "=")
+		if !ok {
+			fmt.Fprintf(os.Stderr, "Error: --layer must be in format digest=path, got %q\n", layerFlag)
+			os.Exit(1)
+		}
+		layerMap[digest] = filePath
 	}
 
 	// Parse platforms
@@ -79,13 +107,75 @@ func DeployProcess(ctx context.Context, args []string) {
 		}
 	}
 
-	if err := DeployWithExtras(ctx, rawRequest, []string(additionalTags), overrideRegistry, overrideRepository, platformList, runfilesRootSymlinksPrefix); err != nil {
+	// Read and merge all request files
+	rawRequest, err := mergeRequestFiles(requestFiles)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	opts := DeployOptions{
+		AdditionalTags:             []string(additionalTags),
+		OverrideRegistry:           overrideRegistry,
+		OverrideRepository:         overrideRepository,
+		PlatformList:               platformList,
+		RunfilesRootSymlinksPrefix: runfilesRootSymlinksPrefix,
+		OCILayouts:                 []string(ociLayouts),
+		ExplicitLayers:             layerMap,
+		Jobs:                       jobs,
+	}
+
+	if err := DeployWithExtras(ctx, rawRequest, opts); err != nil {
 		fmt.Fprintf(os.Stderr, "Error during deploy: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func DeployWithExtras(ctx context.Context, rawRequest []byte, additionalTags []string, overrideRegistry, overrideRepository string, platformList []string, runfilesRootSymlinksPrefix string) error {
+// mergeRequestFiles reads multiple deploy manifest files and merges them into a single manifest.
+// Operations are concatenated; settings from the last file win.
+func mergeRequestFiles(paths []string) ([]byte, error) {
+	if len(paths) == 1 {
+		raw, err := os.ReadFile(paths[0])
+		if err != nil {
+			return nil, fmt.Errorf("reading request file %s: %w", paths[0], err)
+		}
+		return raw, nil
+	}
+
+	var merged api.DeployManifest
+	for _, p := range paths {
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			return nil, fmt.Errorf("reading request file %s: %w", p, err)
+		}
+		var dm api.DeployManifest
+		if err := json.Unmarshal(raw, &dm); err != nil {
+			return nil, fmt.Errorf("parsing request file %s: %w", p, err)
+		}
+		merged.Operations = append(merged.Operations, dm.Operations...)
+		merged.Settings = dm.Settings
+	}
+
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling merged manifest: %w", err)
+	}
+	return out, nil
+}
+
+// DeployOptions contains all configuration for a deploy operation.
+type DeployOptions struct {
+	AdditionalTags             []string
+	OverrideRegistry           string
+	OverrideRepository         string
+	PlatformList               []string
+	RunfilesRootSymlinksPrefix string
+	OCILayouts                 []string
+	ExplicitLayers             map[string]string
+	Jobs                       int
+}
+
+func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions) error {
 	var req api.DeployManifest
 	decoder := json.NewDecoder(bytes.NewReader(rawRequest))
 	decoder.DisallowUnknownFields()
@@ -151,8 +241,14 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, additionalTags []s
 	}
 
 	vfsBuilder := deployvfs.Builder(req).WithContainerRegistryOption(registry.WithAuthFromMultiKeychain())
-	if runfilesRootSymlinksPrefix != "" {
-		vfsBuilder = vfsBuilder.WithRunfilesRootSymlinksPrefix(runfilesRootSymlinksPrefix)
+	if opts.RunfilesRootSymlinksPrefix != "" {
+		vfsBuilder = vfsBuilder.WithRunfilesRootSymlinksPrefix(opts.RunfilesRootSymlinksPrefix)
+	}
+	for _, layoutPath := range opts.OCILayouts {
+		vfsBuilder = vfsBuilder.WithOCILayout(layoutPath)
+	}
+	for digest, filePath := range opts.ExplicitLayers {
+		vfsBuilder = vfsBuilder.WithExplicitLayer(digest, filePath)
 	}
 	if casReader != nil {
 		vfsBuilder = vfsBuilder.WithCASReader(casReader)
@@ -162,25 +258,37 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, additionalTags []s
 		return fmt.Errorf("building VFS: %w", err)
 	}
 
+	// Create a single persistent pusher for all push operations (including registry_tag)
+	var pusher *remote.Pusher
+	needsPusher := len(pushOperations) > 0 || len(registryTagOperations) > 0
+	if needsPusher && req.Settings.PushStrategy != "bes" {
+		pusher, err = remote.NewPusher(registry.WithAuthFromMultiKeychain(), remote.WithJobs(opts.Jobs))
+		if err != nil {
+			return fmt.Errorf("creating pusher: %w", err)
+		}
+	}
+
 	var pushedTags []string
 	// groupCtx is cancelled once g.Wait returns; keep the outer ctx for work after it (registry_tag ops).
 	g, groupCtx := errgroup.WithContext(ctx)
 
 	if len(pushOperations) > 0 {
-		uploadBuilder := push.NewBuilder(vfs)
+		uploadBuilder := push.NewBuilder(vfs).
+			WithPusher(pusher).
+			WithJobs(opts.Jobs).
+			WithRemoteOptions(registry.WithAuthFromMultiKeychain())
 		if haveBlobCacheCient {
 			uploadBuilder = uploadBuilder.WithBlobcacheClient(blobcacheClient)
 		}
-		if overrideRegistry != "" {
-			uploadBuilder = uploadBuilder.WithOverrideRegistry(overrideRegistry)
+		if opts.OverrideRegistry != "" {
+			uploadBuilder = uploadBuilder.WithOverrideRegistry(opts.OverrideRegistry)
 		}
-		if overrideRepository != "" {
-			uploadBuilder = uploadBuilder.WithOverrideRepository(overrideRepository)
+		if opts.OverrideRepository != "" {
+			uploadBuilder = uploadBuilder.WithOverrideRepository(opts.OverrideRepository)
 		}
-		if len(additionalTags) > 0 {
-			uploadBuilder = uploadBuilder.WithExtraTags(additionalTags)
+		if len(opts.AdditionalTags) > 0 {
+			uploadBuilder = uploadBuilder.WithExtraTags(opts.AdditionalTags)
 		}
-		uploadBuilder.WithRemoteOptions(registry.WithAuthFromMultiKeychain())
 		uploader := uploadBuilder.Build()
 
 		g.Go(func() error {
@@ -195,11 +303,11 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, additionalTags []s
 	if len(loadOperations) > 0 {
 		g.Go(func() error {
 			builder := load.NewBuilder(vfs)
-			if len(platformList) > 0 {
-				builder = builder.WithPlatforms(platformList)
+			if len(opts.PlatformList) > 0 {
+				builder = builder.WithPlatforms(opts.PlatformList)
 			}
-			if len(additionalTags) > 0 {
-				builder = builder.WithExtraTags(additionalTags)
+			if len(opts.AdditionalTags) > 0 {
+				builder = builder.WithExtraTags(opts.AdditionalTags)
 			}
 			// LoadAll prints the loaded tags itself, so we discard the return value
 			_, err := builder.Build().LoadAll(groupCtx, loadOperations)
@@ -222,7 +330,7 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, additionalTags []s
 	// Note: loadedTags are already printed by the loader itself
 
 	if len(registryTagOperations) > 0 {
-		extraTagNames, err := applyRegistryTagOperations(ctx, vfs, registryTagOperations, req.Settings.PushStrategy, overrideRegistry, overrideRepository)
+		extraTagNames, err := applyRegistryTagOperations(ctx, vfs, pusher, registryTagOperations, req.Settings.PushStrategy, opts.OverrideRegistry, opts.OverrideRepository, opts.Jobs)
 		if err != nil {
 			return err
 		}
@@ -237,13 +345,18 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, additionalTags []s
 // applyRegistryTagOperations writes the pre-expanded tags from registry_tag
 // ops onto manifests already pushed by a preceding push op. Under the `bes`
 // strategy the BES syncer is responsible for this, so we no-op.
-func applyRegistryTagOperations(ctx context.Context, vfs *deployvfs.VFS, ops []api.IndexedRegistryTagDeployOperation, strategy, overrideRegistry, overrideRepository string) ([]string, error) {
+func applyRegistryTagOperations(ctx context.Context, vfs *deployvfs.VFS, pusher *remote.Pusher, ops []api.IndexedRegistryTagDeployOperation, strategy, overrideRegistry, overrideRepository string, jobs int) ([]string, error) {
 	if strategy == "bes" {
 		return nil, nil
 	}
 
-	todo := make(map[name.Reference]remote.Taggable)
+	type pushItem struct {
+		ref      name.Reference
+		taggable remote.Taggable
+	}
+	var items []pushItem
 	var tagNames []string
+
 	for _, op := range ops {
 		opRegistry := op.Registry
 		if overrideRegistry != "" {
@@ -268,16 +381,25 @@ func applyRegistryTagOperations(ctx context.Context, vfs *deployvfs.VFS, ops []a
 			if err != nil {
 				return nil, fmt.Errorf("creating registry_tag ref %q: %w", tag, err)
 			}
-			todo[ref] = taggable
+			items = append(items, pushItem{ref: ref, taggable: taggable})
 			tagNames = append(tagNames, ref.String())
 		}
 	}
-	if len(todo) == 0 {
+	if len(items) == 0 {
 		return nil, nil
 	}
 
-	opts := []remote.Option{remote.WithContext(ctx), registry.WithAuthFromMultiKeychain()}
-	if err := remote.MultiWrite(todo, opts...); err != nil {
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(jobs)
+
+	for _, item := range items {
+		item := item
+		g.Go(func() error {
+			return pusher.Push(ctx, item.ref, item.taggable)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
 		return nil, fmt.Errorf("applying registry_tag operations: %w", err)
 	}
 	sort.Strings(tagNames)
@@ -318,4 +440,20 @@ func credentialHelperPath() string {
 		return tweagCredentialHelper
 	}
 	return ""
+}
+
+func extractJobsFlag(args []string) int {
+	for i := 0; i < len(args); i++ {
+		key, value, hasValue := strings.Cut(args[i], "=")
+		if key == "--jobs" {
+			if !hasValue && i+1 < len(args) {
+				value = args[i+1]
+			}
+			var j int
+			if _, err := fmt.Sscanf(value, "%d", &j); err == nil && j > 0 {
+				return j
+			}
+		}
+	}
+	return 16
 }

--- a/img_tool/cmd/deploy/persistentworker.go
+++ b/img_tool/cmd/deploy/persistentworker.go
@@ -1,0 +1,315 @@
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/malt3/go-containerregistry/pkg/name"
+	registryv1 "github.com/malt3/go-containerregistry/pkg/v1"
+	"github.com/malt3/go-containerregistry/pkg/v1/remote"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/registry"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/deployvfs"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/load"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/persistentworker"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/push"
+)
+
+type deployWorkerHandler struct {
+	pusher *remote.Pusher
+	jobs   int
+}
+
+func newDeployWorkerHandler(jobs int) *deployWorkerHandler {
+	opts := []remote.Option{registry.WithAuthFromMultiKeychain(), remote.WithJobs(jobs)}
+	p, err := remote.NewPusher(opts...)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to create persistent pusher: %v\n", err)
+		return &deployWorkerHandler{jobs: jobs}
+	}
+	return &deployWorkerHandler{pusher: p, jobs: jobs}
+}
+
+func (h *deployWorkerHandler) HandleRequest(ctx context.Context, req persistentworker.WorkRequest) persistentworker.WorkResponse {
+	output, err := h.processRequest(ctx, req)
+	if err != nil {
+		return persistentworker.WorkResponse{
+			ExitCode:  1,
+			Output:    err.Error(),
+			RequestId: req.RequestId,
+		}
+	}
+	return persistentworker.WorkResponse{
+		ExitCode:  0,
+		Output:    output,
+		RequestId: req.RequestId,
+	}
+}
+
+func (h *deployWorkerHandler) processRequest(ctx context.Context, req persistentworker.WorkRequest) (string, error) {
+	opts, err := parseWorkerArgs(req.Arguments)
+	if err != nil {
+		return "", fmt.Errorf("parsing arguments: %w", err)
+	}
+
+	rawRequest, err := mergeRequestFiles(opts.requestFiles)
+	if err != nil {
+		return "", err
+	}
+
+	var dm api.DeployManifest
+	if err := json.Unmarshal(rawRequest, &dm); err != nil {
+		return "", fmt.Errorf("unmarshalling deploy manifest: %w", err)
+	}
+
+	vfsBuilder := deployvfs.Builder(dm).WithContainerRegistryOption(registry.WithAuthFromMultiKeychain())
+	for _, layoutPath := range opts.ociLayouts {
+		vfsBuilder = vfsBuilder.WithOCILayout(layoutPath)
+	}
+	for digest, filePath := range opts.explicitLayers {
+		vfsBuilder = vfsBuilder.WithExplicitLayer(digest, filePath)
+	}
+	if opts.runfilesPrefix != "" {
+		vfsBuilder = vfsBuilder.WithRunfilesRootSymlinksPrefix(opts.runfilesPrefix)
+	}
+	vfs, err := vfsBuilder.Build()
+	if err != nil {
+		return "", fmt.Errorf("building VFS: %w", err)
+	}
+
+	var output strings.Builder
+
+	pushOps, err := dm.PushOperations()
+	if err != nil {
+		return "", err
+	}
+	if len(pushOps) > 0 {
+		tags, err := h.pushOps(ctx, vfs, pushOps, dm.Settings.PushStrategy, opts)
+		if err != nil {
+			return "", fmt.Errorf("push: %w", err)
+		}
+		for _, tag := range tags {
+			output.WriteString(tag)
+			output.WriteByte('\n')
+		}
+	}
+
+	registryTagOps, err := dm.RegistryTagOperations()
+	if err != nil {
+		return "", err
+	}
+	if len(registryTagOps) > 0 {
+		tags, err := h.registryTagOps(ctx, vfs, registryTagOps, dm.Settings.PushStrategy, opts)
+		if err != nil {
+			return "", fmt.Errorf("registry_tag: %w", err)
+		}
+		for _, tag := range tags {
+			output.WriteString(tag)
+			output.WriteByte('\n')
+		}
+	}
+
+	loadOps, err := dm.LoadOperations()
+	if err != nil {
+		return "", err
+	}
+	if len(loadOps) > 0 {
+		builder := load.NewBuilder(vfs)
+		if len(opts.platforms) > 0 {
+			builder = builder.WithPlatforms(opts.platforms)
+		}
+		if _, err := builder.Build().LoadAll(ctx, loadOps); err != nil {
+			return "", fmt.Errorf("load: %w", err)
+		}
+	}
+
+	return output.String(), nil
+}
+
+func (h *deployWorkerHandler) pushOps(ctx context.Context, vfs *deployvfs.VFS, ops []api.IndexedPushDeployOperation, strategy string, opts *workerOpts) ([]string, error) {
+	uploadBuilder := push.NewBuilder(vfs).
+		WithPusher(h.pusher).
+		WithJobs(h.jobs).
+		WithRemoteOptions(registry.WithAuthFromMultiKeychain())
+	if opts.overrideRegistry != "" {
+		uploadBuilder = uploadBuilder.WithOverrideRegistry(opts.overrideRegistry)
+	}
+	if opts.overrideRepository != "" {
+		uploadBuilder = uploadBuilder.WithOverrideRepository(opts.overrideRepository)
+	}
+	return uploadBuilder.Build().PushAll(ctx, ops, strategy)
+}
+
+func (h *deployWorkerHandler) registryTagOps(ctx context.Context, vfs *deployvfs.VFS, ops []api.IndexedRegistryTagDeployOperation, strategy string, opts *workerOpts) ([]string, error) {
+	if strategy == "bes" {
+		return nil, nil
+	}
+	if h.pusher == nil {
+		return nil, fmt.Errorf("no pusher available for registry_tag operations")
+	}
+
+	type pushItem struct {
+		ref      name.Reference
+		taggable remote.Taggable
+	}
+	var items []pushItem
+	var tagNames []string
+
+	for _, op := range ops {
+		opRegistry := op.Registry
+		if opts.overrideRegistry != "" {
+			opRegistry = opts.overrideRegistry
+		}
+		opRepository := op.Repository
+		if opts.overrideRepository != "" {
+			opRepository = opts.overrideRepository
+		}
+		baseRef := opRegistry + "/" + opRepository
+
+		rootHash, err := registryv1.NewHash(op.Root.Digest)
+		if err != nil {
+			return nil, fmt.Errorf("parsing root digest for registry_tag: %w", err)
+		}
+		taggable, err := vfs.Taggable(rootHash)
+		if err != nil {
+			return nil, fmt.Errorf("locating manifest %s for registry_tag: %w", op.Root.Digest, err)
+		}
+		for _, tag := range op.Tags {
+			ref, err := name.NewTag(baseRef + ":" + tag)
+			if err != nil {
+				return nil, fmt.Errorf("creating registry_tag ref %q: %w", tag, err)
+			}
+			items = append(items, pushItem{ref: ref, taggable: taggable})
+			tagNames = append(tagNames, ref.String())
+		}
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(h.jobs)
+
+	for _, item := range items {
+		item := item
+		g.Go(func() error {
+			return h.pusher.Push(ctx, item.ref, item.taggable)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("applying registry_tag operations: %w", err)
+	}
+	return tagNames, nil
+}
+
+type workerOpts struct {
+	requestFiles       []string
+	ociLayouts         []string
+	explicitLayers     map[string]string
+	runfilesPrefix     string
+	overrideRegistry   string
+	overrideRepository string
+	platforms          []string
+}
+
+func parseWorkerArgs(args []string) (*workerOpts, error) {
+	opts := &workerOpts{
+		explicitLayers: make(map[string]string),
+	}
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		key, value, hasValue := strings.Cut(arg, "=")
+
+		switch {
+		case key == "--request-file":
+			if !hasValue {
+				if i+1 >= len(args) {
+					return nil, fmt.Errorf("--request-file requires a value")
+				}
+				i++
+				value = args[i]
+			}
+			opts.requestFiles = append(opts.requestFiles, value)
+		case key == "--oci-layout":
+			if !hasValue {
+				if i+1 >= len(args) {
+					return nil, fmt.Errorf("--oci-layout requires a value")
+				}
+				i++
+				value = args[i]
+			}
+			opts.ociLayouts = append(opts.ociLayouts, value)
+		case key == "--layer":
+			if !hasValue {
+				if i+1 >= len(args) {
+					return nil, fmt.Errorf("--layer requires a value")
+				}
+				i++
+				value = args[i]
+			}
+			digest, path, ok := strings.Cut(value, "=")
+			if !ok {
+				return nil, fmt.Errorf("--layer must be in format digest=path, got %q", value)
+			}
+			opts.explicitLayers[digest] = path
+		case key == "--runfiles-root-symlinks-prefix":
+			if !hasValue {
+				if i+1 >= len(args) {
+					return nil, fmt.Errorf("--runfiles-root-symlinks-prefix requires a value")
+				}
+				i++
+				value = args[i]
+			}
+			opts.runfilesPrefix = value
+		case key == "--registry":
+			if !hasValue {
+				if i+1 >= len(args) {
+					return nil, fmt.Errorf("--registry requires a value")
+				}
+				i++
+				value = args[i]
+			}
+			opts.overrideRegistry = value
+		case key == "--repository":
+			if !hasValue {
+				if i+1 >= len(args) {
+					return nil, fmt.Errorf("--repository requires a value")
+				}
+				i++
+				value = args[i]
+			}
+			opts.overrideRepository = value
+		case key == "--platform":
+			if !hasValue {
+				if i+1 >= len(args) {
+					return nil, fmt.Errorf("--platform requires a value")
+				}
+				i++
+				value = args[i]
+			}
+			opts.platforms = strings.Split(value, ",")
+			for j, p := range opts.platforms {
+				opts.platforms[j] = strings.TrimSpace(p)
+			}
+		}
+	}
+
+	if len(opts.requestFiles) == 0 {
+		return nil, fmt.Errorf("at least one --request-file is required")
+	}
+	return opts, nil
+}
+
+func persistentWorker(jobs int) error {
+	handler := newDeployWorkerHandler(jobs)
+	worker := persistentworker.NewWorker(handler)
+	return worker.Run()
+}

--- a/img_tool/pkg/deployvfs/deployvfs.go
+++ b/img_tool/pkg/deployvfs/deployvfs.go
@@ -261,6 +261,8 @@ type vfsBuilder struct {
 	casReader                  casReader
 	containerRegistryOptions   []remote.Option
 	runfilesRootSymlinksPrefix string
+	ociLayouts                 []string            // paths to OCI layout directories (sparse or standard)
+	explicitLayers             map[string]string   // digest -> file path
 	layerHints                 map[string][]string // digest -> []paths
 	stats                      *Stats
 }
@@ -284,6 +286,19 @@ func (b *vfsBuilder) WithContainerRegistryOption(o remote.Option) *vfsBuilder {
 
 func (b *vfsBuilder) WithRunfilesRootSymlinksPrefix(prefix string) *vfsBuilder {
 	b.runfilesRootSymlinksPrefix = prefix
+	return b
+}
+
+func (b *vfsBuilder) WithOCILayout(layoutPath string) *vfsBuilder {
+	b.ociLayouts = append(b.ociLayouts, layoutPath)
+	return b
+}
+
+func (b *vfsBuilder) WithExplicitLayer(digest string, filePath string) *vfsBuilder {
+	if b.explicitLayers == nil {
+		b.explicitLayers = make(map[string]string)
+	}
+	b.explicitLayers[digest] = filePath
 	return b
 }
 
@@ -423,12 +438,11 @@ func (b *vfsBuilder) ingest() (map[string]blobEntry, map[string]blobEntry, map[s
 			continue
 		}
 		if op.RootKind == "index" {
-			// There must be a "index.json" file in the runfiles
-			manifests[op.Root.Digest] = b.localIndex(i, op.Root)
+			manifests[op.Root.Digest] = b.resolveManifestBlob(i, op.Root)
 		}
 		for manifestIndex, manifest := range op.Manifests {
-			manifests[manifest.Descriptor.Digest] = b.localManifest(i, manifest.Descriptor)
-			blobs[manifest.Config.Digest] = b.localConfig(i, manifest.Config)
+			manifests[manifest.Descriptor.Digest] = b.resolveManifestBlob(i, manifest.Descriptor)
+			blobs[manifest.Config.Digest] = b.resolveConfigBlob(i, manifest.Config)
 			for layerIndex, layer := range manifest.LayerBlobs {
 				blob, err := b.layerBlob(i, manifestIndex, layerIndex, strategy, op.PullInfo, manifest, layer)
 				if err != nil {
@@ -466,11 +480,19 @@ func (b *vfsBuilder) ingest() (map[string]blobEntry, map[string]blobEntry, map[s
 
 func (b *vfsBuilder) layerBlob(operationIndex int, manifestIndex int, layerIndex int, strategy string, pullInfo api.PullInfo, manifestInfo api.ManifestDeployInfo, desc api.Descriptor) (blobEntry, error) {
 	// we try the following sources, in order:
-	// 1. runfiles tree
-	// 2. registry of base image (if base image is shallow, blob was marked as "missing blob" (exists remotely) and strategy allows it)
-	// 3. bazel remote cache (lazy strategy)
-	// 4. stub blob (cas_registry stategy where all blobs are assumed to already be in the remote CAS)
+	// 1. OCI layouts (--oci-layout flags, supports both sparse and standard formats)
+	// 2. explicit layer files (--layer flags)
+	// 3. runfiles tree
+	// 4. registry of base image (if base image is shallow, blob was marked as "missing blob" (exists remotely) and strategy allows it)
+	// 5. bazel remote cache (lazy strategy)
+	// 6. stub blob (cas_registry strategy where all blobs are assumed to already be in the remote CAS)
 
+	if entry, found := b.layerFromOCILayouts(desc); found {
+		return entry, nil
+	}
+	if entry, found := b.layerFromExplicit(desc); found {
+		return entry, nil
+	}
 	if entry, found := b.layerFromFile(operationIndex, manifestIndex, layerIndex, desc); found {
 		return entry, nil
 	}
@@ -479,12 +501,12 @@ func (b *vfsBuilder) layerBlob(operationIndex int, manifestIndex int, layerIndex
 	}
 	switch strategy {
 	case "eager":
-		return blobEntry{}, fmt.Errorf("layer not found in runfiles (%s) or base image registry, cannot proceed with eager strategy", layerRunfilesPath(operationIndex, manifestIndex, layerIndex))
+		return blobEntry{}, fmt.Errorf("layer not found in any source (OCI layouts, explicit layers, runfiles at %s, or base image registry), cannot proceed with eager strategy", layerRunfilesPath(operationIndex, manifestIndex, layerIndex))
 	case "lazy":
 		if entry, found := b.layerFromCAS(desc); found {
 			return entry, nil
 		}
-		return blobEntry{}, fmt.Errorf("layer not found in runfiles (%s) or base image registry, and not found in remote cache, cannot proceed with lazy strategy", layerRunfilesPath(operationIndex, manifestIndex, layerIndex))
+		return blobEntry{}, fmt.Errorf("layer not found in any source (OCI layouts, explicit layers, runfiles at %s, base image registry, or remote cache), cannot proceed with lazy strategy", layerRunfilesPath(operationIndex, manifestIndex, layerIndex))
 	case "cas_registry", "bes":
 		// create a stub blob that cannot be read.
 		// The push code should never try to read it, since the remote CAS is assumed to already have it.
@@ -492,6 +514,51 @@ func (b *vfsBuilder) layerBlob(operationIndex int, manifestIndex int, layerIndex
 		return stubBlob(desc), nil
 	}
 	return blobEntry{}, fmt.Errorf("unknown push/load strategy: %s", strategy)
+}
+
+// layerFromOCILayouts tries to find the layer in any OCI layout directory (sparse or standard).
+func (b *vfsBuilder) layerFromOCILayouts(desc api.Descriptor) (blobEntry, bool) {
+	for _, layoutPath := range b.ociLayouts {
+		blobPath := sparseLayoutBlobPathInDir(layoutPath, desc.Digest)
+		if _, err := os.Stat(blobPath); err == nil {
+			fpath := blobPath
+			stats := b.stats
+			return blobEntry{
+				Descriptor: desc,
+				Location:   "file",
+				stats:      stats,
+				Opener: func() (io.ReadCloser, error) {
+					stats.LayersFromLocalDisk.Add(1)
+					return os.Open(fpath)
+				},
+			}, true
+		}
+	}
+	return blobEntry{}, false
+}
+
+// layerFromExplicit tries to find the layer in the explicit layer map.
+func (b *vfsBuilder) layerFromExplicit(desc api.Descriptor) (blobEntry, bool) {
+	if b.explicitLayers == nil {
+		return blobEntry{}, false
+	}
+	fpath, found := b.explicitLayers[desc.Digest]
+	if !found {
+		return blobEntry{}, false
+	}
+	if _, err := os.Stat(fpath); err != nil {
+		return blobEntry{}, false
+	}
+	stats := b.stats
+	return blobEntry{
+		Descriptor: desc,
+		Location:   "file",
+		stats:      stats,
+		Opener: func() (io.ReadCloser, error) {
+			stats.LayersFromLocalDisk.Add(1)
+			return os.Open(fpath)
+		},
+	}, true
 }
 
 // layerFromFile tries to find the layer in the runfiles tree. If it exists, it returns the blobEntry and true.
@@ -625,7 +692,44 @@ type blobEntry struct {
 	stats    *Stats // reference to VFS stats for tracking
 }
 
-func (b *vfsBuilder) localIndex(operationIndex int, desc api.Descriptor) blobEntry {
+// resolveManifestBlob resolves a manifest or index blob from available sources.
+// Priority: OCI layouts → runfiles sparse layout path.
+func (b *vfsBuilder) resolveManifestBlob(operationIndex int, desc api.Descriptor) blobEntry {
+	if entry, found := b.blobFromOCILayouts(desc); found {
+		return entry
+	}
+	return b.blobFromRunfilesSparseLayout(operationIndex, desc)
+}
+
+// resolveConfigBlob resolves a config blob from available sources.
+// Priority: OCI layouts → runfiles sparse layout path.
+func (b *vfsBuilder) resolveConfigBlob(operationIndex int, desc api.Descriptor) blobEntry {
+	if entry, found := b.blobFromOCILayouts(desc); found {
+		return entry
+	}
+	return b.blobFromRunfilesSparseLayout(operationIndex, desc)
+}
+
+// blobFromOCILayouts tries to find a blob in any of the configured OCI layout directories.
+func (b *vfsBuilder) blobFromOCILayouts(desc api.Descriptor) (blobEntry, bool) {
+	for _, layoutPath := range b.ociLayouts {
+		blobPath := sparseLayoutBlobPathInDir(layoutPath, desc.Digest)
+		if _, err := os.Stat(blobPath); err == nil {
+			fpath := blobPath
+			return blobEntry{
+				Descriptor: desc,
+				Location:   "file",
+				Opener: func() (io.ReadCloser, error) {
+					return os.Open(fpath)
+				},
+			}, true
+		}
+	}
+	return blobEntry{}, false
+}
+
+// blobFromRunfilesSparseLayout resolves a blob from the runfiles sparse layout tree.
+func (b *vfsBuilder) blobFromRunfilesSparseLayout(operationIndex int, desc api.Descriptor) blobEntry {
 	return blobEntry{
 		Descriptor: desc,
 		Location:   "file",
@@ -639,32 +743,10 @@ func (b *vfsBuilder) localIndex(operationIndex int, desc api.Descriptor) blobEnt
 	}
 }
 
-func (b *vfsBuilder) localManifest(operationIndex int, desc api.Descriptor) blobEntry {
-	return blobEntry{
-		Descriptor: desc,
-		Location:   "file",
-		Opener: func() (io.ReadCloser, error) {
-			fpath, err := b.rlocation(sparseLayoutBlobPath(operationIndex, desc.Digest))
-			if err != nil {
-				return nil, err
-			}
-			return os.Open(fpath)
-		},
-	}
-}
-
-func (b *vfsBuilder) localConfig(operationIndex int, desc api.Descriptor) blobEntry {
-	return blobEntry{
-		Descriptor: desc,
-		Location:   "file",
-		Opener: func() (io.ReadCloser, error) {
-			fpath, err := b.rlocation(sparseLayoutBlobPath(operationIndex, desc.Digest))
-			if err != nil {
-				return nil, err
-			}
-			return os.Open(fpath)
-		},
-	}
+// sparseLayoutBlobPathInDir returns the absolute path to a blob within a sparse layout directory.
+func sparseLayoutBlobPathInDir(layoutDir string, digest string) string {
+	algo, hex, _ := strings.Cut(digest, ":")
+	return filepath.Join(layoutDir, "blobs", algo, hex)
 }
 
 func (b blobEntry) Digest() (registryv1.Hash, error) {

--- a/img_tool/pkg/push/BUILD.bazel
+++ b/img_tool/pkg/push/BUILD.bazel
@@ -7,11 +7,11 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api",
-        "//pkg/progress",
         "//pkg/proto/blobcache",
         "//pkg/proto/remote-apis/build/bazel/remote/execution/v2",
         "@com_github_malt3_go_containerregistry//pkg/name",
         "@com_github_malt3_go_containerregistry//pkg/v1:pkg",
         "@com_github_malt3_go_containerregistry//pkg/v1/remote",
+        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/img_tool/pkg/push/push.go
+++ b/img_tool/pkg/push/push.go
@@ -6,34 +6,43 @@ import (
 	"fmt"
 	"slices"
 	"sort"
-	"sync"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/malt3/go-containerregistry/pkg/name"
 	registryv1 "github.com/malt3/go-containerregistry/pkg/v1"
 	"github.com/malt3/go-containerregistry/pkg/v1/remote"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
-	"github.com/bazel-contrib/rules_img/img_tool/pkg/progress"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/proto/blobcache"
 	blobcache_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/blobcache"
 	remoteexecution_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/remote-apis/build/bazel/remote/execution/v2"
 )
 
+const defaultJobs = 16
+
 type builder struct {
 	blobcacheClient    blobcache.BlobsClient
 	vfs                vfs
+	pusher             *remote.Pusher
 	overrideRegistry   string
 	overrideRepository string
 	extraTags          []string
 	remoteOptions      []remote.Option
+	jobs               int
 }
 
 func NewBuilder(vfs vfs) *builder {
-	return &builder{vfs: vfs}
+	return &builder{vfs: vfs, jobs: defaultJobs}
 }
 
 func (b *builder) WithBlobcacheClient(client blobcache.BlobsClient) *builder {
 	b.blobcacheClient = client
+	return b
+}
+
+func (b *builder) WithPusher(p *remote.Pusher) *builder {
+	b.pusher = p
 	return b
 }
 
@@ -57,24 +66,35 @@ func (b *builder) WithRemoteOptions(opts ...remote.Option) *builder {
 	return b
 }
 
+func (b *builder) WithJobs(jobs int) *builder {
+	if jobs > 0 {
+		b.jobs = jobs
+	}
+	return b
+}
+
 func (b *builder) Build() *uploader {
 	return &uploader{
 		blobcacheClient:    b.blobcacheClient,
 		vfs:                b.vfs,
+		pusher:             b.pusher,
 		overrideRegistry:   b.overrideRegistry,
 		overrideRepository: b.overrideRepository,
 		extraTags:          b.extraTags,
 		remoteOptions:      b.remoteOptions,
+		jobs:               b.jobs,
 	}
 }
 
 type uploader struct {
 	blobcacheClient    blobcache.BlobsClient
 	vfs                vfs
+	pusher             *remote.Pusher
 	overrideRegistry   string
 	overrideRepository string
 	extraTags          []string
 	remoteOptions      []remote.Option
+	jobs               int
 }
 
 func (u *uploader) PushAll(ctx context.Context, ops []api.IndexedPushDeployOperation, strategy string) (tags []string, retErr error) {
@@ -84,7 +104,12 @@ func (u *uploader) PushAll(ctx context.Context, ops []api.IndexedPushDeployOpera
 	if err := u.strategyPreHooks(ctx, ops, strategy); err != nil {
 		return nil, err
 	}
-	todo := make(map[name.Reference]remote.Taggable)
+
+	type pushItem struct {
+		ref      name.Reference
+		taggable remote.Taggable
+	}
+	var items []pushItem
 	var allTags []string
 
 	// collect all operations
@@ -102,46 +127,39 @@ func (u *uploader) PushAll(ctx context.Context, ops []api.IndexedPushDeployOpera
 			return nil, err
 		}
 		for _, ref := range refs {
-			todo[ref] = taggable
-		}
-		for _, ref := range refs {
+			items = append(items, pushItem{ref: ref, taggable: taggable})
 			allTags = append(allTags, ref.String())
 		}
 	}
 
-	// Setup progress tracking if possible
-	ctx, stopProgress := progress.InitProgress(ctx, "push complete")
-
-	prog := progress.NewIndeterminate(ctx, "pushing")
-	progCh := make(chan registryv1.Update, 16) // buffer so we don't block writes
-
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	defer wg.Wait()
-	go func() {
-		defer wg.Done()
-		defer stopProgress()
+	pusher := u.pusher
+	if pusher == nil {
 		var err error
-		for update := range progCh {
-			prog.SetTotal(update.Total)
-			prog.SetComplete(update.Complete)
-			if update.Error != nil {
-				err = update.Error
-			}
+		pusher, err = remote.NewPusher(append(u.remoteOptions, remote.WithJobs(u.jobs))...)
+		if err != nil {
+			return nil, fmt.Errorf("creating pusher: %w", err)
 		}
-		prog.Done(err)
-	}()
+	}
 
-	// push all collected tags in parallel
-	opts := append(u.remoteOptions, remote.WithProgress(progCh))
-	return allTags, remote.MultiWrite(todo, opts...)
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(u.jobs)
+
+	for _, item := range items {
+		item := item
+		g.Go(func() error {
+			return pusher.Push(ctx, item.ref, item.taggable)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return allTags, nil
 }
 
 // tags returns the list of tags to push for the given operation, applying any overrides and extra tags.
 func (u *uploader) tags(op api.IndexedPushDeployOperation) ([]name.Reference, error) {
-	// base reference:
-	// - registry
-	// - repository
 	registry := op.Registry
 	if u.overrideRegistry != "" {
 		registry = u.overrideRegistry
@@ -225,17 +243,12 @@ type vfs interface {
 	SizeOf(digest registryv1.Hash) (int64, error)
 }
 
-// deduplicateAndSort removes duplicates and sorts a slice of strings
 func deduplicateAndSort(tags []string) []string {
 	if len(tags) == 0 {
 		return tags
 	}
-
-	// Sort first, then compact to remove consecutive duplicates
 	sort.Strings(tags)
 	tags = slices.Compact(tags)
-
-	// Remove empty tags
 	var outTags []string
 	for _, tag := range tags {
 		if tag != "" {


### PR DESCRIPTION
Refactor the deploy command to support multiple blob sources and operational modes:

- VFS now resolves blobs from OCI layouts (sparse or standard), explicit layer files, runfiles, registry, and CAS in priority order
- Add --oci-layout flag (repeatable) to provide OCI layout directories as blob sources; supports both sparse and standard formats
- Add --layer flag (repeatable, digest=path) for explicit layer blobs
- Allow multiple --request-file flags with manifest merging
- Add --persistent_worker mode implementing Bazel's persistent worker protocol with a long-lived pusher for connection reuse
- Replace remote.MultiWrite with a persistent pusher and semaphore- based parallel pushes (errgroup with configurable limit)
- Add --jobs flag (default 16, global only) to control parallelism for both the push errgroup and go-containerregistry internals
- Make img_deploy_tool rule executable so targets can be invoked with bazel run
- Add deploy_manifest output group to image_manifest and image_index when deploy specs are configured