### PR TITLE
fix: survive RST_STREAM during slow CAS reads

### DIFF
--- a/img_tool/pkg/auth/protohelper/BUILD.bazel
+++ b/img_tool/pkg/auth/protohelper/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//credentials",
         "@org_golang_google_grpc//credentials/insecure",
+        "@org_golang_google_grpc//keepalive",
     ],
 )
 

--- a/img_tool/pkg/auth/protohelper/protohelper.go
+++ b/img_tool/pkg/auth/protohelper/protohelper.go
@@ -8,10 +8,12 @@ import (
 	"os"
 	"slices"
 	"sync"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 
 	credhelper "github.com/bazel-contrib/rules_img/img_tool/pkg/auth/credential"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/grpcheaderinterceptor"
@@ -48,6 +50,14 @@ func Client(uri string, helper credhelper.Helper, opts ...grpc.DialOption) (*grp
 	}
 
 	opts = append(opts, grpcheaderinterceptor.DialOptions(helper)...)
+
+	// Keep HTTP/2 streams alive during backpressure pauses (e.g. slow compressors
+	// stalling a ByteStream read), which otherwise cause the server to send
+	// RST_STREAM NO_ERROR and tear down the stream mid-transfer.
+	opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		Time:    30 * time.Second,
+		Timeout: 10 * time.Second,
+	}))
 
 	return grpc.NewClient(target, opts...)
 }

