### PR TITLE
org.opencontainers.image.ref.name value backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ common --@rules_img//img/settings:mtree_layer_layout=tar
 # the per-layer files to keep their whiteout markers, so leave mtree_layer_layout
 # at "tar" when using it.
 common --@rules_img//img/settings:mtree_image_layout=oci_layer_filesystem_applied_changeset
+
+# How org.opencontainers.image.ref.name is set in the docker save index.json.
+# "full_reference" (default) writes the full image reference
+# (e.g. registry.io/repo:tag). This is what most tools expect: rules_oci,
+# skopeo, and containerd all use the full reference to identify images.
+# "tag_only" writes just the tag (e.g. "tag"), which is what the OCI image
+# spec technically recommends. Use this if you need strict spec compliance, but
+# note that tools relying on the full reference to look up images will not find
+# them.
+common --@rules_img//img/settings:oci_ref_name=full_reference
 ```
 
 </details>

--- a/img/private/load.bzl
+++ b/img/private/load.bzl
@@ -59,6 +59,8 @@ def _build_docker_tarball(ctx, configuration_json, manifest_info = None, index_i
     args.add("--configuration-file", configuration_json.path)
     if ctx.attr._oci_layout_settings[OCILayoutSettingsInfo].allow_shallow_oci_layout:
         args.add("--allow-missing-blobs")
+    if ctx.attr._oci_ref_name[BuildSettingInfo].value == "tag_only":
+        args.add("--oci-ref-name-tag-only")
 
     inputs = [configuration_json]
 
@@ -341,6 +343,10 @@ Available options:
         ),
         _docker_config_path = attr.label(
             default = Label("//img/settings:docker_config_path"),
+            providers = [BuildSettingInfo],
+        ),
+        _oci_ref_name = attr.label(
+            default = Label("//img/settings:oci_ref_name"),
             providers = [BuildSettingInfo],
         ),
     ),

--- a/img/settings/BUILD.bazel
+++ b/img/settings/BUILD.bazel
@@ -262,3 +262,17 @@ string_flag(
     ],
     visibility = ["//visibility:public"],
 )
+
+# Controls how org.opencontainers.image.ref.name is set in the docker save index.json.
+# "full_reference" (default) uses the full image reference (e.g. registry.io/repo:tag),
+# which is compatible with skopeo and rules_oci.
+# "tag_only" uses just the tag (e.g. "tag"), which matches the OCI image spec.
+string_flag(
+    name = "oci_ref_name",
+    build_setting_default = "full_reference",
+    values = [
+        "full_reference",
+        "tag_only",
+    ],
+    visibility = ["//img/private:__subpackages__"],
+)

--- a/img_tool/cmd/dockersave/dockersave.go
+++ b/img_tool/cmd/dockersave/dockersave.go
@@ -108,6 +108,7 @@ func DockerSaveProcess(ctx context.Context, args []string) {
 	var indexPath string
 	var manifestPaths stringSliceFlag
 	var configPaths stringSliceFlag
+	var ociRefNameTagOnly bool
 
 	flagSet := flag.NewFlagSet("docker-save", flag.ExitOnError)
 	flagSet.Usage = func() {
@@ -137,6 +138,7 @@ func DockerSaveProcess(ctx context.Context, args []string) {
 	flagSet.StringVar(&indexPath, "index", "", "Path to the image index (for multi-platform, mutually exclusive with --manifest and --config)")
 	flagSet.Var(&manifestPaths, "manifest-path", "Path to manifest file (for index, can be specified multiple times)")
 	flagSet.Var(&configPaths, "config-path", "Path to config file (for index, can be specified multiple times)")
+	flagSet.BoolVar(&ociRefNameTagOnly, "oci-ref-name-tag-only", false, "Set org.opencontainers.image.ref.name to just the tag (OCI spec); default uses the full reference (compatible with skopeo and rules_oci)")
 
 	if err := flagSet.Parse(args); err != nil {
 		flagSet.Usage()
@@ -194,7 +196,7 @@ func DockerSaveProcess(ctx context.Context, args []string) {
 			fmt.Fprintf(os.Stderr, "Error: --index requires at least one --manifest-path and --config-path\n")
 			os.Exit(1)
 		}
-		err = assembleDockerSaveWithIndex(indexPath, outputPath, format, manifestPaths, configPaths, layerFlags, repoTags, ociTags, useSymlinks, allowMissingBlobs)
+		err = assembleDockerSaveWithIndex(indexPath, outputPath, format, manifestPaths, configPaths, layerFlags, repoTags, ociTags, useSymlinks, allowMissingBlobs, ociRefNameTagOnly)
 	} else {
 		// Single manifest mode
 		if manifestPath == "" {
@@ -211,7 +213,7 @@ func DockerSaveProcess(ctx context.Context, args []string) {
 			fmt.Fprintf(os.Stderr, "Error: cannot use --manifest-path or --config-path without --index\n")
 			os.Exit(1)
 		}
-		err = assembleDockerSave(manifestPath, configPath, outputPath, format, layerFlags, repoTags, ociTags, useSymlinks, allowMissingBlobs)
+		err = assembleDockerSave(manifestPath, configPath, outputPath, format, layerFlags, repoTags, ociTags, useSymlinks, allowMissingBlobs, ociRefNameTagOnly)
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -219,7 +221,7 @@ func DockerSaveProcess(ctx context.Context, args []string) {
 	}
 }
 
-func assembleDockerSave(manifestPath, configPath, outputPath, format string, layers layerMappingFlag, repoTags, ociTags []string, useSymlinks, allowMissingBlobs bool) error {
+func assembleDockerSave(manifestPath, configPath, outputPath, format string, layers layerMappingFlag, repoTags, ociTags []string, useSymlinks, allowMissingBlobs, ociRefNameTagOnly bool) error {
 	// Read and parse the manifest
 	manifestData, err := os.ReadFile(manifestPath)
 	if err != nil {
@@ -271,12 +273,12 @@ func assembleDockerSave(manifestPath, configPath, outputPath, format string, lay
 	}
 
 	if format == "tar" {
-		return assembleDockerSaveTar(outputPath, &manifest, manifestData, blobs, repoTags, ociTags)
+		return assembleDockerSaveTar(outputPath, &manifest, manifestData, blobs, repoTags, ociTags, ociRefNameTagOnly)
 	}
-	return assembleDockerSaveDirectory(outputPath, &manifest, manifestData, blobs, repoTags, ociTags, useSymlinks)
+	return assembleDockerSaveDirectory(outputPath, &manifest, manifestData, blobs, repoTags, ociTags, useSymlinks, ociRefNameTagOnly)
 }
 
-func assembleDockerSaveTar(outputPath string, manifest *v1.Manifest, manifestData []byte, blobs blobMap, repoTags, ociTags []string) error {
+func assembleDockerSaveTar(outputPath string, manifest *v1.Manifest, manifestData []byte, blobs blobMap, repoTags, ociTags []string, ociRefNameTagOnly bool) error {
 	var w *os.File
 	var err error
 	if outputPath == "-" {
@@ -291,13 +293,14 @@ func assembleDockerSaveTar(outputPath string, manifest *v1.Manifest, manifestDat
 
 	source := &fileBlobSource{blobs: blobs}
 	opts := ocitar.Options{
-		Tags:    repoTags,
-		OCITags: ociTags,
+		Tags:              repoTags,
+		OCITags:           ociTags,
+		OCIRefNameTagOnly: ociRefNameTagOnly,
 	}
 	return ocitar.WriteSingleManifest(context.Background(), w, manifest, manifestData, source, opts)
 }
 
-func assembleDockerSaveDirectory(outputPath string, manifest *v1.Manifest, manifestData []byte, blobs blobMap, repoTags, ociTags []string, useSymlinks bool) error {
+func assembleDockerSaveDirectory(outputPath string, manifest *v1.Manifest, manifestData []byte, blobs blobMap, repoTags, ociTags []string, useSymlinks, ociRefNameTagOnly bool) error {
 	sink := NewDirectorySink(outputPath)
 	defer sink.Close()
 
@@ -318,7 +321,7 @@ func assembleDockerSaveDirectory(outputPath string, manifest *v1.Manifest, manif
 	if manifest.Config.MediaType != "" && !manifest.Config.MediaType.IsConfig() {
 		artifactType = string(manifest.Config.MediaType)
 	}
-	manifests := ocitar.DescriptorsForTags(ociTags, manifest.MediaType, manifestData, manifestDigest, artifactType)
+	manifests := ocitar.DescriptorsForTags(ociTags, manifest.MediaType, manifestData, manifestDigest, artifactType, ociRefNameTagOnly)
 	ociIndex := v1.IndexManifest{
 		SchemaVersion: 2,
 		MediaType:     "application/vnd.oci.image.index.v1+json",
@@ -400,7 +403,7 @@ func (f *fileBlobSource) OpenBlob(_ context.Context, hexDigest string) (io.ReadC
 	return file, info.Size(), nil
 }
 
-func assembleDockerSaveWithIndex(indexPath, outputPath, format string, manifestPaths, configPaths []string, layers layerMappingFlag, repoTags, ociTags []string, useSymlinks, allowMissingBlobs bool) error {
+func assembleDockerSaveWithIndex(indexPath, outputPath, format string, manifestPaths, configPaths []string, layers layerMappingFlag, repoTags, ociTags []string, useSymlinks, allowMissingBlobs, ociRefNameTagOnly bool) error {
 	// Build a map of available layers by their digest
 	layerBlobsByDigest := make(map[string]string)
 	for _, layer := range layers {
@@ -475,12 +478,12 @@ func assembleDockerSaveWithIndex(indexPath, outputPath, format string, manifestP
 	blobs[indexDigest.Hex] = indexPath
 
 	if format == "tar" {
-		return assembleDockerSaveWithIndexTar(outputPath, indexData, manifestInfos, blobs, repoTags, ociTags)
+		return assembleDockerSaveWithIndexTar(outputPath, indexData, manifestInfos, blobs, repoTags, ociTags, ociRefNameTagOnly)
 	}
-	return assembleDockerSaveWithIndexDirectory(outputPath, indexData, indexDigest, manifestInfos, blobs, repoTags, ociTags, useSymlinks)
+	return assembleDockerSaveWithIndexDirectory(outputPath, indexData, indexDigest, manifestInfos, blobs, repoTags, ociTags, useSymlinks, ociRefNameTagOnly)
 }
 
-func assembleDockerSaveWithIndexTar(outputPath string, indexData []byte, manifestInfos []ocitar.ManifestInfo, blobs blobMap, repoTags, ociTags []string) error {
+func assembleDockerSaveWithIndexTar(outputPath string, indexData []byte, manifestInfos []ocitar.ManifestInfo, blobs blobMap, repoTags, ociTags []string, ociRefNameTagOnly bool) error {
 	var w *os.File
 	var err error
 	if outputPath == "-" {
@@ -495,13 +498,14 @@ func assembleDockerSaveWithIndexTar(outputPath string, indexData []byte, manifes
 
 	source := &fileBlobSource{blobs: blobs}
 	opts := ocitar.Options{
-		Tags:    repoTags,
-		OCITags: ociTags,
+		Tags:              repoTags,
+		OCITags:           ociTags,
+		OCIRefNameTagOnly: ociRefNameTagOnly,
 	}
 	return ocitar.WriteIndex(context.Background(), w, indexData, manifestInfos, source, opts)
 }
 
-func assembleDockerSaveWithIndexDirectory(outputPath string, indexData []byte, indexDigest v1.Hash, manifestInfos []ocitar.ManifestInfo, blobs blobMap, repoTags, ociTags []string, useSymlinks bool) error {
+func assembleDockerSaveWithIndexDirectory(outputPath string, indexData []byte, indexDigest v1.Hash, manifestInfos []ocitar.ManifestInfo, blobs blobMap, repoTags, ociTags []string, useSymlinks, ociRefNameTagOnly bool) error {
 	sink := NewDirectorySink(outputPath)
 	defer sink.Close()
 
@@ -516,7 +520,7 @@ func assembleDockerSaveWithIndexDirectory(outputPath string, indexData []byte, i
 	}
 
 	// Write new root index.json referencing the pre-built index blob
-	manifests := ocitar.DescriptorsForTags(ociTags, types.OCIImageIndex, indexData, indexDigest, "")
+	manifests := ocitar.DescriptorsForTags(ociTags, types.OCIImageIndex, indexData, indexDigest, "", ociRefNameTagOnly)
 	rootIndex := v1.IndexManifest{
 		SchemaVersion: 2,
 		MediaType:     "application/vnd.oci.image.index.v1+json",

--- a/img_tool/pkg/ocitar/ocitar.go
+++ b/img_tool/pkg/ocitar/ocitar.go
@@ -32,10 +32,11 @@ type ManifestDescriptor struct {
 }
 
 type Options struct {
-	Tags           []string
-	OCITags        []string
-	ProgressFunc   func(ctx context.Context, size int64, name string) io.Writer
-	ManifestFilter ManifestFilter
+	Tags              []string
+	OCITags           []string
+	ProgressFunc      func(ctx context.Context, size int64, name string) io.Writer
+	ManifestFilter    ManifestFilter
+	OCIRefNameTagOnly bool // if true, org.opencontainers.image.ref.name is set to just the tag (OCI spec); default is full reference (compatible with skopeo/rules_oci)
 }
 
 type ManifestInfo struct {
@@ -61,7 +62,9 @@ func hashBytes(data []byte) v1.Hash {
 // can recover image names from the descriptors of the root index.json file based on some well-known annotations:
 //   - Containerd uses "io.containerd.image.name" to refer to the full image name (<registry>/<repository>:<tag>)
 //   - Apple Containerization uses "com.apple.containerization.image.name" to refer to the full image name (<registry>/<repository>:<tag>)
-//   - The OCI image spec mentions "org.opencontainers.image.ref.name" to refer to the tag only (i.e. "latest")
+//   - The OCI image spec mentions "org.opencontainers.image.ref.name" to refer to the tag only (i.e. "latest"),
+//     but we set it to the full image reference by default because tools like skopeo require a fully-qualified reference.
+//     Pass tagOnly=true to use the OCI-spec-compliant short tag form instead.
 //
 // Note that the "org.opencontainers.image.ref.name" may not be unique within the index.json file.
 // This is surprising, but allowed by the OCI image spec. Other tools also generate duplicate ref.name attributes.
@@ -70,7 +73,7 @@ func hashBytes(data []byte) v1.Hash {
 //
 // Annotations from the referenced content (data) are copied into the produced descriptors.
 // Tag annotations take precedence over content annotations.
-func DescriptorsForTags(ociTags []string, mediaType types.MediaType, data []byte, digest v1.Hash, artifactType string) []v1.Descriptor {
+func DescriptorsForTags(ociTags []string, mediaType types.MediaType, data []byte, digest v1.Hash, artifactType string, tagOnly bool) []v1.Descriptor {
 	size := int64(len(data))
 
 	var parsed struct {
@@ -92,8 +95,12 @@ func DescriptorsForTags(ociTags []string, mediaType types.MediaType, data []byte
 		maps.Copy(annotations, parsed.Annotations)
 		annotations[api.AnnotationContainerdImageName] = repoTag
 		annotations[api.AnnotationAppleContainerizationImageName] = repoTag
-		if ref, err := name.NewTag(repoTag, name.WithDefaultTag("")); err == nil && ref.TagStr() != "" {
-			annotations[api.AnnotationOCIImageRefName] = ref.TagStr()
+		if tagOnly {
+			if ref, err := name.NewTag(repoTag, name.WithDefaultTag("")); err == nil && ref.TagStr() != "" {
+				annotations[api.AnnotationOCIImageRefName] = ref.TagStr()
+			}
+		} else {
+			annotations[api.AnnotationOCIImageRefName] = repoTag
 		}
 		desc := v1.Descriptor{
 			MediaType:   mediaType,
@@ -120,7 +127,7 @@ func WriteSingleManifest(ctx context.Context, w io.Writer, manifest *v1.Manifest
 	if manifest.Config.MediaType != "" && !manifest.Config.MediaType.IsConfig() {
 		artifactType = string(manifest.Config.MediaType)
 	}
-	indexManifests := DescriptorsForTags(opts.OCITags, manifest.MediaType, manifestData, manifestDigest, artifactType)
+	indexManifests := DescriptorsForTags(opts.OCITags, manifest.MediaType, manifestData, manifestDigest, artifactType, opts.OCIRefNameTagOnly)
 	ociIndex := v1.IndexManifest{
 		SchemaVersion: 2,
 		MediaType:     "application/vnd.oci.image.index.v1+json",
@@ -251,7 +258,7 @@ func WriteIndex(ctx context.Context, w io.Writer, indexData []byte, manifestInfo
 	indexDigest := hashBytes(indexData)
 
 	// Build root OCI index.json (wraps the original index blob)
-	rootManifests := DescriptorsForTags(opts.OCITags, types.OCIImageIndex, indexData, indexDigest, "")
+	rootManifests := DescriptorsForTags(opts.OCITags, types.OCIImageIndex, indexData, indexDigest, "", opts.OCIRefNameTagOnly)
 	rootIndex := v1.IndexManifest{
 		SchemaVersion: 2,
 		MediaType:     "application/vnd.oci.image.index.v1+json",

--- a/img_tool/pkg/ocitar/ocitar_test.go
+++ b/img_tool/pkg/ocitar/ocitar_test.go
@@ -97,8 +97,27 @@ func TestWriteSingleManifest(t *testing.T) {
 	if index.Manifests[0].Annotations["io.containerd.image.name"] != "registry.io/repo:v1.0" {
 		t.Errorf("wrong containerd annotation: %v", index.Manifests[0].Annotations)
 	}
-	if index.Manifests[0].Annotations["org.opencontainers.image.ref.name"] != "v1.0" {
+	if index.Manifests[0].Annotations["org.opencontainers.image.ref.name"] != "registry.io/repo:v1.0" {
 		t.Errorf("wrong ref.name annotation: %v", index.Manifests[0].Annotations)
+	}
+
+	// Verify tagOnly mode produces just the tag
+	var buf2 bytes.Buffer
+	optsTagOnly := Options{
+		Tags:              []string{"registry.io/repo:v1.0"},
+		OCITags:           []string{"registry.io/repo:v1.0"},
+		OCIRefNameTagOnly: true,
+	}
+	if err := WriteSingleManifest(context.Background(), &buf2, manifest, manifestData, source, optsTagOnly); err != nil {
+		t.Fatalf("WriteSingleManifest (tagOnly) failed: %v", err)
+	}
+	filesTagOnly := extractTar(t, &buf2)
+	var indexTagOnly v1.IndexManifest
+	if err := json.Unmarshal(filesTagOnly["index.json"], &indexTagOnly); err != nil {
+		t.Fatalf("parsing tagOnly index.json: %v", err)
+	}
+	if indexTagOnly.Manifests[0].Annotations["org.opencontainers.image.ref.name"] != "v1.0" {
+		t.Errorf("tagOnly: wrong ref.name annotation: %v", indexTagOnly.Manifests[0].Annotations)
 	}
 
 	// Verify manifest.json (Docker format)


### PR DESCRIPTION
rules_oci used to set `org.opencontainers.image.ref.name` to the full image name (registry/repository:tag).
The OCI spec recommends to use just the tag.
We now support both, but use the full name by default. This makes the output compatible with tools that previously interacted with rules_oci (such as `skopeo copy`).