### PR TITLE
pull: add 'load' target for final images

### DIFF
--- a/e2e/workspace/WORKSPACE.bazel
+++ b/e2e/workspace/WORKSPACE.bazel
@@ -24,6 +24,9 @@ img_register_prebuilt_toolchains()
 
 register_toolchains("@img_toolchain//:all")
 
+# Register hermetic launcher toolchains
+register_toolchains("@hermetic_launcher//launcher/private/prebuilt:all")
+
 # Pull Alpine Linux as base image for WORKSPACE mode test
 load("@rules_img//img:pull.bzl", "pull")
 

--- a/img/dependencies.bzl
+++ b/img/dependencies.bzl
@@ -54,3 +54,9 @@ def rules_img_dependencies():
         strip_prefix = "rules_runfiles_group-0.0.1-rc.3",
         url = "https://github.com/hermeticbuild/rules_runfiles_group/releases/download/v0.0.1-rc.3/rules_runfiles_group-v0.0.1-rc.3.tar.gz",
     )
+
+    http_archive(
+        name = "hermetic_launcher",
+        sha256 = "eeb520ca97697368a4d459e06f37600550971291171a1257f02a33e17fdd2df9",
+        url = "https://github.com/hermeticbuild/hermetic-launcher/releases/download/v0.0.10/hermetic_launcher-v0.0.10.tar.gz",
+    )

--- a/img/private/release/release_notes/release_notes.go
+++ b/img/private/release/release_notes/release_notes.go
@@ -103,6 +103,9 @@ load("@rules_img//img:repositories.bzl", "img_register_prebuilt_toolchains")
 img_register_prebuilt_toolchains()
 register_toolchains("@img_toolchain//:all")
 
+# Register hermetic launcher toolchains
+register_toolchains("@hermetic_launcher//launcher/private/prebuilt:all")
+
 # Example: Pull a base image
 load("@rules_img//img:pull.bzl", "pull")
 pull(

--- a/img/private/repository_rules/pull.bzl
+++ b/img/private/repository_rules/pull.bzl
@@ -152,6 +152,7 @@ def _pull_impl(rctx):
     loads = [
         (str(Label("@package_metadata//rules:package_metadata.bzl")), "package_metadata"),
         (str(Label("@rules_img//img/private:import.bzl")), "image_import"),
+        (str(Label("@rules_img//img:load.bzl")), "image_load"),
     ]
     maybe_lazy_layer_download = ""
     if rctx.attr.layer_handling == "lazy":
@@ -224,6 +225,13 @@ alias(
     actual = ":image_import",
     visibility = ["//visibility:public"],
 )
+
+image_load(
+    name = "load",
+    image = ":final",
+    tag = {load_tag},
+    visibility = ["//visibility:public"],
+)
 """.format(
             target_compatible_with = target_compatible_with,
             loads = "\n".join(
@@ -250,6 +258,7 @@ alias(
             purl = repr(purl),
             repository = repr(rctx.attr.repository),
             tag = repr(rctx.attr.tag) if rctx.attr.tag else "None",
+            load_tag = repr(registries[0] + "/" + rctx.attr.repository + ((":" + rctx.attr.tag) if rctx.attr.tag else ("@" + digest))),
         ),
     )
     rctx.file("REPO.bazel", """\


### PR DESCRIPTION
Follow-up to #628.

This PR adds a `load` target in the pull repo rule to load the remote image directly into a daemon using the default load strategy and daemon.

The image is named according to the registry, repo, and tag (if available, otherwise the digest), mirroring the loading behavior of `docker pull`.

This can be used by users who wish to write integration tests which require loading remote images without the indirection of defining a custom `image_load` target.

More fully resolves #440.