### PR TITLE
Use a param file for multi_deploy merge inputs

### DIFF
--- a/img/private/multi_deploy.bzl
+++ b/img/private/multi_deploy.bzl
@@ -47,26 +47,26 @@ def _compute_multi_deploy_metadata(*, ctx):
             inputs.append(deploy_info.layer_hints)
 
     # Create the merge command
-    args = ctx.actions.args()
-    args.add("deploy-merge")
-    args.add("--push-strategy", _multi_deploy_strategy(ctx, "push"))
-    args.add("--load-strategy", _multi_deploy_strategy(ctx, "load"))
+    merge_args = ctx.actions.args()
+    merge_args.add("--push-strategy", _multi_deploy_strategy(ctx, "push"))
+    merge_args.add("--load-strategy", _multi_deploy_strategy(ctx, "load"))
 
     # Add layer hints inputs and output if any exist
     layer_hints_out = None
     if layer_hints_files:
         for layer_hints_file in layer_hints_files:
-            args.add("--layer-hints-input", layer_hints_file.path)
+            merge_args.add("--layer-hints-input", layer_hints_file)
         layer_hints_out = ctx.actions.declare_file(ctx.label.name + ".layer_hints")
-        args.add("--layer-hints-output", layer_hints_out.path)
+        merge_args.add("--layer-hints-output", layer_hints_out)
 
     # Add input deploy manifest files
-    for manifest in deploy_manifests:
-        args.add(manifest.path)
+    merge_args.add_all(deploy_manifests)
 
     # Output file
     metadata_out = ctx.actions.declare_file(ctx.label.name + ".json")
-    args.add(metadata_out.path)
+    merge_args.add(metadata_out)
+    merge_args.set_param_file_format("multiline")
+    merge_args.use_param_file("@%s", use_always = True)
 
     outputs = [metadata_out]
     if layer_hints_out != None:
@@ -77,7 +77,7 @@ def _compute_multi_deploy_metadata(*, ctx):
         inputs = inputs,
         outputs = outputs,
         executable = img_toolchain_info.tool_exe,
-        arguments = [args],
+        arguments = ["deploy-merge", merge_args],
         mnemonic = "MultiDeployMerge",
     )
     return metadata_out, layer_hints_out

--- a/img/private/multi_deploy.bzl
+++ b/img/private/multi_deploy.bzl
@@ -54,8 +54,7 @@ def _compute_multi_deploy_metadata(*, ctx):
     # Add layer hints inputs and output if any exist
     layer_hints_out = None
     if layer_hints_files:
-        for layer_hints_file in layer_hints_files:
-            merge_args.add("--layer-hints-input", layer_hints_file)
+        merge_args.add_all(layer_hints_files, before_each = "--layer-hints-input")
         layer_hints_out = ctx.actions.declare_file(ctx.label.name + ".layer_hints")
         merge_args.add("--layer-hints-output", layer_hints_out)
 

--- a/img_tool/cmd/deploymetadata/BUILD.bazel
+++ b/img_tool/cmd/deploymetadata/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "deploymetadata",
@@ -12,6 +12,14 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api",
+        "//pkg/argfile",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
     ],
+)
+
+go_test(
+    name = "deploymetadata_test",
+    srcs = ["merge_test.go"],
+    embed = [":deploymetadata"],
+    deps = ["//pkg/api"],
 )

