### PR TITLE
image_load: add image tags to OCI tarball

### DIFF
--- a/img_tool/cmd/dockersave/BUILD.bazel
+++ b/img_tool/cmd/dockersave/BUILD.bazel
@@ -10,6 +10,9 @@ go_library(
     importpath = "github.com/bazel-contrib/rules_img/img_tool/cmd/dockersave",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/api",
+        "@com_github_malt3_go_containerregistry//pkg/name",
         "@com_github_malt3_go_containerregistry//pkg/v1:pkg",
+        "@com_github_malt3_go_containerregistry//pkg/v1/types",
     ],
 )

--- a/img_tool/cmd/dockersave/dockersave.go
+++ b/img_tool/cmd/dockersave/dockersave.go
@@ -6,12 +6,18 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	v1 "github.com/malt3/go-containerregistry/pkg/v1"
+	"github.com/malt3/go-containerregistry/pkg/v1/types"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+
+	"github.com/malt3/go-containerregistry/pkg/name"
 )
 
 type blobMap map[string]string // digest -> source path
@@ -165,7 +171,12 @@ func DockerSaveProcess(ctx context.Context, args []string) {
 		}
 	}
 
-	// Default repo tag if none provided from either flags or config
+	// ociTags are the user-provided tags used for OCI index.json annotations.
+	// They may be empty if no tags were specified.
+	ociTags := []string(repoTags)
+
+	// Default repo tag if none provided from either flags or config.
+	// This default is only used for Docker's manifest.json RepoTags.
 	if len(repoTags) == 0 {
 		repoTags = []string{"image:latest"}
 	}
@@ -185,7 +196,7 @@ func DockerSaveProcess(ctx context.Context, args []string) {
 			fmt.Fprintf(os.Stderr, "Error: --index requires at least one --manifest-path and --config-path\n")
 			os.Exit(1)
 		}
