### PR TITLE
image_load: Use "{daemon} image load" instead of alias

### DIFF
--- a/img_tool/pkg/docker/load.go
+++ b/img_tool/pkg/docker/load.go
@@ -36,7 +36,7 @@ func loadWithBinary(tarReader io.Reader, loaderBinary string) error {
 
 	fmt.Fprintf(os.Stderr, "Using %s as loader binary\n", loaderBinary)
 
-	cmd := exec.Command(loaderBinary, "load")
+	cmd := exec.Command(loaderBinary, "image", "load")
 	cmd.Stdin = tarReader
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Before, the image load command would load images
using the alias "docker load". Some container runtimes do not have that alias and require the use of the "image load" command.