--- a/img_tool/cmd/deploymetadata/merge.go
+++ b/img_tool/cmd/deploymetadata/merge.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/argfile"
 )
 
 var (
@@ -18,6 +19,13 @@ var (
 )
 
 func DeployMergeProcess(ctx context.Context, args []string) {
+	expandedArgs, err := argfile.Expand(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing argfile: %v\n", err)
+		os.Exit(1)
+	}
+	args = expandedArgs
+
 	flagSet := flag.NewFlagSet("deploy-merge", flag.ExitOnError)
 	flagSet.Usage = func() {
 		fmt.Fprintf(flagSet.Output(), "Merges multiple deploy manifests into a single unified deployment.\n\n")

--- a/img_tool/cmd/deploymetadata/merge_test.go
+++ b/img_tool/cmd/deploymetadata/merge_test.go
@@ -1,0 +1,97 @@
+package deploymetadata
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+)
+
+func TestDeployMergeProcessExpandsArgfile(t *testing.T) {
+	tmp := t.TempDir()
+	input1 := writeDeployManifest(t, filepath.Join(tmp, "input1.json"), "first")
+	input2 := writeDeployManifest(t, filepath.Join(tmp, "input2.json"), "second")
+	output := filepath.Join(tmp, "out.json")
+	argfile := filepath.Join(tmp, "args.params")
+
+	args := []string{
+		"--push-strategy",
+		"lazy",
+		"--load-strategy",
+		"eager",
+		input1,
+		input2,
+		output,
+	}
+	if err := os.WriteFile(argfile, []byte(strings.Join(args, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("writing argfile: %v", err)
+	}
+
+	DeployMergeProcess(context.Background(), []string{"@" + argfile})
+
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("reading output manifest: %v", err)
+	}
+
+	var got api.DeployManifest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshalling output manifest: %v", err)
+	}
+
+	if got.Settings.PushStrategy != "lazy" {
+		t.Errorf("PushStrategy = %q, want lazy", got.Settings.PushStrategy)
+	}
+	if got.Settings.LoadStrategy != "eager" {
+		t.Errorf("LoadStrategy = %q, want eager", got.Settings.LoadStrategy)
+	}
+
+	var commands []string
+	for _, raw := range got.Operations {
+		var op struct {
+			Command string `json:"command"`
+		}
+		if err := json.Unmarshal(raw, &op); err != nil {
+			t.Fatalf("unmarshalling operation %s: %v", raw, err)
+		}
+		commands = append(commands, op.Command)
+	}
+
+	wantCommands := []string{"first", "second"}
+	if !reflect.DeepEqual(commands, wantCommands) {
+		t.Errorf("merged commands = %v, want %v", commands, wantCommands)
+	}
+}
+
+func writeDeployManifest(t *testing.T, path string, commands ...string) string {
+	t.Helper()
+
+	manifest := api.DeployManifest{
+		Operations: make([]json.RawMessage, 0, len(commands)),
+	}
+	for _, command := range commands {
+		raw, err := json.Marshal(struct {
+			Command string `json:"command"`
+		}{
+			Command: command,
+		})
+		if err != nil {
+			t.Fatalf("marshalling operation: %v", err)
+		}
+		manifest.Operations = append(manifest.Operations, raw)
+	}
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshalling deploy manifest: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("writing deploy manifest: %v", err)
+	}
+	return path
+}

--- a/img_tool/pkg/argfile/BUILD.bazel
+++ b/img_tool/pkg/argfile/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "argfile",
+    srcs = ["argfile.go"],
+    importpath = "github.com/bazel-contrib/rules_img/img_tool/pkg/argfile",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "argfile_test",
+    srcs = ["argfile_test.go"],
+    embed = [":argfile"],
+)

--- a/img_tool/pkg/argfile/argfile.go
+++ b/img_tool/pkg/argfile/argfile.go
@@ -1,0 +1,64 @@
+package argfile
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Expand expands a single optional argfile argument (@path/to/file).
+// Argfiles use Bazel's multiline format: one argument per line.
+// Empty lines and lines starting with # are ignored.
+func Expand(args []string) ([]string, error) {
+	argfileIndex := -1
+	for i, arg := range args {
+		if strings.HasPrefix(arg, "@") {
+			if argfileIndex != -1 {
+				return nil, fmt.Errorf("multiple argfiles not supported")
+			}
+			argfileIndex = i
+		}
+	}
+
+	if argfileIndex == -1 {
+		return args, nil
+	}
+
+	argfilePath := args[argfileIndex][1:]
+	fileArgs, err := read(argfilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read argfile %s: %w", argfilePath, err)
+	}
+
+	result := make([]string, 0, len(args)-1+len(fileArgs))
+	result = append(result, args[:argfileIndex]...)
+	result = append(result, fileArgs...)
+	result = append(result, args[argfileIndex+1:]...)
+
+	return result, nil
+}
+
+func read(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var args []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		args = append(args, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return args, nil
+}

--- a/img_tool/pkg/argfile/argfile_test.go
+++ b/img_tool/pkg/argfile/argfile_test.go
@@ -1,0 +1,72 @@
+package argfile
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestExpandNoArgfile(t *testing.T) {
+	args := []string{"--flag", "value", "input.json"}
+	got, err := Expand(args)
+	if err != nil {
+		t.Fatalf("Expand(%v) returned error: %v", args, err)
+	}
+	if !reflect.DeepEqual(got, args) {
+		t.Errorf("Expand(%v) = %v, want %v", args, got, args)
+	}
+}
+
+func TestExpandOneArgfile(t *testing.T) {
+	argfilePath := writeArgfile(t, "--one\nvalue\n")
+	args := []string{"before", "@" + argfilePath, "after"}
+
+	got, err := Expand(args)
+	if err != nil {
+		t.Fatalf("Expand(%v) returned error: %v", args, err)
+	}
+
+	want := []string{"before", "--one", "value", "after"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Expand(%v) = %v, want %v", args, got, want)
+	}
+}
+
+func TestExpandMultipleArgfilesReturnsError(t *testing.T) {
+	first := writeArgfile(t, "first\n")
+	second := writeArgfile(t, "second\n")
+
+	_, err := Expand([]string{"@" + first, "@" + second})
+	if err == nil {
+		t.Fatal("Expand with multiple argfiles returned nil error")
+	}
+	if !strings.Contains(err.Error(), "multiple argfiles not supported") {
+		t.Fatalf("Expand error = %v, want multiple argfiles error", err)
+	}
+}
+
+func TestExpandIgnoresBlankAndCommentLines(t *testing.T) {
+	argfilePath := writeArgfile(t, "\n# comment\n--flag\n\nvalue\n  # another comment  \noutput.json\n")
+
+	got, err := Expand([]string{"@" + argfilePath})
+	if err != nil {
+		t.Fatalf("Expand returned error: %v", err)
+	}
+
+	want := []string{"--flag", "value", "output.json"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Expand() = %v, want %v", got, want)
+	}
+}
+
+func writeArgfile(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "args.params")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("writing argfile: %v", err)
+	}
+	return path
+}

