### PR TITLE
img_tool: support Unix socket REAPI endpoints

### DIFF
--- a/img_tool/pkg/auth/protohelper/BUILD.bazel
+++ b/img_tool/pkg/auth/protohelper/BUILD.bazel
@@ -18,4 +18,7 @@ go_test(
     name = "protohelper_test",
     srcs = ["protohelper_test.go"],
     embed = [":protohelper"],
+    deps = [
+        "//pkg/auth/credential",
+    ],
 )

--- a/img_tool/pkg/auth/protohelper/protohelper.go
+++ b/img_tool/pkg/auth/protohelper/protohelper.go
@@ -25,13 +25,19 @@ func Client(uri string, helper credhelper.Helper, opts ...grpc.DialOption) (*grp
 		return nil, fmt.Errorf("invalid uri for grpc: %s: %w", uri, err)
 	}
 
+	var target string
 	switch parsed.Scheme {
 	case "grpc":
 		// unencrypted grpc
 		warnUnencryptedGRPC(uri)
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		target = fmt.Sprintf("dns:%s", parsed.Host)
 	case "grpcs":
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(nil)))
+		target = fmt.Sprintf("dns:%s", parsed.Host)
+	case "unix":
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		target = uri
 	default:
 		return nil, fmt.Errorf("unsupported scheme for grpc: %s", parsed.Scheme)
 	}
@@ -40,8 +46,6 @@ func Client(uri string, helper credhelper.Helper, opts ...grpc.DialOption) (*grp
 	if parsed.User != nil && parsed.User.String() != "" {
 		opts = append(opts, grpc.WithPerRPCCredentials(basicAuthFromUserinfo(parsed.User)))
 	}
-
-	target := fmt.Sprintf("dns:%s", parsed.Host)
 
 	opts = append(opts, grpcheaderinterceptor.DialOptions(helper)...)
 

--- a/img_tool/pkg/auth/protohelper/protohelper_test.go
+++ b/img_tool/pkg/auth/protohelper/protohelper_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/url"
 	"testing"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/credential"
 )
 
 func TestBasicAuthCredentials(t *testing.T) {
@@ -166,6 +168,44 @@ func TestParseGRPCURL(t *testing.T) {
 			hasUser := parsed.User != nil && parsed.User.String() != ""
 			if hasUser != tt.hasUser {
 				t.Errorf("expected hasUser=%v, got %v", tt.hasUser, hasUser)
+			}
+		})
+	}
+}
+
+func TestClientTarget(t *testing.T) {
+	tests := []struct {
+		name       string
+		uri        string
+		wantTarget string
+	}{
+		{
+			name:       "grpc endpoint",
+			uri:        "grpc://example.com:9092",
+			wantTarget: "dns:example.com:9092",
+		},
+		{
+			name:       "grpcs endpoint",
+			uri:        "grpcs://example.com:443",
+			wantTarget: "dns:example.com:443",
+		},
+		{
+			name:       "unix endpoint",
+			uri:        "unix:///mnt/ephemeral/buildbarn/.cache/bb_clientd/grpc",
+			wantTarget: "unix:///mnt/ephemeral/buildbarn/.cache/bb_clientd/grpc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, err := Client(tt.uri, credential.NopHelper())
+			if err != nil {
+				t.Fatalf("Client(%q) returned error: %v", tt.uri, err)
+			}
+			defer conn.Close()
+
+			if got := conn.Target(); got != tt.wantTarget {
+				t.Fatalf("Client(%q).Target() = %q, want %q", tt.uri, got, tt.wantTarget)
 			}
 		})
 	}


### PR DESCRIPTION
## Why

`rules_img` lazy image pushes can use REAPI through `IMG_REAPI_ENDPOINT` / `--@rules_img//img/settings:remote_cache`. Buildbarn `bb_clientd` exposes a local REAPI Unix socket, but `protohelper.Client` currently rejects `unix:///...` endpoints before gRPC can dial them.

Fixes #593.

## Summary

- Allow `protohelper.Client` to accept `unix:///...` REAPI endpoints and pass them through to `grpc.NewClient`.
- Keep existing `grpc://` and `grpcs://` endpoint behavior unchanged by continuing to rewrite those targets to `dns:<host>`.
- Add target-selection coverage for `grpc`, `grpcs`, and a `bb_clientd`-style Unix socket endpoint.

## Test plan

- [x] `bazel test @rules_img_tool//pkg/auth/protohelper:protohelper_test`
- [x] `git diff --check`