### PR TITLE
feat(push): restore progress bar for image push

### DIFF
--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -253,10 +253,10 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 		haveBlobCacheCient = true
 	}
 
-	// Create a single persistent pusher for all push operations (including registry_tag)
+	// Create a pusher for registry_tag operations only.
+	// Push operations use an internally-created pusher in PushAll (with progress tracking).
 	var pusher *remote.Pusher
-	needsPusher := len(pushOperations) > 0 || len(registryTagOperations) > 0
-	if needsPusher && req.Settings.PushStrategy != "bes" {
+	if len(registryTagOperations) > 0 && req.Settings.PushStrategy != "bes" {
 		pusher, err = remote.NewPusher(registry.WithAuthFromMultiKeychain(), remote.WithJobs(opts.Jobs))
 		if err != nil {
 			return fmt.Errorf("creating pusher: %w", err)
@@ -269,7 +269,6 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 
 	if len(pushOperations) > 0 {
 		uploadBuilder := push.NewBuilder(vfs).
-			WithPusher(pusher).
 			WithJobs(opts.Jobs).
 			WithRemoteOptions(registry.WithAuthFromMultiKeychain())
 		if haveBlobCacheCient {

--- a/img_tool/pkg/push/BUILD.bazel
+++ b/img_tool/pkg/push/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api",
+        "//pkg/progress",
         "//pkg/proto/blobcache",
         "//pkg/proto/remote-apis/build/bazel/remote/execution/v2",
         "@com_github_google_go_containerregistry//pkg/name",

--- a/img_tool/pkg/push/push.go
+++ b/img_tool/pkg/push/push.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/progress"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/proto/blobcache"
 	blobcache_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/blobcache"
 	remoteexecution_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/remote-apis/build/bazel/remote/execution/v2"
@@ -132,14 +134,40 @@ func (u *uploader) PushAll(ctx context.Context, ops []api.IndexedPushDeployOpera
 		}
 	}
 
+	ctx, stopProgress := progress.InitProgress(ctx, "pushed")
+	prog := progress.NewIndeterminate(ctx, "pushing")
+
+	var progCh chan registryv1.Update
+	var drainWg sync.WaitGroup
+
 	pusher := u.pusher
 	if pusher == nil {
+		progCh = make(chan registryv1.Update, 256)
+		drainWg.Add(1)
+		go func() {
+			defer drainWg.Done()
+			for update := range progCh {
+				prog.SetTotal(update.Total)
+				prog.SetComplete(update.Complete)
+			}
+		}()
 		var err error
-		pusher, err = remote.NewPusher(append(u.remoteOptions, remote.WithJobs(u.jobs))...)
+		pusher, err = remote.NewPusher(append(u.remoteOptions, remote.WithJobs(u.jobs), remote.WithProgress(progCh))...)
 		if err != nil {
+			close(progCh)
+			drainWg.Wait()
 			return nil, fmt.Errorf("creating pusher: %w", err)
 		}
 	}
+
+	defer func() {
+		if progCh != nil {
+			close(progCh)
+			drainWg.Wait()
+		}
+		prog.Done(retErr)
+		stopProgress()
+	}()
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(u.jobs)


### PR DESCRIPTION
Wire up remote.WithProgress so that PushAll shows a bytes-progress bar (via the existing Indeterminate tracker) when running in single-shot mode with a TTY.

The implementation was dropped in b2c8a1b when remote.MultiWrite was replaced with a persistent pusher, because WithProgress must be set at pusher-creation time. The fix is to let PushAll create its own pusher (with the progress channel baked in) for single-shot mode. The persistent worker continues to pass h.pusher via WithPusher, which takes the no-progress path; since worker mode never has a TTY stderr, all progress calls are already no-ops there.

deploy.go now creates the external pusher only for registry_tag operations; push operations rely on the internally-created pusher.