### PR TITLE
deployvfs: eagerly stat hint paths so missing files don't short-circu…

### DIFF
--- a/img_tool/pkg/deployvfs/deployvfs.go
+++ b/img_tool/pkg/deployvfs/deployvfs.go
@@ -769,19 +769,28 @@ func (b *Builder) layerFromHints(desc api.Descriptor) (blobEntry, error) {
 	if len(hintPaths) == 0 {
 		return blobEntry{}, &BlobSourceError{Source: "layer hints", Digest: desc.Digest, Kind: BlobSourceBlobMissing, Message: "digest not in layer hints"}
 	}
+	var foundPath string
+	for _, localPath := range hintPaths {
+		if _, err := os.Stat(localPath); err == nil {
+			foundPath = localPath
+			break
+		}
+	}
+	if foundPath == "" {
+		return blobEntry{}, &BlobSourceError{Source: "layer hints", Digest: desc.Digest, Kind: BlobSourceBlobMissing, Message: "digest not in layer hints"}
+	}
 	stats := b.stats
 	return blobEntry{
 		Descriptor: desc,
 		Location:   "file",
 		stats:      stats,
 		Opener: func() (io.ReadCloser, error) {
-			for _, localPath := range hintPaths {
-				if file, err := os.Open(localPath); err == nil {
-					stats.BlobsFromLocalDisk.Add(1)
-					return file, nil
-				}
+			file, err := os.Open(foundPath)
+			if err != nil {
+				return nil, fmt.Errorf("layer %s not found in hint path: %w", desc.Digest, err)
 			}
-			return nil, fmt.Errorf("layer %s not found in any hint path", desc.Digest)
+			stats.BlobsFromLocalDisk.Add(1)
+			return file, nil
 		},
 	}, nil
 }

--- a/img_tool/pkg/deployvfs/deployvfs.go
+++ b/img_tool/pkg/deployvfs/deployvfs.go
@@ -800,16 +800,19 @@ func (b *Builder) layerFromCAS(desc api.Descriptor) (blobEntry, error) {
 	if b.casReader == nil {
 		return blobEntry{}, &BlobSourceError{Source: "remote CAS", Digest: desc.Digest, Kind: BlobSourceUnconfigured, Message: "no CAS reader configured"}
 	}
+	digest, err := digestFromDescriptor(desc)
+	if err != nil {
+		return blobEntry{}, &BlobSourceError{Source: "remote CAS", Digest: desc.Digest, Kind: BlobSourceBlobMissing, Err: err}
+	}
+	if missing, err := b.casReader.FindMissingBlobs(context.TODO(), []cas.Digest{digest}); err == nil && len(missing) > 0 {
+		return blobEntry{}, &BlobSourceError{Source: "remote CAS", Digest: desc.Digest, Kind: BlobSourceBlobMissing, Message: "blob not found in remote CAS"}
+	}
 	stats := b.stats
 	return blobEntry{
 		Descriptor: desc,
 		Location:   "remote_cache",
 		stats:      stats,
 		Opener: func() (io.ReadCloser, error) {
-			digest, err := digestFromDescriptor(desc)
-			if err != nil {
-				return nil, err
-			}
 			stats.BlobsFromRemoteCache.Add(1)
 			return b.casReader.ReaderForBlob(context.TODO(), digest)
 		},
@@ -884,16 +887,19 @@ func (b *Builder) blobFromCAS(desc api.Descriptor) (blobEntry, error) {
 	if b.casReader == nil {
 		return blobEntry{}, &BlobSourceError{Source: "remote CAS", Digest: desc.Digest, Kind: BlobSourceUnconfigured, Message: "no CAS reader configured"}
 	}
+	digest, err := digestFromDescriptor(desc)
+	if err != nil {
+		return blobEntry{}, &BlobSourceError{Source: "remote CAS", Digest: desc.Digest, Kind: BlobSourceBlobMissing, Err: err}
+	}
+	if missing, err := b.casReader.FindMissingBlobs(context.TODO(), []cas.Digest{digest}); err == nil && len(missing) > 0 {
+		return blobEntry{}, &BlobSourceError{Source: "remote CAS", Digest: desc.Digest, Kind: BlobSourceBlobMissing, Message: "blob not found in remote CAS"}
+	}
 	stats := b.stats
 	return blobEntry{
 		Descriptor: desc,
 		Location:   "remote_cache",
 		stats:      stats,
 		Opener: func() (io.ReadCloser, error) {
-			digest, err := digestFromDescriptor(desc)
-			if err != nil {
-				return nil, err
-			}
 			stats.BlobsFromRemoteCache.Add(1)
 			return b.casReader.ReaderForBlob(context.TODO(), digest)
 		},


### PR DESCRIPTION
…it fallback sources

Previously layerFromHints returned a blobEntry with no error even when none of the hint paths existed on disk. Because layerBlob treats a nil error as success and returns immediately, all subsequent fallback sources (remote CAS, registry pull, etc.) were bypassed. The "not found" error only surfaced later when the caller tried to open the blob, at which point there was no way to retry other sources.

Fix by stat-ing each hint path eagerly before constructing the blobEntry. If a file exists, capture that path for the Opener. If none exist, return BlobSourceBlobMissing immediately so layerBlob continues down the fallback chain.