### PR TITLE
Identify rules_img as the calling tool in REAPI requests

### DIFF
--- a/img_tool/cmd/img/BUILD.bazel
+++ b/img_tool/cmd/img/BUILD.bazel
@@ -29,15 +29,21 @@ go_library(
         "//cmd/sparseocilayout",
         "//cmd/syncocirefgraph",
         "//cmd/validate",
+        "//pkg/version",
         "@com_github_google_go_containerregistry//pkg/logs",
     ],
 )
+
+version_x_defs = {
+    "github.com/bazel-contrib/rules_img/img_tool/pkg/version.Version": module_version() or "dev",
+}
 
 go_binary(
     name = "img",
     embed = [":img_lib"],
     pure = "on",
     visibility = ["//visibility:public"],
+    x_defs = version_x_defs,
 )
 
 platform_tuples = [
@@ -58,6 +64,7 @@ platform_tuples = [
         goos = os,
         pure = "on",
         visibility = ["//toolchain:__subpackages__"],
+        x_defs = version_x_defs,
     )
     for os, arch in platform_tuples
 ]

--- a/img_tool/pkg/auth/grpcheaderinterceptor/BUILD.bazel
+++ b/img_tool/pkg/auth/grpcheaderinterceptor/BUILD.bazel
@@ -7,7 +7,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/auth/credential",
+        "//pkg/proto/remote-apis/build/bazel/remote/execution/v2",
+        "//pkg/version",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_google_protobuf//proto",
     ],
 )

--- a/img_tool/pkg/auth/grpcheaderinterceptor/grpcheaderinterceptor.go
+++ b/img_tool/pkg/auth/grpcheaderinterceptor/grpcheaderinterceptor.go
@@ -9,9 +9,34 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/credential"
+	remoteexecution_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/remote-apis/build/bazel/remote/execution/v2"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/version"
 )
+
+// requestMetadataHeaderKey is the binary metadata header name defined by the
+// Remote Execution API for identifying the calling tool. See:
+// https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto
+const requestMetadataHeaderKey = "build.bazel.remote.execution.v2.requestmetadata-bin"
+
+// requestMetadataBin is the wire-encoded RequestMetadata identifying rules_img
+// as the calling tool, attached to every outgoing REAPI/CAS/ByteStream call.
+var requestMetadataBin = mustMarshalRequestMetadata()
+
+func mustMarshalRequestMetadata() string {
+	b, err := proto.Marshal(&remoteexecution_proto.RequestMetadata{
+		ToolDetails: &remoteexecution_proto.ToolDetails{
+			ToolName:    "rules_img",
+			ToolVersion: version.Version,
+		},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal RequestMetadata: %v", err))
+	}
+	return string(b)
+}
 
 type authenticatingInterceptor struct {
 	helper credential.Helper
@@ -25,6 +50,7 @@ func (i *authenticatingInterceptor) unaryAddHeaders(ctx context.Context, method 
 	}
 
 	md = addCredentialsToMD(ctx, cc.Target(), method, md, i.helper)
+	md.Set(requestMetadataHeaderKey, requestMetadataBin)
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	return invoker(ctx, method, req, reply, cc, opts...)
@@ -38,6 +64,7 @@ func (i *authenticatingInterceptor) streamAddHeaders(ctx context.Context, desc *
 	}
 
 	md = addCredentialsToMD(ctx, cc.Target(), method, md, i.helper)
+	md.Set(requestMetadataHeaderKey, requestMetadataBin)
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	return streamer(ctx, desc, cc, method, opts...)

--- a/img_tool/pkg/version/BUILD.bazel
+++ b/img_tool/pkg/version/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "version",
+    srcs = ["version.go"],
+    importpath = "github.com/bazel-contrib/rules_img/img_tool/pkg/version",
+    visibility = ["//visibility:public"],
+)

--- a/img_tool/pkg/version/version.go
+++ b/img_tool/pkg/version/version.go
@@ -1,0 +1,7 @@
+// Package version holds the rules_img version, stamped in at build time.
+package version
+
+// Version is the rules_img version. It defaults to "dev" and is overridden
+// via x_defs on the img go_binary target with the version of the rules_img
+// Bazel module.
+var Version = "dev"


### PR DESCRIPTION
Attach RequestMetadata with ToolDetails{ToolName: "rules_img", ToolVersion} to every outgoing REAPI/CAS/ByteStream call, as recommended by the Remote Execution API spec. The version is stamped at build time via x_defs, reading the rules_img module version through Bazel module_version().