### PR TITLE
[codex] Log deploy push progress

### DIFF
--- a/img_tool/cmd/deploy/BUILD.bazel
+++ b/img_tool/cmd/deploy/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/deployvfs",
         "//pkg/load",
         "//pkg/persistentworker",
+        "//pkg/progress",
         "//pkg/proto/blobcache",
         "//pkg/push",
         "@com_github_google_go_containerregistry//pkg/name",

--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/deployvfs"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/load"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/persistentworker"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/progress"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/proto/blobcache"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/push"
 )
@@ -77,6 +79,10 @@ func DeployProcess(ctx context.Context, args []string) {
 
 	if flagSet.NArg() != 0 {
 		flagSet.Usage()
+		os.Exit(1)
+	}
+	if jobs <= 0 {
+		fmt.Fprintf(os.Stderr, "Error: --jobs must be greater than zero, got %d\n", jobs)
 		os.Exit(1)
 	}
 
@@ -215,10 +221,6 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 	for digest, filePath := range opts.ExplicitLayers {
 		vfsBuilder = vfsBuilder.WithExplicitLayer(digest, filePath)
 	}
-	vfs, err := vfsBuilder.Build()
-	if err != nil {
-		return fmt.Errorf("building VFS: %w", err)
-	}
 
 	pushOperations, err := req.PushOperations()
 	if err != nil {
@@ -234,6 +236,12 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 	}
 	if len(pushOperations) == 0 && len(loadOperations) == 0 && len(registryTagOperations) == 0 {
 		return fmt.Errorf("no push, load, or registry_tag operations found in deploy manifest")
+	}
+	logDeployConfig(req, opts, len(pushOperations), len(loadOperations), len(registryTagOperations))
+
+	vfs, err := vfsBuilder.Build()
+	if err != nil {
+		return fmt.Errorf("building VFS: %w", err)
 	}
 
 	// check if any operation requires a blob cache endpoint
@@ -257,7 +265,14 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 	var pusher *remote.Pusher
 	needsPusher := len(pushOperations) > 0 || len(registryTagOperations) > 0
 	if needsPusher && req.Settings.PushStrategy != "bes" {
-		pusher, err = remote.NewPusher(registry.WithAuthFromMultiKeychain(), remote.WithJobs(opts.Jobs))
+		remoteOptions := []remote.Option{registry.WithAuthFromMultiKeychain(), remote.WithJobs(opts.Jobs)}
+		progressUpdates, stopProgressLogger := progress.StartLogger(pushProgressLogInterval, "push")
+		defer stopProgressLogger()
+		if progressUpdates != nil {
+			remoteOptions = append(remoteOptions, remote.WithProgress(progressUpdates))
+		}
+
+		pusher, err = remote.NewPusher(remoteOptions...)
 		if err != nil {
 			return fmt.Errorf("creating pusher: %w", err)
 		}
@@ -335,6 +350,21 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 	}
 
 	return nil
+}
+
+const pushProgressLogInterval = time.Minute
+
+func logDeployConfig(req api.DeployManifest, opts DeployOptions, pushOps int, loadOps int, registryTagOps int) {
+	fmt.Fprintf(os.Stderr, "deploy config: jobs=%d push_strategy=%s load_strategy=%s push_ops=%d load_ops=%d registry_tag_ops=%d\n", opts.Jobs, req.Settings.PushStrategy, req.Settings.LoadStrategy, pushOps, loadOps, registryTagOps)
+	if opts.OverrideRegistry != "" {
+		fmt.Fprintf(os.Stderr, "deploy config: override_registry=%s\n", opts.OverrideRegistry)
+	}
+	if opts.OverrideRepository != "" {
+		fmt.Fprintf(os.Stderr, "deploy config: override_repository=%s\n", opts.OverrideRepository)
+	}
+	if len(opts.AdditionalTags) > 0 {
+		fmt.Fprintf(os.Stderr, "deploy config: additional_tags=%s\n", strings.Join(opts.AdditionalTags, ","))
+	}
 }
 
 // applyRegistryTagOperations writes the pre-expanded tags from registry_tag

--- a/img_tool/pkg/progress/BUILD.bazel
+++ b/img_tool/pkg/progress/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/bazel-contrib/rules_img/img_tool/pkg/progress",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_jedib0t_go_pretty_v6//progress",
         "@org_golang_x_term//:term",
     ],

--- a/img_tool/pkg/progress/progress.go
+++ b/img_tool/pkg/progress/progress.go
@@ -3,11 +3,13 @@ package progress
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"sync"
 	"time"
 
+	registryv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/jedib0t/go-pretty/v6/progress"
 	"golang.org/x/term"
 )
@@ -276,17 +278,170 @@ func NewIndeterminate(ctx context.Context, message string) *Indeterminate {
 	return &Indeterminate{tracker: tracker}
 }
 
