### PR TITLE
pull: add 'final' target without platform constraints

### DIFF
--- a/e2e/generic/load/BUILD.bazel
+++ b/e2e/generic/load/BUILD.bazel
@@ -81,7 +81,7 @@ image_load(
 # Load alpine base image without modifying it
 image_load(
     name = "load_alpine",
-    image = "@alpine",
+    image = "@alpine//:final",
     tag = "ghcr.io/malt3/rules_img:alpine-sideloaded",
     visibility = ["//visibility:public"],
 )

--- a/img/private/repository_rules/pull.bzl
+++ b/img/private/repository_rules/pull.bzl
@@ -196,13 +196,19 @@ package_metadata(
 {maybe_lazy_layer_download}
 
 image_import(
-    name = "image",
+    name = "image_import",
     digest = {digest},
     data = {data},
     files = {files},
     registries = {registries},
     repository = {repository},
     tag = {tag},
+    visibility = ["//visibility:private"],
+)
+
+alias(
+    name = "image",
+    actual = ":image_import",
     target_compatible_with = {target_compatible_with},
     visibility = ["//visibility:public"],
 )
@@ -210,6 +216,12 @@ image_import(
 alias(
     name = {name},
     actual = ":image",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "final",
+    actual = ":image_import",
     visibility = ["//visibility:public"],
 )
 """.format(


### PR DESCRIPTION
This PR updates the generated BUILD file for the `pull` repo rule to create an extra `final` alias without `target_compatible_with` contraints.

Closes #440.