-		err = assembleDockerSaveWithIndex(indexPath, outputPath, format, manifestPaths, configPaths, layerFlags, repoTags, useSymlinks, allowMissingBlobs)
+		err = assembleDockerSaveWithIndex(indexPath, outputPath, format, manifestPaths, configPaths, layerFlags, repoTags, ociTags, useSymlinks, allowMissingBlobs)
 	} else {
 		// Single manifest mode
 		if manifestPath == "" {
@@ -202,7 +213,7 @@ func DockerSaveProcess(ctx context.Context, args []string) {
 			fmt.Fprintf(os.Stderr, "Error: cannot use --manifest-path or --config-path without --index\n")
 			os.Exit(1)
 		}
-		err = assembleDockerSave(manifestPath, configPath, outputPath, format, layerFlags, repoTags, useSymlinks, allowMissingBlobs)
+		err = assembleDockerSave(manifestPath, configPath, outputPath, format, layerFlags, repoTags, ociTags, useSymlinks, allowMissingBlobs)
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -222,7 +233,60 @@ func createSink(outputPath, format string) (DockerSaveSink, error) {
 	}
 }
 
-func assembleDockerSave(manifestPath, configPath, outputPath, format string, layers layerMappingFlag, repoTags []string, useSymlinks, allowMissingBlobs bool) error {
+// descriptorsForTags generates descriptors for the given image manifest and tags.
+// Tooling that ingests OCI layouts (containerd loading, docker image load, container load, ...)
+// can recover image names from the descriptors of the root index.json file based on some well-known annotations:
+//   - Containerd uses "io.containerd.image.name" to refer to the full image name (<registry>/<repository>:<tag>)
+//   - Apple Containerization uses "com.apple.containerization.image.name" to refer to the full image name (<registry>/<repository>:<tag>)
+//   - The OCI image spec mentions "org.opencontainers.image.ref.name" to refer to the tag only (i.e. "latest")
+//
+// Note that the "org.opencontainers.image.ref.name" may not be unique within the index.json file.
+// This is surprising, but allowed by the OCI image spec. Other tools also generate duplicate ref.name attributes.
+// Tooling that consumes the index and needs to select images based on tags SHOULD select the first matching manifest.
+// See also this upstream discussion: https://github.com/opencontainers/image-spec/issues/581
+//
+// Annotations from the referenced content (data) are copied into the produced descriptors.
+// Tag annotations take precedence over content annotations.
+func descriptorsForTags(ociTags []string, mediaType types.MediaType, data []byte, digest v1.Hash, artifactType string) []v1.Descriptor {
+	size := int64(len(data))
+
+	var parsed struct {
+		Annotations map[string]string `json:"annotations,omitempty"`
+	}
+	json.Unmarshal(data, &parsed)
+
+	if len(ociTags) == 0 {
+		desc := v1.Descriptor{MediaType: mediaType, Digest: digest, Size: size, Annotations: parsed.Annotations}
+		if artifactType != "" {
+			desc.ArtifactType = artifactType
+		}
+		return []v1.Descriptor{desc}
+	}
+
+	descs := make([]v1.Descriptor, 0, len(ociTags))
+	for _, repoTag := range ociTags {
+		annotations := make(map[string]string)
+		maps.Copy(annotations, parsed.Annotations)
+		annotations[api.AnnotationContainerdImageName] = repoTag
+		annotations[api.AnnotationAppleContainerizationImageName] = repoTag
+		if ref, err := name.NewTag(repoTag, name.WithDefaultTag("")); err == nil && ref.TagStr() != "" {
+			annotations[api.AnnotationOCIImageRefName] = ref.TagStr()
+		}
+		desc := v1.Descriptor{
+			MediaType:   mediaType,
+			Digest:      digest,
+			Size:        size,
+			Annotations: annotations,
+		}
+		if artifactType != "" {
+			desc.ArtifactType = artifactType
+		}
+		descs = append(descs, desc)
+	}
+	return descs
+}
+
+func assembleDockerSave(manifestPath, configPath, outputPath, format string, layers layerMappingFlag, repoTags, ociTags []string, useSymlinks, allowMissingBlobs bool) error {
 	sink, err := createSink(outputPath, format)
 	if err != nil {
 		return err
@@ -300,19 +364,15 @@ func assembleDockerSave(manifestPath, configPath, outputPath, format string, lay
 	}
 
 	// Write OCI index.json pointing to the manifest
-	indexDesc := v1.Descriptor{
-		MediaType:   manifest.MediaType,
-		Digest:      manifestDigest,
-		Size:        int64(len(manifestData)),
-		Annotations: manifest.Annotations,
-	}
+	var artifactType string
 	if manifest.Config.MediaType != "" && !manifest.Config.MediaType.IsConfig() {
-		indexDesc.ArtifactType = string(manifest.Config.MediaType)
+		artifactType = string(manifest.Config.MediaType)
 	}
+	manifests := descriptorsForTags(ociTags, manifest.MediaType, manifestData, manifestDigest, artifactType)
 	ociIndex := v1.IndexManifest{
 		SchemaVersion: 2,
 		MediaType:     "application/vnd.oci.image.index.v1+json",
-		Manifests:     []v1.Descriptor{indexDesc},
+		Manifests:     manifests,
 	}
 	if err := writeJSONWithSink(sink, "index.json", ociIndex); err != nil {
 		return fmt.Errorf("writing index.json: %w", err)
@@ -365,7 +425,7 @@ func copyBlobs(sink DockerSaveSink, blobs blobMap, useSymlinks bool) error {
 	return nil
 }
 
-func assembleDockerSaveWithIndex(indexPath, outputPath, format string, manifestPaths, configPaths []string, layers layerMappingFlag, repoTags []string, useSymlinks, allowMissingBlobs bool) error {
+func assembleDockerSaveWithIndex(indexPath, outputPath, format string, manifestPaths, configPaths []string, layers layerMappingFlag, repoTags, ociTags []string, useSymlinks, allowMissingBlobs bool) error {
 	sink, err := createSink(outputPath, format)
 	if err != nil {
 		return err
@@ -448,9 +508,23 @@ func assembleDockerSaveWithIndex(indexPath, outputPath, format string, manifestP
 		return fmt.Errorf("writing oci-layout: %w", err)
 	}
 
-	// Copy pre-built index.json (already generated by Bazel)
-	if err := sink.CopyFile("index.json", indexPath, false); err != nil {
-		return fmt.Errorf("copying index file: %w", err)
+	// Read the pre-built index to store as a blob and wrap in a new root index
+	indexData, err := os.ReadFile(indexPath)
+	if err != nil {
+		return fmt.Errorf("reading index file: %w", err)
+	}
+	indexDigest := hashBytes(indexData)
+	blobs[indexDigest.Hex] = indexPath
+
+	// Write new root index.json referencing the pre-built index blob
+	manifests := descriptorsForTags(ociTags, types.OCIImageIndex, indexData, indexDigest, "")
+	rootIndex := v1.IndexManifest{
+		SchemaVersion: 2,
+		MediaType:     "application/vnd.oci.image.index.v1+json",
+		Manifests:     manifests,
+	}
+	if err := writeJSONWithSink(sink, "index.json", rootIndex); err != nil {
+		return fmt.Errorf("writing index.json: %w", err)
 	}
 
 	// Build Docker manifest.json from the FIRST manifest (the "default" for docker load)

--- a/img_tool/pkg/api/api.go
+++ b/img_tool/pkg/api/api.go
@@ -106,6 +106,22 @@ type TarAppender interface {
 }
 
 const (
+	// AnnotationContainerdImageName is the annotation used by containerd to store the full
+	// image reference (<registry>/<repository>:<tag>) in an OCI image index descriptor.
+	// See https://github.com/containerd/containerd/blob/main/core/images/image.go
+	AnnotationContainerdImageName = "io.containerd.image.name"
+
+	// AnnotationAppleContainerizationImageName is the annotation used by Apple's Containerization
+	// framework to store the full image reference (<registry>/<repository>:<tag>) in an OCI
+	// image index descriptor.
+	AnnotationAppleContainerizationImageName = "com.apple.containerization.image.name"
+
+	// AnnotationOCIImageRefName is the annotation defined by the OCI image spec to store the
+	// tag component of an image reference (e.g. "latest") in an OCI image index descriptor.
+	// Note that this value may not be unique within the index.
+	// See https://github.com/opencontainers/image-spec/blob/main/annotations.md
+	AnnotationOCIImageRefName = "org.opencontainers.image.ref.name"
+
 	// TocDigestAnnotation is the annotation key for the TOC digest in estargz layers
 	TocDigestAnnotation = "containerd.io/snapshot/stargz/toc.digest"
 	// UncompressedSizeAnnotation is the annotation key for the uncompressed size in estargz layers

--- a/tests/img_toolchain/testcases/dockersave_index_directory.ini
+++ b/tests/img_toolchain/testcases/dockersave_index_directory.ini
@@ -126,9 +126,10 @@ file_exists = docker-save/index.json
 file_valid_json = docker-save/oci-layout
 file_valid_json = docker-save/index.json
 file_contains = docker-save/oci-layout, "1.0.0"
-# index.json should contain both platform manifests
-file_contains = docker-save/index.json, "amd64"
-file_contains = docker-save/index.json, "arm64"
+# index.json should reference the multi-platform index blob with tag annotations
+file_contains = docker-save/index.json, "io.containerd.image.name"
+file_contains = docker-save/index.json, "my/image:latest"
+file_contains = docker-save/index.json, "application/vnd.oci.image.index.v1+json"
 # All blobs should be present: configs, layers, and manifest blobs
 file_exists = docker-save/blobs/sha256/c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1
 file_exists = docker-save/blobs/sha256/e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1
@@ -137,3 +138,5 @@ file_exists = docker-save/blobs/sha256/f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f
 # Manifest blobs
 file_exists = docker-save/blobs/sha256/0a6230c7f60edf206b84d75bddaf9135fc478abd0967329a2fdc2e4261bc9f14
 file_exists = docker-save/blobs/sha256/2883c23ecede9b60b8cc40d54f2465b08f24c3ce16bf02eefca87b0ff84058fb
+# Index blob (the original multi-platform index, now stored as a blob)
+file_exists = docker-save/blobs/sha256/ea001a26d4b5c6624535fa56f07b6478a9e48e05544c4c84e1f5aedff0dfdde4

--- a/tests/img_toolchain/testcases/dockersave_index_tar.ini
+++ b/tests/img_toolchain/testcases/dockersave_index_tar.ini
@@ -129,3 +129,5 @@ tar_entry_exists = docker-save.tar, blobs/sha256/f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f
 # Manifest blobs
 tar_entry_exists = docker-save.tar, blobs/sha256/0a6230c7f60edf206b84d75bddaf9135fc478abd0967329a2fdc2e4261bc9f14
 tar_entry_exists = docker-save.tar, blobs/sha256/2883c23ecede9b60b8cc40d54f2465b08f24c3ce16bf02eefca87b0ff84058fb
+# Index blob
+tar_entry_exists = docker-save.tar, blobs/sha256/ea001a26d4b5c6624535fa56f07b6478a9e48e05544c4c84e1f5aedff0dfdde4


### PR DESCRIPTION
Currently, the image_load rule produces a special "tarball" output group. This tarball is compatble with the old docker load format and the OCI layout format. When using the docker load format, we already correctly set the image tags so that docker can name the image upon load. For the OCI layout format, the image name wasn't set. With this change, we set annotations in the OCI layout index.json file that are understood by most tools (including docker, containerd, podman, containerization) and that contain the image name including tags.