### PR TITLE
fix: compute include_layers per-operation in multi_deploy

### DIFF
--- a/img/private/load.bzl
+++ b/img/private/load.bzl
@@ -219,6 +219,7 @@ def _image_load_impl(ctx):
             image = image_provider,
             deploy_manifest = deploy_metadata,
             layer_hints = layer_hints,
+            include_layers = strategy == "eager",
         ),
     ]
 

--- a/img/private/multi_deploy.bzl
+++ b/img/private/multi_deploy.bzl
@@ -137,21 +137,14 @@ def _multi_deploy_impl(ctx):
     # Collect all image providers for root symlinks
     images = _collect_all_image_providers(ctx)
 
-    # Build root symlinks including all layers from all operations
-    # We need to include layers for strategies that require them
-    include_layers = (
-        _multi_deploy_strategy(ctx, "push") == "eager" or
-        _multi_deploy_strategy(ctx, "load") == "eager"
-    )
-
     root_symlinks = {}
 
-    # Add symlinks for all deploy commands
+    # Add symlinks for all deploy commands, using per-operation include_layers from DeployInfo
     for (i, image) in enumerate(images):
         symlinks = calculate_root_symlinks(
             index_info = image["index_info"],
             manifest_info = image["manifest_info"],
-            include_layers = include_layers,
+            include_layers = ctx.attr.operations[i][DeployInfo].include_layers,
             operation_index = i,
             symlink_name_prefix = root_symlinks_prefix,
         )

--- a/img/private/providers/deploy_info.bzl
+++ b/img/private/providers/deploy_info.bzl
@@ -9,6 +9,7 @@ FIELDS = dict(
     image = "ImageManifestInfo or ImageIndexInfo of the image or image index to push or load.",
     deploy_manifest = "File containing the deploy manifest (JSON).",
     layer_hints = "File containing layer path hints (or None).",
+    include_layers = "Bool, whether layer blobs must be present in the run-time file tree (True for eager strategies, False for lazy/CAS strategies).",
 )
 
 DeployInfo = provider(

--- a/img/private/push.bzl
+++ b/img/private/push.bzl
@@ -105,11 +105,12 @@ def _image_push_impl(ctx):
         configuration_json = configuration_json,
         destination_file = ctx.file.destination_file,
     )
+    push_strategy = resolve_push_strategy(ctx)
     root_symlinks_prefix = symlink_name_prefix(ctx)
     root_symlinks = calculate_root_symlinks(
         index_info,
         manifest_info,
-        include_layers = resolve_push_strategy(ctx) == "eager",
+        include_layers = push_strategy == "eager",
         symlink_name_prefix = root_symlinks_prefix,
     )
 
@@ -120,7 +121,7 @@ def _image_push_impl(ctx):
         root_symlinks.update(calculate_root_symlinks(
             ref_index_info,
             ref_manifest_info,
-            include_layers = resolve_push_strategy(ctx) == "eager",
+            include_layers = push_strategy == "eager",
             symlink_name_prefix = root_symlinks_prefix,
             operation_index = ref_idx + 1,
         ))
@@ -184,6 +185,7 @@ def _image_push_impl(ctx):
             image = image_provider,
             deploy_manifest = deploy_metadata,
             layer_hints = layer_hints,
+            include_layers = push_strategy == "eager",
         ),
     ]
 

--- a/img/private/push_metadata.bzl
+++ b/img/private/push_metadata.bzl
@@ -553,11 +553,17 @@ def process_deploy_specs(
         )
         deploy_infos.append(struct(metadata = deploy_metadata, layer_hints = layer_hints))
 
+    include_layers = (
+        any([d[PushConfigInfo].strategy == "eager" for d in push_specs]) or
+        any([d[LoadConfigInfo].strategy == "eager" for d in load_specs])
+    )
+
     if len(deploy_infos) == 1:
         return DeployInfo(
             image = image_info,
             deploy_manifest = deploy_infos[0].metadata,
             layer_hints = deploy_infos[0].layer_hints,
+            include_layers = include_layers,
         )
 
     first_push_strategy = push_specs[0][PushConfigInfo].strategy if push_specs else "auto"
@@ -573,4 +579,5 @@ def process_deploy_specs(
         image = image_info,
         deploy_manifest = merged_metadata,
         layer_hints = merged_layer_hints,
+        include_layers = include_layers,
     )


### PR DESCRIPTION
Add `include_layers` to `DeployInfo` so each operation records whether its own strategy requires layer blobs at runtime. `multi_deploy` now reads this field per-operation instead of OR-ing push and load strategies globally, which caused layers to be included even for push-only deployments using a lazy strategy.