### PR TITLE
fix(push): suppress progress bar in persistent-worker mode

### DIFF
--- a/img_tool/pkg/push/push.go
+++ b/img_tool/pkg/push/push.go
@@ -134,15 +134,13 @@ func (u *uploader) PushAll(ctx context.Context, ops []api.IndexedPushDeployOpera
 		}
 	}
 
-	ctx, stopProgress := progress.InitProgress(ctx, "pushed")
-	prog := progress.NewIndeterminate(ctx, "pushing")
-
-	var progCh chan registryv1.Update
-	var drainWg sync.WaitGroup
-
 	pusher := u.pusher
 	if pusher == nil {
-		progCh = make(chan registryv1.Update, 256)
+		ctx, stopProgress := progress.InitProgress(ctx, "pushed")
+		prog := progress.NewIndeterminate(ctx, "pushing")
+
+		progCh := make(chan registryv1.Update, 256)
+		var drainWg sync.WaitGroup
 		drainWg.Add(1)
 		go func() {
 			defer drainWg.Done()
@@ -156,18 +154,17 @@ func (u *uploader) PushAll(ctx context.Context, ops []api.IndexedPushDeployOpera
 		if err != nil {
 			close(progCh)
 			drainWg.Wait()
+			prog.Done(err)
+			stopProgress()
 			return nil, fmt.Errorf("creating pusher: %w", err)
 		}
-	}
-
-	defer func() {
-		if progCh != nil {
+		defer func() {
 			close(progCh)
 			drainWg.Wait()
-		}
-		prog.Done(retErr)
-		stopProgress()
-	}()
+			prog.Done(retErr)
+			stopProgress()
+		}()
+	}
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(u.jobs)


### PR DESCRIPTION
Progress setup (InitProgress, NewIndeterminate, progCh) was always called in PushAll, even when a pre-created pusher was provided. In persistent-worker mode this produced a stuck indeterminate tracker with no byte-level updates. Scope all progress infrastructure to the `if pusher == nil` branch so it only runs when PushAll creates its own pusher (single-shot mode); the persistent worker continues to supply h.pusher via WithPusher and takes the no-progress path.