### PR TITLE
fix: restore docker config priority over google keychain

### DIFF
--- a/img_tool/pkg/auth/registry/registry.go
+++ b/img_tool/pkg/auth/registry/registry.go
@@ -31,8 +31,8 @@ func WithAuthFromMultiKeychain() remote.Option {
 
 	keychains = append(
 		keychains,
-		namedKeychain("google", google.Keychain, debug),
 		namedKeychain("docker config", authn.DefaultKeychain, debug),
+		namedKeychain("google", google.Keychain, debug),
 	)
 
 	kc := authn.NewMultiKeychain(keychains...)

--- a/pull_tool/pkg/auth/registry/registry.go
+++ b/pull_tool/pkg/auth/registry/registry.go
@@ -31,8 +31,8 @@ func WithAuthFromMultiKeychain() remote.Option {
 
 	keychains = append(
 		keychains,
-		namedKeychain("google", google.Keychain, debug),
 		namedKeychain("docker config", authn.DefaultKeychain, debug),
+		namedKeychain("google", google.Keychain, debug),
 	)
 
 	kc := authn.NewMultiKeychain(keychains...)


### PR DESCRIPTION
#519 accidentally reversed the credential helper order. Docker config should take priority over the Google keychain so that explicit docker config auth is respected even when running in GKE.

Closes #525