### PR TITLE
resolve %workspace% for finding the credential helper

### DIFF
--- a/img_tool/pkg/auth/credential/credentialhelper.go
+++ b/img_tool/pkg/auth/credential/credentialhelper.go
@@ -36,9 +36,12 @@ type externalCredentialHelper struct {
 }
 
 func New(credentialHelperBinary string, opts *Options) Helper {
-	workingDirectory := os.Getenv("BUILD_WORKSPACE_DIRECTORY")
-	if workingDirectory != "" {
-		credentialHelperBinary = strings.Replace(credentialHelperBinary, "%workspace%", workingDirectory, 1)
+	if strings.Contains(credentialHelperBinary, "%workspace%") {
+		if workingDirectory := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); workingDirectory != "" {
+			credentialHelperBinary = strings.ReplaceAll(credentialHelperBinary, "%workspace%", workingDirectory)
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: credential helper path %q contains %%workspace%% but BUILD_WORKSPACE_DIRECTORY is not set; leaving the placeholder unresolved\n", credentialHelperBinary)
+		}
 	}
 	var captureStderr bool
 	if opts != nil {

--- a/img_tool/pkg/auth/credential/credentialhelper_test.go
+++ b/img_tool/pkg/auth/credential/credentialhelper_test.go
@@ -42,6 +42,30 @@ func TestNew_WithoutWorkspacePlaceholder(t *testing.T) {
 	}
 }
 
+func TestNew_WorkspacePlaceholderWithoutEnv(t *testing.T) {
+	orig, hadOrig := os.LookupEnv("BUILD_WORKSPACE_DIRECTORY")
+	defer func() {
+		if hadOrig {
+			os.Setenv("BUILD_WORKSPACE_DIRECTORY", orig)
+		} else {
+			os.Unsetenv("BUILD_WORKSPACE_DIRECTORY")
+		}
+	}()
+	os.Unsetenv("BUILD_WORKSPACE_DIRECTORY")
+
+	helper := New("%workspace%/bin/helper", nil)
+	extHelper, ok := helper.(*externalCredentialHelper)
+	if !ok {
+		t.Fatalf("expected *externalCredentialHelper, got %T", helper)
+	}
+	// Without BUILD_WORKSPACE_DIRECTORY, the placeholder is left unresolved
+	// (and a warning is printed to stderr).
+	expected := "%workspace%/bin/helper"
+	if extHelper.helperBinary != expected {
+		t.Errorf("expected helperBinary to be %q, got %q", expected, extHelper.helperBinary)
+	}
+}
+
 type TestHelper struct {
 	Headers map[string][]string
 }


### PR DESCRIPTION
Resolve %workspace% in the credential helper path against $BUILD_WORKSPACE_DIRECTORY (now ReplaceAll, matching Bazel). When the placeholder is present but the env var is unset, print a warning and leave the placeholder unresolved instead of silently dropping the substitution.

Fixes #572