### PR TITLE
pull: send manifest Accept headers for Bazel downloader

### DIFF
--- a/img/private/repository_rules/download.bzl
+++ b/img/private/repository_rules/download.bzl
@@ -3,6 +3,15 @@
 load("@pull_hub_repo//:defs.bzl", "tool_for_repository_os")
 load(":registry.bzl", "get_registries", "get_sources_list")
 
+_MANIFEST_ACCEPT_HEADERS = {
+    "Accept": ",".join([
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    ]),
+}
+
 def learn_digest_from_tag(rctx, *, tag, downloader, sources):
     """Learn the digest of an image from its tag by downloading manifest headers.
 
@@ -32,6 +41,7 @@ def learn_digest_from_tag(rctx, *, tag, downloader, sources):
         result = rctx.download(
             url = urls,
             output = "temp_manifest_for_digest_learning.json",
+            headers = _MANIFEST_ACCEPT_HEADERS,
         )
 
         # The digest is the SHA256 of the downloaded manifest
@@ -339,6 +349,7 @@ def download_manifest_bazel(rctx, *, reference, sha256, have_valid_digest, sourc
 
     manifest_result = rctx.download(
         url = urls,
+        headers = _MANIFEST_ACCEPT_HEADERS,
         **kwargs
     )
     if have_valid_digest and manifest_result.sha256 != sha256:


### PR DESCRIPTION
## Summary
Fixes #442

- Add OCI/Docker manifest Accept headers to Bazel-downloader manifest fetches.
- Apply the headers to both tag-to-digest resolution and manifest/index downloads.
- Leave blob downloads and the default img_tool downloader path unchanged.

## Why

`pull(..., downloader = "bazel")` currently fetches `/manifests/{reference}` via
`repository_ctx.download` without manifest negotiation headers. Strict registries
such as Harbor can reject that request even when the manifest exists.

## Testing

- `bazelisk run //util:buildifier.check` (basic)
- Temporarily added `pull(name = "alpine_bazel", downloader = "bazel", digest = ..., repository = "library/alpine")` in `e2e/generic/MODULE.bazel`; verified with `bazelisk build @alpine_bazel//:package_metadata`
- Temporarily added `pull(name = "alpine_bazel_tag", downloader = "bazel", tag = "3.23", unsafe_allow_tag_without_digest = True, repository = "library/alpine")`; verified with `bazelisk build @alpine_bazel_tag//:package_metadata`
- Verified existing default img_tool path with `bazelisk build @alpine//:package_metadata`
- `bazelisk test //... @rules_img_tool//... @rules_img_pull_tool//... --test_output=errors`


e.g. in `e2e/generic/MODULE.bazel`
```
pull(
    name = "alpine_bazel",
    digest = "sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375",
    downloader = "bazel",
    layer_handling = "lazy",
    registries = [
        "mirror.gcr.io",
        "index.docker.io",
    ],
    repository = "library/alpine",
    tag = "3.23",
)
```

from `e2e/generic`
run `bazelisk build @alpine_bazel//:package_metadata`

got 
```
Target @@+pull+alpine_bazel//:package_metadata up-to-date:
  bazel-bin/external/+pull+alpine_bazel/package_metadata.package-metadata.json
INFO: Build completed successfully, 1 total action
```

also -
```
pull(
    name = "alpine_bazel_tag",
    downloader = "bazel",
    layer_handling = "lazy",
    registries = [
        "mirror.gcr.io",
        "index.docker.io",
    ],
    repository = "library/alpine",
    tag = "3.23",
    unsafe_allow_tag_without_digest = True,
)
```
run `bazelisk build @alpine_bazel_tag//:package_metadata`
->
```
Target @@+pull+alpine_bazel_tag//:package_metadata up-to-date:
  bazel-bin/external/+pull+alpine_bazel_tag/package_metadata.package-metadata.json
INFO: Build completed successfully, 1 total action
```