+// StartLogger emits progress updates according to the active output mode:
+// no output when progress is disabled by environment, progress bars on TTYs,
+// and throttled line-oriented logs for non-interactive outputs such as CI.
+func StartLogger(interval time.Duration, prefix string) (chan<- registryv1.Update, func()) {
+	if progressDisabled() {
+		return nil, func() {}
+	}
+
+	updates := make(chan registryv1.Update, 1024)
+	if stderrIsTerminal() {
+		return updates, startBarLogger(updates, prefix)
+	}
+	return updates, startPlainLogger(updates, interval, prefix)
+}
+
+func startBarLogger(updates chan registryv1.Update, prefix string) func() {
+	pw := progress.NewWriter()
+	pw.SetAutoStop(false)
+
+	style := progress.StyleDefault
+	style.Visibility.Time = false
+	style.Visibility.Percentage = true
+	style.Visibility.Speed = true
+	style.Visibility.Tracker = true
+	style.Visibility.Value = true
+	style.Options.DoneString = "complete"
+	pw.SetStyle(style)
+
+	pw.SetTrackerLength(60)
+	pw.SetTrackerPosition(progress.PositionRight)
+	pw.SetUpdateFrequency(100 * time.Millisecond)
+	pw.SetOutputWriter(os.Stderr)
+
+	tracker := &progress.Tracker{
+		Message: prefix,
+		Units:   progress.UnitsBytes,
+	}
+	pw.AppendTracker(tracker)
+	go pw.Render()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for update := range updates {
+			if update.Error != nil {
+				tracker.MarkAsErrored()
+				continue
+			}
+			if update.Total > 0 {
+				tracker.UpdateTotal(update.Total)
+			}
+			tracker.SetValue(update.Complete)
+		}
+		tracker.MarkAsDone()
+		pw.Stop()
+		time.Sleep(110 * time.Millisecond)
+	}()
+
+	return func() {
+		close(updates)
+		<-done
+	}
+}
+
+func startPlainLogger(updates chan registryv1.Update, interval time.Duration, prefix string) func() {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		var latest registryv1.Update
+		haveLatest := false
+		var lastLoggedComplete int64 = -1
+		var lastLoggedTotal int64 = -1
+
+		logLatest := func(final bool) {
+			if !haveLatest {
+				return
+			}
+			if latest.Complete == lastLoggedComplete && latest.Total == lastLoggedTotal && !final {
+				return
+			}
+			lastLoggedComplete = latest.Complete
+			lastLoggedTotal = latest.Total
+
+			status := "progress"
+			if final {
+				status = "complete"
+			}
+			if latest.Total > 0 {
+				percent := float64(latest.Complete) * 100 / float64(latest.Total)
+				fmt.Fprintf(os.Stderr, "%s %s: %s/%s (%.1f%%)\n", prefix, status, formatByteCount(latest.Complete), formatByteCount(latest.Total), percent)
+				return
+			}
+			fmt.Fprintf(os.Stderr, "%s %s: %s transferred\n", prefix, status, formatByteCount(latest.Complete))
+		}
+
+		for {
+			select {
+			case update, ok := <-updates:
+				if !ok {
+					logLatest(true)
+					return
+				}
+				if update.Error != nil {
+					fmt.Fprintf(os.Stderr, "%s progress error: %v\n", prefix, update.Error)
+					continue
+				}
+				latest = update
+				haveLatest = true
+			case <-ticker.C:
+				logLatest(false)
+			}
+		}
+	}()
+	return func() {
+		close(updates)
+		<-done
+	}
+}
+
 var noProgressEnvVars = []string{
 	"NO_PROGRESS",
 	"NO_INTERACTIVE",
 	"NO_COLOR",
 }
 
