### PR TITLE
image_layer: place a single file under a trailing-slash srcs key by b…

### DIFF
--- a/img_tool/cmd/layer/placement.go
+++ b/img_tool/cmd/layer/placement.go
@@ -33,9 +33,11 @@ import (
 //     an executable's extra default outputs, anchored at the executable.
 //   - "package_relative": like "relative", but if the spec resolves to exactly
 //     one file that file is placed directly at dest (the path key is the file
-//     path, not a directory).
+//     path, not a directory). If dest ends with "/" it is treated as a
+//     directory and the single file is placed inside it by basename.
 //   - "flatten": each file is placed directly under dest by basename; but if
-//     the spec resolves to exactly one file it is placed directly at dest.
+//     the spec resolves to exactly one file it is placed directly at dest
+//     (or, when dest ends with "/", inside it by basename).
 //   - dest is the normalized (no leading slash) destination directory (or, for
 //     the single-file collapse, the destination path) in the image.
 //   - anchor is the rebased short_path prefix that files are placed relative to.
@@ -144,8 +146,13 @@ func parsePlaceFilesHeader(line string) (placeFilesSpec, error) {
 // (after skips), used by the single-file collapse modes.
 func (s placeFilesSpec) place(shortPath string, count int) (string, error) {
 	// In the collapse modes, a single output is placed directly at dest (the
-	// path key is the file path, not a directory).
+	// path key is the file path, not a directory) — unless dest is a directory
+	// key (trailing slash), in which case the file is placed inside it by
+	// basename, matching the multi-file directory semantics.
 	if count == 1 && (s.Mode == "package_relative" || s.Mode == "flatten") {
+		if strings.HasSuffix(s.Dest, "/") {
+			return path.Join(s.Dest, path.Base(shortPath)), nil
+		}
 		return s.Dest, nil
 	}
 	if s.Mode == "flatten" {

--- a/tests/layering/testcases/trailing_slash/BUILD.bazel
+++ b/tests/layering/testcases/trailing_slash/BUILD.bazel
@@ -16,6 +16,12 @@ write_file(
     content = ["b\n"],
 )
 
+write_file(
+    name = "single",
+    out = "single.txt",
+    content = ["single\n"],
+)
+
 filegroup(
     name = "files",
     srcs = [
@@ -24,12 +30,15 @@ filegroup(
     ],
 )
 
-# A srcs key ending in "/" is accepted and normalized by the placement math (no
-# doubled slash); the multi-output target is placed package-relative beneath it.
+# srcs keys ending in "/" are treated as directories:
+# - a multi-output target is placed package-relative beneath the directory, with
+#   the trailing slash normalized (no doubled slash);
+# - a single file is placed inside the directory under its basename.
 image_layer(
     name = "layer",
     srcs = {
         "/opt/data/": ":files",
+        "/opt/solo/": ":single",
     },
 )
 

--- a/tests/layering/testcases/trailing_slash/expected.ndjson
+++ b/tests/layering/testcases/trailing_slash/expected.ndjson
@@ -1,2 +1,3 @@
 {"name":"opt/data/a.txt","typeflag":"0","size":2,"mode":493,"uid":0,"gid":0,"modtime":"1970-01-01T00:00:00Z","sha256":"87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7"}
 {"name":"opt/data/nested/b.txt","typeflag":"0","size":2,"mode":493,"uid":0,"gid":0,"modtime":"1970-01-01T00:00:00Z","sha256":"0263829989b6fd954f72baaf2fc64bc2e2f01d692d4de72986ea808f6e99813f"}
+{"name":"opt/solo/single.txt","typeflag":"0","size":7,"mode":493,"uid":0,"gid":0,"modtime":"1970-01-01T00:00:00Z","sha256":"f9ea4b8413f7b84383d16b6fdf36872439f9d7223623480c0eebfba0e5291ded"}


### PR DESCRIPTION
…asename

A srcs key ending in "/" denotes a directory. For a multi-output target the trailing slash was already normalized away, but a single-file src used the key verbatim as the tar entry name, which the layer tool rejected with "invalid node header: <path>/". Now a single file under a directory key is placed inside it by basename, matching the multi-file directory semantics (and layer_from_binary's trailing-slash path handling).

Extends the tests/layering/testcases/trailing_slash case to cover a single file placed at a trailing-slash key.