--- a/img_tool/pkg/cas/BUILD.bazel
+++ b/img_tool/pkg/cas/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "cas",
@@ -14,5 +14,21 @@ go_library(
         "@com_github_google_uuid//:uuid",
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)
+
+go_test(
+    name = "cas_test",
+    size = "small",
+    srcs = ["read_test.go"],
+    embed = [":cas"],
+    deps = [
+        "@org_golang_google_genproto_googleapis_bytestream//:bytestream",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/img_tool/pkg/cas/read.go
+++ b/img_tool/pkg/cas/read.go
@@ -7,11 +7,30 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"time"
 
 	bytestream_proto "google.golang.org/genproto/googleapis/bytestream"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	remoteexecution_proto "github.com/bazel-contrib/rules_img/img_tool/pkg/proto/remote-apis/build/bazel/remote/execution/v2"
+)
+
+const (
+	// maxByteStreamReconnects bounds how many times we transparently reconnect a
+	// ByteStream read that the server tore down mid-transfer before giving up.
+	// The counter resets whenever we make forward progress, so this only limits
+	// consecutive failures without any data.
+	maxByteStreamReconnects = 5
+)
+
+// Backoff between ByteStream reconnect attempts. Declared as vars so tests can
+// shrink them.
+var (
+	byteStreamBaseBackoff = 250 * time.Millisecond
+	byteStreamMaxBackoff  = 5 * time.Second
 )
 
 type CAS struct {
@@ -162,28 +181,20 @@ func (c *CAS) batchReadOne(ctx context.Context, digest Digest) ([]byte, error) {
 }
 
 func (c *CAS) streamReadOne(ctx context.Context, digest Digest) (io.ReadCloser, error) {
-	ctx, cancel := context.WithCancel(ctx)
 	resourceName := fmt.Sprintf("blobs/%x/%d", digest.Hash, digest.SizeBytes)
 	if c.instanceName != "" {
 		resourceName = c.instanceName + "/" + resourceName
 	}
-	resp, err := c.byteStreamClient.Read(ctx, &bytestream_proto.ReadRequest{
-		ResourceName: resourceName,
-		ReadOffset:   0,
-	})
-	if err != nil {
-		cancel()
-		return nil, fmt.Errorf("failed to read blob: %w", casErr(err))
+	r := &byteStreamReadCloser{
+		client:       c.byteStreamClient,
+		ctx:          ctx,
+		resourceName: resourceName,
+		limit:        digest.SizeBytes,
 	}
-	if resp == nil {
-		cancel()
-		return nil, errors.New("byte stream response is nil")
+	if err := r.connect(0); err != nil {
+		return nil, fmt.Errorf("failed to read blob: %w", err)
 	}
-	return &byteStreamReadCloser{
-		stream: resp,
-		cancel: cancel,
-		limit:  digest.SizeBytes,
-	}, nil
+	return r, nil
 }
 
 type Digest struct {
@@ -292,14 +303,120 @@ func learnCapabilities(ctx context.Context, capabilitiesClient remoteexecution_p
 }
 
 type byteStreamReadCloser struct {
+	// Fields needed to (re)establish the underlying stream so a read that the
+	// server tears down mid-transfer can be resumed from the current offset.
+	client       bytestream_proto.ByteStreamClient
+	ctx          context.Context
+	resourceName string
+
 	stream bytestream_proto.ByteStream_ReadClient
 	buf    bytes.Buffer
 	eof    bool
 	cancel context.CancelFunc
 
-	limit          int64
-	readFromRemote int64
-	writtenToOut   int64
+	limit             int64
+	readFromRemote    int64
+	writtenToOut      int64
+	reconnectAttempts int
+}
+
+// connect (re)opens the ByteStream read at the given offset, cancelling any
+// previous stream first. On reconnect, offset is the number of bytes already
+// received from the server, so the server resumes exactly where it left off.
+func (b *byteStreamReadCloser) connect(offset int64) error {
+	if b.cancel != nil {
+		b.cancel()
+	}
+	ctx, cancel := context.WithCancel(b.ctx)
+	stream, err := b.client.Read(ctx, &bytestream_proto.ReadRequest{
+		ResourceName: b.resourceName,
+		ReadOffset:   offset,
+	})
+	if err != nil {
+		cancel()
+		return casErr(err)
+	}
+	if stream == nil {
+		cancel()
+		return errors.New("byte stream response is nil")
+	}
+	b.stream = stream
+	b.cancel = cancel
+	return nil
+}
+
+// recvWithReconnect wraps stream.Recv, transparently reconnecting and resuming
+// from the current offset when the server tears the stream down mid-transfer
+// (e.g. an HTTP/2 RST_STREAM after an idle period). It gives up after
+// maxByteStreamReconnects consecutive failures without forward progress.
+func (b *byteStreamReadCloser) recvWithReconnect() (*bytestream_proto.ReadResponse, error) {
+	// If the whole blob has already been received, we're done. Avoid an extra
+	// Recv/reconnect that could hit OUT_OF_RANGE at the tail if the stream was
+	// torn down right after the final byte.
+	if b.readFromRemote >= b.limit {
+		return nil, io.EOF
+	}
+	for {
+		resp, err := b.stream.Recv()
+		if err == nil {
+			if len(resp.GetData()) > 0 {
+				// Forward progress: restore the full reconnect budget.
+				b.reconnectAttempts = 0
+			}
+			return resp, nil
+		}
+		if err == io.EOF {
+			return resp, io.EOF
+		}
+		if !b.shouldReconnect(err) {
+			return nil, casErr(err)
+		}
+		b.reconnectAttempts++
+		fmt.Fprintf(os.Stderr,
+			"WARNING: CAS byte stream read of %q interrupted at offset %d: %v; reconnecting to resume (attempt %d/%d)\n",
+			b.resourceName, b.readFromRemote, err, b.reconnectAttempts, maxByteStreamReconnects)
+		if err := b.sleepBackoff(); err != nil {
+			return nil, casErr(err)
+		}
+		if err := b.connect(b.readFromRemote); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// shouldReconnect reports whether a Recv error is a transient server-side
+// stream teardown we can recover from by resuming the read.
+func (b *byteStreamReadCloser) shouldReconnect(err error) bool {
+	if b.reconnectAttempts >= maxByteStreamReconnects {
+		return false
+	}
+	// Our own cancellation or deadline (e.g. Close, or a caller-imposed timeout)
+	// is not a transient server failure — don't try to resume.
+	if b.ctx.Err() != nil {
+		return false
+	}
+	switch status.Code(err) {
+	case codes.Unavailable, codes.Internal, codes.Aborted:
+		return true
+	default:
+		return false
+	}
+}
+
+// sleepBackoff waits before the next reconnect, honoring context cancellation.
+func (b *byteStreamReadCloser) sleepBackoff() error {
+	backoff := byteStreamBaseBackoff * time.Duration(1<<(b.reconnectAttempts-1))
+	if backoff > byteStreamMaxBackoff {
+		backoff = byteStreamMaxBackoff
+	}
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+	select {
+	case <-b.ctx.Done():
+		return b.ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (b *byteStreamReadCloser) Read(p []byte) (n int, err error) {
@@ -333,8 +450,9 @@ func (b *byteStreamReadCloser) Read(p []byte) (n int, err error) {
 		return 0, io.EOF
 	}
 
-	// read from the stream
-	resp, err := b.stream.Recv()
+	// read from the stream, transparently reconnecting and resuming from the
+	// current offset if the server tears the stream down mid-transfer.
+	resp, err := b.recvWithReconnect()
 	var readFromRemoteNow int
 	if resp != nil {
 		readFromRemoteNow = len(resp.Data)
@@ -345,7 +463,8 @@ func (b *byteStreamReadCloser) Read(p []byte) (n int, err error) {
 		// we will return EOF after the buffer is drained
 		b.eof = true
 	} else if err != nil {
-		return 0, casErr(err)
+		// already wrapped by recvWithReconnect/connect
+		return 0, err
 	}
 	b.readFromRemote += int64(readFromRemoteNow)
 
@@ -367,7 +486,9 @@ func (b *byteStreamReadCloser) Read(p []byte) (n int, err error) {
 func (b *byteStreamReadCloser) Close() error {
 	// cancel the context to
 	// stop the stream from our side
-	b.cancel()
+	if b.cancel != nil {
+		b.cancel()
+	}
 	return nil
 }
 

--- a/img_tool/pkg/cas/read_test.go
+++ b/img_tool/pkg/cas/read_test.go
@@ -1,0 +1,250 @@
+package cas
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	bytestream_proto "google.golang.org/genproto/googleapis/bytestream"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// fakeByteStreamClient serves a fixed blob over the ByteStream Read RPC and can
+// be programmed to tear each connection down after delivering a number of
+// bytes, mimicking an HTTP/2 RST_STREAM mid-transfer.
+type fakeByteStreamClient struct {
+	blob      []byte
+	chunkSize int
+	// failAfterBytes[i] is how many bytes connection i delivers before returning
+	// failErr instead of continuing. Connections past the end of the slice serve
+	// to EOF.
+	failAfterBytes []int
+	failErr        error
+
+	conns   int
+	offsets []int64 // recorded ReadOffset per connection, in order
+}
+
+func (f *fakeByteStreamClient) Read(ctx context.Context, in *bytestream_proto.ReadRequest, _ ...grpc.CallOption) (bytestream_proto.ByteStream_ReadClient, error) {
+	idx := f.conns
+	f.conns++
+	f.offsets = append(f.offsets, in.ReadOffset)
+	failAfter := -1
+	if idx < len(f.failAfterBytes) {
+		failAfter = f.failAfterBytes[idx]
+	}
+	return &fakeReadClient{
+		ctx:       ctx,
+		data:      f.blob[in.ReadOffset:],
+		chunkSize: f.chunkSize,
+		failAfter: failAfter,
+		failErr:   f.failErr,
+	}, nil
+}
+
+func (f *fakeByteStreamClient) Write(context.Context, ...grpc.CallOption) (bytestream_proto.ByteStream_WriteClient, error) {
+	panic("not implemented")
+}
+
+func (f *fakeByteStreamClient) QueryWriteStatus(context.Context, *bytestream_proto.QueryWriteStatusRequest, ...grpc.CallOption) (*bytestream_proto.QueryWriteStatusResponse, error) {
+	panic("not implemented")
+}
+
+type fakeReadClient struct {
+	ctx       context.Context
+	data      []byte
+	chunkSize int
+	failAfter int // -1 => never fail
+	failErr   error
+
+	pos  int
+	sent int
+}
+
+func (r *fakeReadClient) Recv() (*bytestream_proto.ReadResponse, error) {
+	if r.failAfter >= 0 && r.sent >= r.failAfter {
+		return nil, r.failErr
+	}
+	if r.pos >= len(r.data) {
+		return nil, io.EOF
+	}
+	end := r.pos + r.chunkSize
+	if end > len(r.data) {
+		end = len(r.data)
+	}
+	if r.failAfter >= 0 && r.sent+(end-r.pos) > r.failAfter {
+		// don't overshoot the programmed failure point within a chunk
+		end = r.pos + (r.failAfter - r.sent)
+	}
+	chunk := append([]byte(nil), r.data[r.pos:end]...)
+	r.pos = end
+	r.sent += len(chunk)
+	return &bytestream_proto.ReadResponse{Data: chunk}, nil
+}
+
+func (r *fakeReadClient) Header() (metadata.MD, error) { return nil, nil }
+func (r *fakeReadClient) Trailer() metadata.MD         { return nil }
+func (r *fakeReadClient) CloseSend() error             { return nil }
+func (r *fakeReadClient) Context() context.Context     { return r.ctx }
+func (r *fakeReadClient) SendMsg(any) error            { return nil }
+func (r *fakeReadClient) RecvMsg(any) error            { return nil }
+
+func testBlob(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(i % 251)
+	}
+	return b
+}
+
+func shrinkBackoff(t *testing.T) {
+	t.Helper()
+	prevBase, prevMax := byteStreamBaseBackoff, byteStreamMaxBackoff
+	byteStreamBaseBackoff = time.Millisecond
+	byteStreamMaxBackoff = time.Millisecond
+	t.Cleanup(func() {
+		byteStreamBaseBackoff = prevBase
+		byteStreamMaxBackoff = prevMax
+	})
+}
+
+// rstErr mimics the error surfaced when the server sends RST_STREAM NO_ERROR.
+func rstErr() error {
+	return status.Error(codes.Internal, "stream terminated by RST_STREAM with error code: NO_ERROR")
+}
+
+func TestStreamReadReconnectResumesAfterRST(t *testing.T) {
+	shrinkBackoff(t)
+	blob := testBlob(1000)
+	fake := &fakeByteStreamClient{
+		blob:      blob,
+		chunkSize: 64,
+		// conn 0 delivers 100 bytes then RSTs; conn 1 delivers another 250 then
+		// RSTs; conn 2 serves the rest to EOF.
+		failAfterBytes: []int{100, 250},
+		failErr:        rstErr(),
+	}
+	c := &CAS{byteStreamClient: fake}
+
+	rc, err := c.streamReadOne(context.Background(), SHA256(make([]byte, 32), int64(len(blob))))
+	if err != nil {
+		t.Fatalf("streamReadOne: %v", err)
+	}
+	defer rc.Close()
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, blob) {
+		t.Fatalf("blob mismatch: got %d bytes, want %d", len(got), len(blob))
+	}
+	// The second and third connections must resume exactly where the previous
+	// one stopped, so no bytes are duplicated or skipped.
+	wantOffsets := []int64{0, 100, 350}
+	if !reflect.DeepEqual(fake.offsets, wantOffsets) {
+		t.Fatalf("resume offsets = %v, want %v", fake.offsets, wantOffsets)
+	}
+}
+
+func TestStreamReadGivesUpAfterMaxReconnects(t *testing.T) {
+	shrinkBackoff(t)
+	blob := testBlob(1000)
+	// Every connection RSTs immediately without delivering any bytes, so the
+	// consecutive-failure counter is never reset.
+	failPlan := make([]int, maxByteStreamReconnects+2)
+	fake := &fakeByteStreamClient{
+		blob:           blob,
+		chunkSize:      64,
+		failAfterBytes: failPlan, // all zeros => fail before any data
+		failErr:        rstErr(),
+	}
+	c := &CAS{byteStreamClient: fake}
+
+	rc, err := c.streamReadOne(context.Background(), SHA256(make([]byte, 32), int64(len(blob))))
+	if err != nil {
+		t.Fatalf("streamReadOne: %v", err)
+	}
+	defer rc.Close()
+
+	_, err = io.ReadAll(rc)
+	if err == nil {
+		t.Fatal("expected an error after exhausting reconnects, got nil")
+	}
+	// initial connection + maxByteStreamReconnects retries
+	wantConns := 1 + maxByteStreamReconnects
+	if fake.conns != wantConns {
+		t.Fatalf("connections = %d, want %d", fake.conns, wantConns)
+	}
+}
+
+func TestStreamReadDoesNotRetryNonTransient(t *testing.T) {
+	shrinkBackoff(t)
+	blob := testBlob(1000)
+	fake := &fakeByteStreamClient{
+		blob:           blob,
+		chunkSize:      64,
+		failAfterBytes: []int{100},
+		failErr:        status.Error(codes.NotFound, "blob not found"),
+	}
+	c := &CAS{byteStreamClient: fake}
+
+	rc, err := c.streamReadOne(context.Background(), SHA256(make([]byte, 32), int64(len(blob))))
+	if err != nil {
+		t.Fatalf("streamReadOne: %v", err)
+	}
+	defer rc.Close()
+
+	_, err = io.ReadAll(rc)
+	if err == nil {
+		t.Fatal("expected NotFound error to propagate, got nil")
+	}
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("error code = %s, want %s", status.Code(err), codes.NotFound)
+	}
+	// Only the initial connection should have been made; NotFound is not retried.
+	if fake.conns != 1 {
+		t.Fatalf("connections = %d, want 1 (no retry on non-transient error)", fake.conns)
+	}
+}
+
+func TestStreamReadDoesNotRetryOnCallerCancel(t *testing.T) {
+	shrinkBackoff(t)
+	blob := testBlob(1000)
+	ctx, cancel := context.WithCancel(context.Background())
+	fake := &fakeByteStreamClient{
+		blob:      blob,
+		chunkSize: 64,
+		// Deliver 100 bytes, then fail. The test cancels the caller context
+		// before the failure is observed.
+		failAfterBytes: []int{100},
+		failErr:        rstErr(),
+	}
+	c := &CAS{byteStreamClient: fake}
+
+	rc, err := c.streamReadOne(ctx, SHA256(make([]byte, 32), int64(len(blob))))
+	if err != nil {
+		t.Fatalf("streamReadOne: %v", err)
+	}
+	defer rc.Close()
+
+	// Drain the first 100 bytes that arrive before the RST.
+	buf := make([]byte, 100)
+	if _, err := io.ReadFull(rc, buf); err != nil {
+		t.Fatalf("ReadFull: %v", err)
+	}
+	// Now cancel: the subsequent RST must not trigger a reconnect.
+	cancel()
+	if _, err := io.ReadAll(rc); err == nil {
+		t.Fatal("expected error after caller cancellation, got nil")
+	}
+	if fake.conns != 1 {
+		t.Fatalf("connections = %d, want 1 (no reconnect after caller cancel)", fake.conns)
+	}
+}


### PR DESCRIPTION
Two complementary changes for large compact-layer blobs streamed from the Bazel remote cache, where backpressure from a slow compressor can leave a ByteStream connection idle long enough for the server to send RST_STREAM NO_ERROR and abort the read mid-transfer:

- Add gRPC keepalive so idle streams stay alive during backpressure pauses.
- Reconnect-and-resume in the shared ByteStream reader: on a transient teardown, reopen the Read at the current offset (ReadOffset = bytes already received), print a warning to stderr, and continue instead of failing. Retries are bounded (5 consecutive failures without progress) with backoff; caller cancellation and non-transient codes are not retried.