--- a/img_tool/pkg/persistentworker/BUILD.bazel
+++ b/img_tool/pkg/persistentworker/BUILD.bazel
@@ -11,4 +11,5 @@ go_library(
     ],
     importpath = "github.com/bazel-contrib/rules_img/img_tool/pkg/persistentworker",
     visibility = ["//visibility:public"],
+    deps = ["//pkg/argfile"],
 )

--- a/img_tool/pkg/persistentworker/args.go
+++ b/img_tool/pkg/persistentworker/args.go
@@ -1,10 +1,7 @@
 package persistentworker
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-	"strings"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/argfile"
 )
 
 // ParseArgs processes command arguments by expanding argfiles and extracting
@@ -12,7 +9,7 @@ import (
 // a boolean indicating whether the persistent_worker flag was set.
 func ParseArgs(args []string) ([]string, bool, error) {
 	// Expand argfile if present
-	expandedArgs, err := expandArgfile(args)
+	expandedArgs, err := argfile.Expand(args)
 	if err != nil {
 		return nil, false, err
 	}
@@ -39,65 +36,4 @@ func extractPersistentWorkerFlag(args []string) ([]string, bool) {
 	}
 
 	return result, isPersistentWorker
-}
-
-// expandArgfile expands a single optional argfile argument (@path/to/file).
-// If an argfile is found, it reads the file and returns the arguments from it.
-// Only one argfile is supported.
-func expandArgfile(args []string) ([]string, error) {
-	argfileIndex := -1
-	for i, arg := range args {
-		if strings.HasPrefix(arg, "@") {
-			if argfileIndex != -1 {
-				return nil, fmt.Errorf("multiple argfiles not supported")
-			}
-			argfileIndex = i
-		}
-	}
-
-	// No argfile found
-	if argfileIndex == -1 {
-		return args, nil
-	}
-
-	argfilePath := args[argfileIndex][1:] // Remove @ prefix
-	fileArgs, err := readArgfile(argfilePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read argfile %s: %w", argfilePath, err)
-	}
-
-	// Build new args slice: args before argfile + fileArgs + args after argfile
-	result := make([]string, 0, len(args)-1+len(fileArgs))
-	result = append(result, args[:argfileIndex]...)
-	result = append(result, fileArgs...)
-	result = append(result, args[argfileIndex+1:]...)
-
-	return result, nil
-}
-
-// readArgfile reads arguments from a file, one per line.
-// Empty lines and lines starting with # are ignored.
-func readArgfile(path string) ([]string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	var args []string
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		// Skip empty lines and comments
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		args = append(args, line)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-
-	return args, nil
 }


### PR DESCRIPTION
Summary:
- Spill multi_deploy's deploy-merge arguments into a Bazel multiline param file.
- Expand @argfiles in img deploy-merge before flag parsing.
- Add regression coverage for deploy-merge argfile handling.

Why:
- Large multi_deploy targets can have thousands of operations.
- Passing every deploy manifest path inline can exceed OS command-line limits.
- Bazel param files are the standard way for rules to avoid long argv failures.

Notes:
- The "deploy-merge" subcommand remains inline so the img dispatcher still works.
- This follows the existing repo pattern of using Bazel Args param files for large action inputs, as seen in layer and layer_from_binary actions.
- The public Starlark API is unchanged.
- Prebuilt binaries are not patched in this PR; releases/toolchain packaging should pick up the source change normally.