### PR TITLE
fix: write pull_manifest_blob manifest.json as a regular file (#625)

### DIFF
--- a/img/private/repository_rules/pull_blob.bzl
+++ b/img/private/repository_rules/pull_blob.bzl
@@ -281,9 +281,15 @@ def _pull_manifest_blob_impl(rctx):
         downloader = rctx.attr.downloader,
         reference = reference,
     )
-    rctx.symlink(
-        manifest_info.path,
+
+    # Write the manifest as a regular file rather than a symlink. An absolute
+    # symlink into the fetch-time output base must not appear in a repo declared
+    # reproducible: under Bazel 9 it poisons the shared repo contents cache and
+    # becomes dangling once the original output base is deleted (see #625).
+    rctx.file(
         "manifest.json",
+        content = manifest_info.data,
+        executable = False,
     )
     rctx.file(
         "digest",


### PR DESCRIPTION
pull_manifest_blob symlinked manifest.json to the downloaded blob at blobs/sha256/<digest>. rctx.symlink resolves this to an absolute path into the fetch-time output base, and the repo is then declared reproducible. Under Bazel 9 the reproducible repo is stored in the shared repo contents cache, so the cache entry embeds an absolute symlink that is only valid while the originating output base exists. Once that output base is deleted, any other workspace restoring the cache entry gets a dangling manifest.json and fails with FileNotFoundException, surviving even bazel clean --expunge.

Write manifest.json as a regular file from manifest_info.data instead. Every download_manifest_* path already populates data via rctx.read, and on Bazel >= 8 the round-trip is byte-exact, so the repo becomes genuinely reproducible and cache-safe.

Fixes https://github.com/bazel-contrib/rules_img/issues/625