### PR TITLE
feat: pool gRPC connections for remote CAS reads

### DIFF
--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"golang.org/x/sync/errgroup"
@@ -202,7 +203,7 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 			break
 		}
 	}
-	vfsBuilder, err = configureBuilderFromEnv(vfsBuilder, hasLazyStrategy)
+	vfsBuilder, err = configureBuilderFromEnv(vfsBuilder, hasLazyStrategy, opts.Jobs)
 	if err != nil {
 		return err
 	}
@@ -444,7 +445,7 @@ func credentialHelperInstance() credential.Helper {
 	return credential.NopHelper()
 }
 
-func configureBuilderFromEnv(builder *deployvfs.Builder, needsCAS bool) (*deployvfs.Builder, error) {
+func configureBuilderFromEnv(builder *deployvfs.Builder, needsCAS bool, jobs int) (*deployvfs.Builder, error) {
 	diskCachePath := os.Getenv("IMG_DISK_CACHE")
 	if diskCachePath != "" {
 		builder = builder.WithDiskCache(diskCachePath)
@@ -455,19 +456,49 @@ func configureBuilderFromEnv(builder *deployvfs.Builder, needsCAS bool) (*deploy
 		if reapiEndpoint != "" {
 			reapiInstanceName := os.Getenv("IMG_REAPI_INSTANCE_NAME")
 			credHelper := credentialHelperInstance()
-			grpcConn, err := protohelper.Client(reapiEndpoint, credHelper)
-			if err != nil {
-				return nil, fmt.Errorf("creating gRPC client for REAPI: %w", err)
+			// A single gRPC connection multiplexes all CAS reads onto one TCP
+			// connection, which bottlenecks bulk downloads on high-latency
+			// links. Optionally open a pool of connections and round-robin
+			// reads across them (cf. Bazel's --remote_max_connections).
+			numConns := reapiMaxConnections(jobs)
+			members := make([]*cas.CAS, 0, numConns)
+			for range numConns {
+				grpcConn, err := protohelper.Client(reapiEndpoint, credHelper)
+				if err != nil {
+					return nil, fmt.Errorf("creating gRPC client for REAPI: %w", err)
+				}
+				member, err := cas.New(grpcConn, cas.WithInstanceName(reapiInstanceName))
+				if err != nil {
+					return nil, fmt.Errorf("creating CAS client: %w", err)
+				}
+				members = append(members, member)
 			}
-			casReader, err := cas.New(grpcConn, cas.WithInstanceName(reapiInstanceName))
-			if err != nil {
-				return nil, fmt.Errorf("creating CAS client: %w", err)
-			}
-			builder = builder.WithCASReader(casReader)
+			builder = builder.WithCASReader(cas.NewPool(members))
 		}
 	}
 
 	return builder, nil
+}
+
+// reapiMaxConnections returns the size of the gRPC connection pool used to read
+// blobs from the remote CAS. It defaults to jobs (the number of parallel push
+// operations, i.e. the maximum number of concurrent reads in flight), which can
+// be overridden with IMG_REAPI_MAX_CONNECTIONS. Values below 1 or unparseable
+// values fall back to the default with a warning.
+func reapiMaxConnections(jobs int) int {
+	if jobs < 1 {
+		jobs = 1
+	}
+	raw := os.Getenv("IMG_REAPI_MAX_CONNECTIONS")
+	if raw == "" {
+		return jobs
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		fmt.Fprintf(os.Stderr, "WARNING: ignoring invalid IMG_REAPI_MAX_CONNECTIONS=%q, using %d\n", raw, jobs)
+		return jobs
+	}
+	return n
 }
 
 func extractJobsFlag(args []string) int {

--- a/img_tool/cmd/deploy/persistentworker.go
+++ b/img_tool/cmd/deploy/persistentworker.go
@@ -33,7 +33,7 @@ func newDeployWorkerHandler(jobs int) *deployWorkerHandler {
 	// We set needsCAS to true unconditionally.
 	// The reason is that we just cannot know in advance whether a future work request
 	// wants to connect to the remote cache or not.
-	baseBuilder, err := configureBuilderFromEnv(baseBuilder, true /* needsCAS */)
+	baseBuilder, err := configureBuilderFromEnv(baseBuilder, true /* needsCAS */, jobs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to configure VFS from environment: %v\n", err)
 	}

--- a/img_tool/pkg/cas/BUILD.bazel
+++ b/img_tool/pkg/cas/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "cas",
     srcs = [
         "error.go",
+        "pool.go",
         "read.go",
         "write.go",
     ],
@@ -22,7 +23,10 @@ go_library(
 go_test(
     name = "cas_test",
     size = "small",
-    srcs = ["read_test.go"],
+    srcs = [
+        "pool_test.go",
+        "read_test.go",
+    ],
     embed = [":cas"],
     deps = [
         "@org_golang_google_genproto_googleapis_bytestream//:bytestream",

--- a/img_tool/pkg/cas/pool.go
+++ b/img_tool/pkg/cas/pool.go
@@ -1,0 +1,72 @@
+package cas
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+)
+
+// blobSource is the subset of *CAS a Pool distributes reads across. It exists
+// so the pool's round-robin logic can be unit-tested with fakes.
+type blobSource interface {
+	FindMissingBlobs(ctx context.Context, digests []Digest) ([]Digest, error)
+	ReadBlob(ctx context.Context, digest Digest) ([]byte, error)
+	ReaderForBlob(ctx context.Context, digest Digest) (io.ReadCloser, error)
+}
+
+// Pool spreads CAS reads across several independent gRPC connections.
+//
+// A single gRPC ClientConn multiplexes every RPC onto one HTTP/2 (TCP)
+// connection, which shares a single congestion window and receive buffer. On
+// high-latency links that caps bulk-download throughput no matter how many
+// reads run concurrently. A Pool round-robins reads across several members —
+// each backed by its own ClientConn/TCP connection — so aggregate throughput
+// can scale with the number of connections. This mirrors the connection
+// pooling behind Bazel's --remote_max_connections.
+//
+// A Pool exposes the same read surface as *CAS (FindMissingBlobs, ReadBlob,
+// ReaderForBlob) and is safe for concurrent use.
+type Pool struct {
+	members []blobSource
+	next    atomic.Uint64
+}
+
+// NewPool returns a Pool that round-robins reads across the given CAS members.
+// Each member should be backed by its own gRPC connection for pooling to have
+// any effect. NewPool panics if members is empty; a single-member pool is
+// valid and behaves like the member itself.
+func NewPool(members []*CAS) *Pool {
+	sources := make([]blobSource, len(members))
+	for i, m := range members {
+		sources[i] = m
+	}
+	return newPool(sources)
+}
+
+func newPool(members []blobSource) *Pool {
+	if len(members) == 0 {
+		panic("cas.NewPool: at least one member is required")
+	}
+	return &Pool{members: members}
+}
+
+// pick returns the next member in round-robin order.
+func (p *Pool) pick() blobSource {
+	if len(p.members) == 1 {
+		return p.members[0]
+	}
+	i := p.next.Add(1) - 1
+	return p.members[i%uint64(len(p.members))]
+}
+
+func (p *Pool) FindMissingBlobs(ctx context.Context, digests []Digest) ([]Digest, error) {
+	return p.pick().FindMissingBlobs(ctx, digests)
+}
+
+func (p *Pool) ReadBlob(ctx context.Context, digest Digest) ([]byte, error) {
+	return p.pick().ReadBlob(ctx, digest)
+}
+
+func (p *Pool) ReaderForBlob(ctx context.Context, digest Digest) (io.ReadCloser, error) {
+	return p.pick().ReaderForBlob(ctx, digest)
+}

--- a/img_tool/pkg/cas/pool_test.go
+++ b/img_tool/pkg/cas/pool_test.go
@@ -1,0 +1,109 @@
+package cas
+
+import (
+	"context"
+	"io"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeSource is a blobSource that records how many calls it handled.
+type fakeSource struct {
+	id int
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (f *fakeSource) FindMissingBlobs(context.Context, []Digest) ([]Digest, error) {
+	f.record()
+	return nil, nil
+}
+
+func (f *fakeSource) ReadBlob(context.Context, Digest) ([]byte, error) {
+	f.record()
+	return nil, nil
+}
+
+func (f *fakeSource) ReaderForBlob(context.Context, Digest) (io.ReadCloser, error) {
+	f.record()
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+func (f *fakeSource) record() {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+}
+
+func TestPoolPickRoundRobin(t *testing.T) {
+	a, b, c := &fakeSource{id: 0}, &fakeSource{id: 1}, &fakeSource{id: 2}
+	p := newPool([]blobSource{a, b, c})
+
+	var got []int
+	for range 7 {
+		got = append(got, p.pick().(*fakeSource).id)
+	}
+	want := []int{0, 1, 2, 0, 1, 2, 0}
+	if !slices.Equal(got, want) {
+		t.Fatalf("pick order = %v, want %v", got, want)
+	}
+}
+
+func TestPoolDistributesPublicMethods(t *testing.T) {
+	members := []*fakeSource{{}, {}, {}}
+	sources := make([]blobSource, len(members))
+	for i, m := range members {
+		sources[i] = m
+	}
+	p := newPool(sources)
+
+	ctx := context.Background()
+	// Each iteration issues one of each read method (3 picks); 3 iterations
+	// spread 9 picks evenly across the 3 members.
+	for range 3 {
+		if _, err := p.FindMissingBlobs(ctx, nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := p.ReadBlob(ctx, Digest{}); err != nil {
+			t.Fatal(err)
+		}
+		rc, err := p.ReaderForBlob(ctx, Digest{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rc.Close()
+	}
+
+	for i, m := range members {
+		if m.calls != 3 {
+			t.Errorf("member %d handled %d calls, want 3", i, m.calls)
+		}
+	}
+}
+
+func TestPoolSingleMember(t *testing.T) {
+	only := &fakeSource{}
+	p := newPool([]blobSource{only})
+
+	ctx := context.Background()
+	for range 5 {
+		if _, err := p.ReadBlob(ctx, Digest{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if only.calls != 5 {
+		t.Fatalf("single member handled %d calls, want 5", only.calls)
+	}
+}
+
+func TestNewPoolEmptyPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for empty pool")
+		}
+	}()
+	newPool(nil)
+}


### PR DESCRIPTION
Reading image-layer blobs from the remote CAS during `img deploy` used a single gRPC ClientConn, which multiplexes every read onto one TCP connection. On high-latency links (e.g. a remote cache reached over a VPN) that single connection's congestion window and TCP receive buffer cap download throughput regardless of --jobs.

Add cas.Pool, which round-robins CAS reads across N independent gRPC connections (each with its own TCP window), and wire it into deploy. The pool size defaults to --jobs (the number of concurrent reads in flight) and can be overridden with IMG_REAPI_MAX_CONNECTIONS. Analogous to Bazel's --remote_max_connections.