-var wantProgressBar = sync.OnceValue(func() bool {
+var progressDisabled = sync.OnceValue(func() bool {
 	for _, envVar := range noProgressEnvVars {
 		if _, exists := os.LookupEnv(envVar); exists {
-			return false
+			return true
 		}
 	}
+	return false
+})
+
+var stderrIsTerminal = sync.OnceValue(func() bool {
 	return term.IsTerminal(int(os.Stderr.Fd()))
 })
+
+var wantProgressBar = sync.OnceValue(func() bool {
+	return !progressDisabled() && stderrIsTerminal()
+})
+
+var wantPlainProgress = sync.OnceValue(func() bool {
+	return !progressDisabled() && !stderrIsTerminal()
+})
+
+func WantPlainProgress() bool {
+	return wantPlainProgress()
+}
+
+func formatByteCount(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div := int64(unit)
+	exp := 0
+	for n := bytes / unit; n >= unit && exp < len("KMGTPE")-1; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/img_tool/pkg/push/BUILD.bazel
+++ b/img_tool/pkg/push/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api",
+        "//pkg/progress",
         "//pkg/proto/blobcache",
         "//pkg/proto/remote-apis/build/bazel/remote/execution/v2",
         "@com_github_google_go_containerregistry//pkg/name",

--- a/img_tool/pkg/push/push.go
+++ b/img_tool/pkg/push/push.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"sort"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/progress"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/proto/blobcache"
 	blobcache_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/blobcache"
 	remoteexecution_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/remote-apis/build/bazel/remote/execution/v2"
@@ -24,7 +26,7 @@ const defaultJobs = 16
 type builder struct {
 	blobcacheClient    blobcache.BlobsClient
 	vfs                vfs
-	pusher             *remote.Pusher
+	pusher             pusher
 	overrideRegistry   string
 	overrideRepository string
 	extraTags          []string
@@ -89,7 +91,7 @@ func (b *builder) Build() *uploader {
 type uploader struct {
 	blobcacheClient    blobcache.BlobsClient
 	vfs                vfs
-	pusher             *remote.Pusher
+	pusher             pusher
 	overrideRegistry   string
 	overrideRepository string
 	extraTags          []string
@@ -144,15 +146,25 @@ func (u *uploader) PushAll(ctx context.Context, ops []api.IndexedPushDeployOpera
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(u.jobs)
 
+	logPlainProgress := progress.WantPlainProgress()
+	if logPlainProgress {
+		fmt.Fprintf(os.Stderr, "push: starting %d refs with jobs=%d\n", len(items), u.jobs)
+	}
 	for _, item := range items {
 		item := item
 		g.Go(func() error {
-			return pusher.Push(ctx, item.ref, item.taggable)
+			if err := pusher.Push(ctx, item.ref, item.taggable); err != nil {
+				return fmt.Errorf("pushing %s: %w", item.ref.String(), err)
+			}
+			return nil
 		})
 	}
 
 	if err := g.Wait(); err != nil {
 		return nil, err
+	}
+	if logPlainProgress {
+		fmt.Fprintf(os.Stderr, "push: completed %d refs\n", len(items))
 	}
 
 	return allTags, nil
@@ -241,6 +253,10 @@ type vfs interface {
 	Taggable(digest registryv1.Hash) (remote.Taggable, error)
 	Digests() ([]registryv1.Hash, error)
 	SizeOf(digest registryv1.Hash) (int64, error)
+}
+
+type pusher interface {
+	Push(context.Context, name.Reference, remote.Taggable) error
 }
 
 func deduplicateAndSort(tags []string) []string {


### PR DESCRIPTION
## Summary
- print the effective deploy runtime configuration, including `--jobs`, push/load strategies, and operation counts
- route registry push progress through `pkg/progress` so it follows the existing progress policy
- use progress bars on TTYs and throttled aggregate line logs for non-TTY CI/Bazel output
- keep aggregate push start/completion logs in the non-TTY plain-progress path without per-ref start/completed chatter

## Why
Large multi-deploy pushes can be quiet for a long time while blobs transfer, which makes it hard to tell whether the binary is running with the expected concurrency or making progress. The existing progress package already handles TTY progress bars well; this extends that same package to provide a CI-friendly fallback when stderr is not a TTY.

## Progress Behavior
- If `NO_PROGRESS`, `NO_INTERACTIVE`, or `NO_COLOR` is set, no registry push progress channel is attached and no push progress output is emitted.
- If stderr is connected to a TTY, `pkg/progress` renders a progress bar for registry push bytes.
- If progress is enabled but stderr is not a TTY, `pkg/progress` emits throttled, line-oriented stderr logs once per minute plus a final completion line.

## Progress Output Examples
These examples focus on progress output. Normal deploy output such as the deploy config line, blob transfer stats, and pushed refs/tags is otherwise unchanged.

### 1. Progress disabled by env var
For example, when `NO_PROGRESS=1`, `NO_INTERACTIVE=1`, or `NO_COLOR=1` is set:

```text
<no progress output>
```

### 2. Connected to a TTY
The existing progress bar path is used, so the terminal updates a single progress line frequently:

```text
push   4.2 GiB / 18.7 GiB [==========>---------------------------------------]
```

That same line continues updating in place until complete:

```text
push   18.7 GiB / 18.7 GiB [================================================] complete
```

### 3. Progress enabled, non-TTY output
For CI/Bazel logs, the output is intentionally aggregate and line-oriented:

```text
deploy config: jobs=64 push_strategy=lazy load_strategy=eager push_ops=1000 load_ops=0 registry_tag_ops=0
push: starting 2200 refs with jobs=64
push progress: 4.2 GiB/18.7 GiB (22.5%)
push progress: 9.8 GiB/18.7 GiB (52.4%)
push complete: 18.7 GiB/18.7 GiB (100.0%)
push: completed 2200 refs
```

stdout remains reserved for the pushed refs/tags, for example:

```text
registry.example.com/repo/image@sha256:...
registry.example.com/repo/image:latest
```

## Validation
- `bazel test @rules_img_tool//cmd/deploy:all @rules_img_tool//pkg/push:all @rules_img_tool//pkg/progress:all @rules_img_tool//cmd/deploymetadata:all //util:buildifier.check`
- `bazel build @rules_img_tool//cmd/img`
