### PR TITLE
feat(load): align image_load API with image_push (registry/repository…

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,30 @@ Run with:
 bazel run //:push
 ```
 
+### 4. Load into a Local Daemon
+
+```starlark
+load("@rules_img//img:load.bzl", "image_load")
+
+image_load(
+    name = "load",
+    image = ":image",
+    registry = "ghcr.io",
+    repository = "my-project/app",
+    tag = "latest",
+)
+```
+
+Run with:
+```bash
+bazel run //:load
+```
+
+`image_load` takes the same `registry` / `repository` / `tag` split as
+`image_push`, so the same image is easy to push to a registry later. A single
+fully-qualified `tag` (with no `registry`/`repository`) also works for
+`rules_oci` compatibility.
+
 ### Composing Images from Layers
 
 For more control over the image contents, you can compose images from individual layers using `image_layer` and `image_manifest`:

--- a/docs/load.md
+++ b/docs/load.md
@@ -26,20 +26,37 @@ image_manifest(
     layers = [":app_layer"],
 )
 
-# Create a load target with a single tag
+# Preferred: the same registry/repository/tag split as image_push. The loaded
+# image name is reconstructed as "my-registry.example.com/my-app:latest".
 image_load(
     name = "load",
+    image = ":my_image",
+    registry = "my-registry.example.com",
+    repository = "my-app",
+    tag = "latest",
+)
+
+# The rules_oci-compatible form still works: when loading into a daemon the image
+# name is just a string, so a single fully-qualified tag (with no
+# registry/repository) is used verbatim.
+image_load(
+    name = "load_legacy",
     image = ":my_image",
     tag = "my-app:latest",
 )
 
-# Load with multiple tags
+# Load with multiple full-reference tags
 image_load(
     name = "load_multi",
     image = ":my_image",
     tag_list = ["my-app:latest", "my-app:v1.0.0"],
 )
 ```
+
+Splitting the name into `registry` / `repository` / `tag` is optional and does
+not change what a local daemon sees; it just keeps the load target aligned with
+a matching `image_push`, making it easy to push the same image to a registry
+later.
 
 Then run:
 ```bash
@@ -68,8 +85,8 @@ bazel run //path/to:load_target -- --platform linux/amd64
 <pre>
 load("@rules_img//img:load.bzl", "image_load")
 
-image_load(<a href="#image_load-name">name</a>, <a href="#image_load-build_settings">build_settings</a>, <a href="#image_load-daemon">daemon</a>, <a href="#image_load-deploy_tool">deploy_tool</a>, <a href="#image_load-image">image</a>, <a href="#image_load-stamp">stamp</a>, <a href="#image_load-strategy">strategy</a>, <a href="#image_load-tag">tag</a>, <a href="#image_load-tag_file">tag_file</a>,
-           <a href="#image_load-tag_list">tag_list</a>, <a href="#image_load-tool_cfg">tool_cfg</a>, <a href="#image_load-tracks_content">tracks_content</a>)
+image_load(<a href="#image_load-name">name</a>, <a href="#image_load-build_settings">build_settings</a>, <a href="#image_load-daemon">daemon</a>, <a href="#image_load-deploy_tool">deploy_tool</a>, <a href="#image_load-image">image</a>, <a href="#image_load-registry">registry</a>, <a href="#image_load-repository">repository</a>, <a href="#image_load-stamp">stamp</a>, <a href="#image_load-strategy">strategy</a>,
+           <a href="#image_load-tag">tag</a>, <a href="#image_load-tag_file">tag_file</a>, <a href="#image_load-tag_list">tag_list</a>, <a href="#image_load-tool_cfg">tool_cfg</a>, <a href="#image_load-tracks_content">tracks_content</a>)
 </pre>
 
 Loads container images into a local daemon (Docker, containerd, or Podman).
@@ -86,6 +103,14 @@ Key features:
 
 The rule produces an executable that can be run with `bazel run`.
 
+Image names: when loading into a local daemon the image name is ultimately just
+a string, so a single fully-qualified `tag` (the rules_oci-compatible form) is
+all a daemon needs. The rule also accepts the same `registry` / `repository` /
+`tag` split as `image_push`; the loaded name is simply reconstructed as
+`{registry}/{repository}:{tag}`. Splitting it out is purely a convenience: it
+keeps the load target aligned with a matching `image_push` so the same image is
+easy to push to a registry later.
+
 Output groups:
 - `tarball`: "docker save" compatible tarball with OCI layout (available for both single and multi-platform images).
   For multi-platform images, the first manifest is used as the default in `manifest.json`,
@@ -98,29 +123,42 @@ Example:
 ```python
 load("@rules_img//img:load.bzl", "image_load")
 
-# Load a single-platform image with a single tag
+# Load using separate registry/repository/tag (same API as image_push).
+# The loaded image name is reconstructed as gcr.io/my-project/my-app:latest.
 image_load(
     name = "load_app",
     image = ":my_app",  # References an image_manifest
+    registry = "gcr.io",
+    repository = "my-project/my-app",
+    tag = "latest",
+)
+
+# Load a multi-platform image with the split API
+image_load(
+    name = "load_multiarch",
+    image = ":my_app_index",  # References an image_index
+    registry = "gcr.io",
+    repository = "my-project/my-app",
+    tag = "latest",
+    daemon = "containerd",  # Explicitly use containerd
+)
+
+# The rules_oci-compatible form still works: a single fully-qualified tag with no
+# registry/repository is used verbatim as the loaded image name.
+image_load(
+    name = "load_legacy",
+    image = ":my_app",
     tag = "my-app:latest",
 )
 
-# Load with multiple tags
+# ...including multiple full-reference tags:
 image_load(
     name = "load_multi",
     image = ":my_app",
     tag_list = ["my-app:latest", "my-app:v1.0.0", "my-app:stable"],
 )
 
-# Load a multi-platform image
-image_load(
-    name = "load_multiarch",
-    image = ":my_app_index",  # References an image_index
-    tag = "my-app:latest",
-    daemon = "containerd",  # Explicitly use containerd
-)
-
-# Load with dynamic tagging
+# Load with dynamic tagging (template expansion works with either form)
 image_load(
     name = "load_dynamic",
     image = ":my_app",
@@ -165,9 +203,11 @@ Performance notes:
 | <a id="image_load-daemon"></a>daemon |  Container daemon to use for loading the image.<br><br>Available options: - **`auto`** (default): Uses the global default setting (usually `docker`) - **`containerd`**: Loads directly into containerd namespace. Supports multi-platform images   and incremental loading. - **`docker`**: Loads via Docker daemon. When Docker uses containerd storage (23.0+),   loads directly into containerd. Otherwise falls back to `docker image load` command which   is slower and limited to single-platform images. - **`podman`**: Loads via Podman daemon using `podman image load` command. Similar to Docker   fallback mode, this is slower than containerd and limited to single-platform images. - **`containerization`**: Loads via Apple's Containerization framework using `container image load`.   Reads a unified OCI+Docker tar from stdin. - **`tar`**: Does not load into any daemon. Instead, streams the unified OCI+Docker tar to stdout.   Useful for piping to other tools or saving to a file. - **`generic`**: Loads via a custom container runtime. The loader will invoke the command   specified in the `LOADER_BINARY` environment variable with `image load` subcommands. For example,   if `LOADER_BINARY=nerdctl`, it will run `nerdctl image load`.   Requires `LOADER_BINARY` to be set at runtime.<br><br>The best performance is achieved with: - Direct containerd access (daemon = "containerd") - Docker 23.0+ with containerd storage enabled and accessible containerd socket   | String | optional |  `"auto"`  |
 | <a id="image_load-deploy_tool"></a>deploy_tool |  Optional label of a deploy tool target providing `DeployToolInfo` (created with `img_deploy_tool` from `@rules_img//img:deploy_tool.bzl`). When set, overrides `tool_cfg`.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="image_load-image"></a>image |  Image to load. Should provide ImageManifestInfo or ImageIndexInfo.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="image_load-registry"></a>registry |  Registry component of the image name to load.<br><br>Optional. When set, `repository` must also be set, and each entry in `tag` / `tag_list` / `tag_file` is treated as a bare tag: the loaded image name is reconstructed as `{registry}/{repository}:{tag}` (mirroring `image_push`).<br><br>When omitted (together with `repository`), the tags are used verbatim as full image references, preserving the `rules_oci`-compatible behavior.<br><br>Subject to [template expansion](/docs/templating.md).   | String | optional |  `""`  |
+| <a id="image_load-repository"></a>repository |  Repository component of the image name to load.<br><br>Optional. Must be set together with `registry` (see `registry` for details).<br><br>Subject to [template expansion](/docs/templating.md).   | String | optional |  `""`  |
 | <a id="image_load-stamp"></a>stamp |  Controls build stamping for template expansion.<br><br>- **`auto`** (default): Defers to the global `--@rules_img//img/settings:stamp` setting. - **`force`**: Always stamp if templates contain `{{}}` placeholders, ignoring Bazel's `--stamp` flag. - **`disabled`**: Never include stamp information.<br><br>See [template expansion](/docs/templating.md) for available stamp variables.   | String | optional |  `"auto"`  |
 | <a id="image_load-strategy"></a>strategy |  Strategy for handling image layers during load.<br><br>Available strategies: - **`auto`** (default): Uses the global default load strategy - **`eager`**: Downloads all layers during the build phase. Ensures all layers are   available locally before running the load command. - **`lazy`**: Downloads layers only when needed during the load operation. More   efficient for large images where some layers might already exist in the daemon.   | String | optional |  `"auto"`  |
-| <a id="image_load-tag"></a>tag |  Tag to apply when loading the image.<br><br>Optional - if omitted, the image is loaded without a tag.<br><br>Subject to [template expansion](/docs/templating.md).   | String | optional |  `""`  |
+| <a id="image_load-tag"></a>tag |  Tag to apply when loading the image.<br><br>Optional - if omitted, the image is loaded without a tag.<br><br>When `registry`/`repository` are set, this is a bare tag (e.g. `latest`); otherwise it is a full image reference (e.g. `my-app:latest`).<br><br>Subject to [template expansion](/docs/templating.md).   | String | optional |  `""`  |
 | <a id="image_load-tag_file"></a>tag_file |  File containing newline-delimited tags to apply when loading the image.<br><br>The file should contain one tag per line. Empty lines are ignored. Tags from this file are merged with tags specified via `tag` or `tag_list` attributes.<br><br>Example file content: <pre><code>latest&#10;v1.0.0&#10;stable</code></pre><br><br>Can be combined with `tag` or `tag_list` to merge tags from multiple sources. Each tag is subject to [template expansion](/docs/templating.md).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="image_load-tag_list"></a>tag_list |  List of tags to apply when loading the image.<br><br>Useful for applying multiple tags in a single load:<br><br><pre><code class="language-python">tag_list = ["latest", "v1.0.0", "stable"]</code></pre><br><br>Cannot be used together with `tag`. Can be combined with `tag_file` to merge tags from both sources. Each tag is subject to [template expansion](/docs/templating.md).   | List of strings | optional |  `[]`  |
 | <a id="image_load-tool_cfg"></a>tool_cfg |  **Experimental**: This attribute may be removed if we find a way to automatically select the correct loader platform based on the context of use. Configuration of the loader executable. By default, the loader executable is always chosen for the host platform, regardless of the value of `--platforms`. Setting this attribute to 'target' makes the loader match the target platform instead. The `"target"` option is useful when the "image_load" target is used as a data dependency of an integration test.<br><br>Available options: - **`host`** (default): Loader executable matches the host platform. - **`target`**: Loader executable matches the target platform(s) specified via `--platforms`.   | String | optional |  `"host"`  |
@@ -181,14 +221,15 @@ Performance notes:
 <pre>
 load("@rules_img//img:load.bzl", "image_load_spec")
 
-image_load_spec(<a href="#image_load_spec-name">name</a>, <a href="#image_load_spec-build_settings">build_settings</a>, <a href="#image_load_spec-daemon">daemon</a>, <a href="#image_load_spec-stamp">stamp</a>, <a href="#image_load_spec-strategy">strategy</a>, <a href="#image_load_spec-tag">tag</a>, <a href="#image_load_spec-tag_file">tag_file</a>, <a href="#image_load_spec-tag_list">tag_list</a>,
-                <a href="#image_load_spec-tracks_content">tracks_content</a>)
+image_load_spec(<a href="#image_load_spec-name">name</a>, <a href="#image_load_spec-build_settings">build_settings</a>, <a href="#image_load_spec-daemon">daemon</a>, <a href="#image_load_spec-registry">registry</a>, <a href="#image_load_spec-repository">repository</a>, <a href="#image_load_spec-stamp">stamp</a>, <a href="#image_load_spec-strategy">strategy</a>, <a href="#image_load_spec-tag">tag</a>, <a href="#image_load_spec-tag_file">tag_file</a>,
+                <a href="#image_load_spec-tag_list">tag_list</a>, <a href="#image_load_spec-tracks_content">tracks_content</a>)
 </pre>
 
 Defines load configuration for container images without referencing a specific image.
 
-This rule captures daemon, tag, and strategy settings that can be attached to
-`image_manifest` or `image_index` targets via their `load_specs` attribute.
+This rule captures registry, repository, daemon, tag, and strategy settings that
+can be attached to `image_manifest` or `image_index` targets via their
+`load_specs` attribute.
 Template strings using Go template syntax (`{{.VAR}}`) are accepted but not
 expanded — expansion happens when the deployment is consumed by the image rule.
 Note that the template strings `{{.image_target_package}}` and `{{.image_target_name}}` are especially useful here.
@@ -202,9 +243,19 @@ Example:
 ```python
 load("@rules_img//img:load.bzl", "image_load_spec")
 
+# Full image reference in a single tag (rules_oci-compatible).
 image_load_spec(
     name = "load_config",
     tag = "{{.image_target_package}}/{{.image_target_name}}:latest",
+    daemon = "containerd",
+)
+
+# Or split into registry/repository/tag (same API as image_push_spec):
+image_load_spec(
+    name = "load_config_split",
+    registry = "gcr.io",
+    repository = "my-project/{{.image_target_package}}/{{.image_target_name}}",
+    tag = "latest",
     daemon = "containerd",
 )
 
@@ -242,9 +293,11 @@ multi_deploy(
 | <a id="image_load_spec-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="image_load_spec-build_settings"></a>build_settings |  Build settings for template expansion.<br><br>Maps template variable names to string_flag targets. These values can be used in tag attributes using `{{.VARIABLE_NAME}}` syntax (Go template).<br><br>See [template expansion](/docs/templating.md) for more details.   | Dictionary: String -> Label | optional |  `{}`  |
 | <a id="image_load_spec-daemon"></a>daemon |  Container daemon to use for loading the image.<br><br>Available options: - **`auto`** (default): Uses the global default setting (usually `docker`) - **`containerd`**: Loads directly into containerd namespace. Supports multi-platform images   and incremental loading. - **`docker`**: Loads via Docker daemon. When Docker uses containerd storage (23.0+),   loads directly into containerd. Otherwise falls back to `docker image load` command which   is slower and limited to single-platform images. - **`podman`**: Loads via Podman daemon using `podman image load` command. Similar to Docker   fallback mode, this is slower than containerd and limited to single-platform images. - **`containerization`**: Loads via Apple's Containerization framework using `container image load`.   Reads a unified OCI+Docker tar from stdin. - **`tar`**: Does not load into any daemon. Instead, streams the unified OCI+Docker tar to stdout.   Useful for piping to other tools or saving to a file. - **`generic`**: Loads via a custom container runtime. The loader will invoke the command   specified in the `LOADER_BINARY` environment variable with `image load` subcommands. For example,   if `LOADER_BINARY=nerdctl`, it will run `nerdctl image load`.   Requires `LOADER_BINARY` to be set at runtime.<br><br>The best performance is achieved with: - Direct containerd access (daemon = "containerd") - Docker 23.0+ with containerd storage enabled and accessible containerd socket   | String | optional |  `"auto"`  |
+| <a id="image_load_spec-registry"></a>registry |  Registry component of the image name to load.<br><br>Optional. When set, `repository` must also be set, and each entry in `tag` / `tag_list` / `tag_file` is treated as a bare tag: the loaded image name is reconstructed as `{registry}/{repository}:{tag}` (mirroring `image_push`).<br><br>When omitted (together with `repository`), the tags are used verbatim as full image references, preserving the `rules_oci`-compatible behavior.<br><br>Subject to [template expansion](/docs/templating.md).   | String | optional |  `""`  |
+| <a id="image_load_spec-repository"></a>repository |  Repository component of the image name to load.<br><br>Optional. Must be set together with `registry` (see `registry` for details).<br><br>Subject to [template expansion](/docs/templating.md).   | String | optional |  `""`  |
 | <a id="image_load_spec-stamp"></a>stamp |  Controls build stamping for template expansion.<br><br>- **`auto`** (default): Defers to the global `--@rules_img//img/settings:stamp` setting. - **`force`**: Always stamp if templates contain `{{}}` placeholders, ignoring Bazel's `--stamp` flag. - **`disabled`**: Never include stamp information.<br><br>See [template expansion](/docs/templating.md) for available stamp variables.   | String | optional |  `"auto"`  |
 | <a id="image_load_spec-strategy"></a>strategy |  Strategy for handling image layers during load.<br><br>Available strategies: - **`auto`** (default): Uses the global default load strategy - **`eager`**: Downloads all layers during the build phase. Ensures all layers are   available locally before running the load command. - **`lazy`**: Downloads layers only when needed during the load operation. More   efficient for large images where some layers might already exist in the daemon.   | String | optional |  `"auto"`  |
-| <a id="image_load_spec-tag"></a>tag |  Tag to apply when loading the image.<br><br>Optional - if omitted, the image is loaded without a tag.<br><br>Subject to [template expansion](/docs/templating.md).   | String | optional |  `""`  |
+| <a id="image_load_spec-tag"></a>tag |  Tag to apply when loading the image.<br><br>Optional - if omitted, the image is loaded without a tag.<br><br>When `registry`/`repository` are set, this is a bare tag (e.g. `latest`); otherwise it is a full image reference (e.g. `my-app:latest`).<br><br>Subject to [template expansion](/docs/templating.md).   | String | optional |  `""`  |
 | <a id="image_load_spec-tag_file"></a>tag_file |  File containing newline-delimited tags to apply when loading the image.<br><br>The file should contain one tag per line. Empty lines are ignored. Tags from this file are merged with tags specified via `tag` or `tag_list` attributes.<br><br>Example file content: <pre><code>latest&#10;v1.0.0&#10;stable</code></pre><br><br>Can be combined with `tag` or `tag_list` to merge tags from multiple sources. Each tag is subject to [template expansion](/docs/templating.md).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="image_load_spec-tag_list"></a>tag_list |  List of tags to apply when loading the image.<br><br>Useful for applying multiple tags in a single load:<br><br><pre><code class="language-python">tag_list = ["latest", "v1.0.0", "stable"]</code></pre><br><br>Cannot be used together with `tag`. Can be combined with `tag_file` to merge tags from both sources. Each tag is subject to [template expansion](/docs/templating.md).   | List of strings | optional |  `[]`  |
 | <a id="image_load_spec-tracks_content"></a>tracks_content |  When True, the template expansion action depends on the image digest.<br><br>A template string built from a volatile stamp value (e.g. `{{.BUILD_TIMESTAMP}}`) normally freezes on the first build, because Bazel excludes the volatile workspace-status file from the action cache key. With this enabled, the image descriptor becomes an input to the tag-expansion action, so the tag re-stamps whenever the image content (digest) changes, while unchanged content keeps the cached tag.<br><br>The digest is exposed to the `tag` templates as `{{.digest}}`. Referencing the digest in the tag is optional: the re-stamp behavior applies whether or not the tag contains it.   | Boolean | optional |  `False`  |

--- a/e2e/generic/load/BUILD.bazel
+++ b/e2e/generic/load/BUILD.bazel
@@ -44,11 +44,13 @@ image_index(
 image_load(
     name = "load_image",
     image = ":image",
-    tag = "ghcr.io/malt3/rules_img:sideloaded",
+    registry = "ghcr.io",
+    repository = "malt3/rules_img",
+    tag = "sideloaded",
     visibility = ["//visibility:public"],
 )
 
-# load an image with template variables
+# load an image with template variables (split registry/repository/tag)
 image_load(
     name = "load_image_templated",
     build_settings = {
@@ -57,7 +59,9 @@ image_load(
         "TAG": "//build_settings:tag",
     },
     image = ":image",
-    tag = "{{.REGISTRY}}/{{.USER}}/rules_img:{{.TAG}}",
+    registry = "{{.REGISTRY}}",
+    repository = "{{.USER}}/rules_img",
+    tag = "{{.TAG}}",
     visibility = ["//visibility:public"],
 )
 
@@ -65,15 +69,18 @@ image_load(
 image_load(
     name = "load_index",
     image = ":index",
-    tag = "ghcr.io/malt3/rules_img:sideloaded",
+    registry = "ghcr.io",
+    repository = "malt3/rules_img",
+    tag = "sideloaded",
     visibility = ["//visibility:public"],
 )
 
-# Test loading with a name that needs normalization
+# Legacy (rules_oci-compatible) mode: a single full reference with no
+# registry/repository. Demonstrates that a bare name is normalized (loaded as
+# docker.io/library/funny_name:sideloaded).
 image_load(
     name = "load_normalized",
     image = ":index",
-    # this will be loaded as docker.io/library/funny_name:sideloaded
     tag = "funny_name:sideloaded",
     visibility = ["//visibility:public"],
 )
@@ -82,7 +89,9 @@ image_load(
 image_load(
     name = "load_alpine",
     image = "@alpine//:final",
-    tag = "ghcr.io/malt3/rules_img:alpine-sideloaded",
+    registry = "ghcr.io",
+    repository = "malt3/rules_img",
+    tag = "alpine-sideloaded",
     visibility = ["//visibility:public"],
 )
 
@@ -90,37 +99,44 @@ image_load(
 image_load(
     name = "load_cuda",
     image = "@cuda",
-    tag = "ghcr.io/malt3/rules_img:cuda-sideloaded",
+    registry = "ghcr.io",
+    repository = "malt3/rules_img",
+    tag = "cuda-sideloaded",
     visibility = ["//visibility:public"],
 )
 
 image_load(
     name = "load_envoy",
     image = "@envoy",
-    tag = "ghcr.io/malt3/rules_img:envoy-sideloaded",
+    registry = "ghcr.io",
+    repository = "malt3/rules_img",
+    tag = "envoy-sideloaded",
     visibility = ["//visibility:public"],
 )
 
-# Load with multiple tags
+# Load with multiple (bare) tags under a shared registry/repository
 image_load(
     name = "load_multi_tags",
     image = ":image",
+    registry = "ghcr.io",
+    repository = "malt3/rules_img",
     tag_list = [
-        "ghcr.io/malt3/rules_img:multi-latest",
-        "ghcr.io/malt3/rules_img:multi-v1.0.0",
-        "ghcr.io/malt3/rules_img:multi-stable",
+        "multi-latest",
+        "multi-v1.0.0",
+        "multi-stable",
     ],
     visibility = ["//visibility:public"],
 )
 
-# File containing multiple tags (one per line)
+# File containing multiple bare tags (one per line), combined with a
+# registry/repository split.
 write_file(
     name = "tags_file",
     out = "tags.txt",
     content = [
-        "ghcr.io/malt3/rules_img:from-file-v1",
-        "ghcr.io/malt3/rules_img:from-file-v2",
-        "ghcr.io/malt3/rules_img:from-file-stable",
+        "from-file-v1",
+        "from-file-v2",
+        "from-file-stable",
     ],
 )
 
@@ -128,7 +144,39 @@ write_file(
 image_load(
     name = "load_tag_file",
     image = ":image",
+    registry = "ghcr.io",
+    repository = "malt3/rules_img",
     tag_file = ":tags_file",
+    visibility = ["//visibility:public"],
+)
+
+# Scratch image (no remote base) so the split registry/repository behavior can be
+# built and validated without network access.
+image_manifest(
+    name = "scratch_image",
+    cmd = [
+        "/bin/cat",
+        "/hello.txt",
+    ],
+    layers = [":layer"],
+    visibility = ["//visibility:public"],
+)
+
+image_load(
+    name = "load_scratch_split",
+    image = ":scratch_image",
+    registry = "ghcr.io",
+    repository = "malt3/rules_img",
+    tag = "scratch-split",
+    visibility = ["//visibility:public"],
+)
+
+# Backwards-compatible mode on the same scratch image: a full-reference tag with
+# no registry/repository must be preserved verbatim (network-free regression).
+image_load(
+    name = "load_scratch_compat",
+    image = ":scratch_image",
+    tag = "scratch-app:compat",
     visibility = ["//visibility:public"],
 )
 
@@ -143,5 +191,7 @@ build_test(
         ":load_normalized",
         ":load_multi_tags",
         ":load_tag_file",
+        ":load_scratch_split",
+        ":load_scratch_compat",
     ],
 )

--- a/e2e/go/customization/BUILD.bazel
+++ b/e2e/go/customization/BUILD.bazel
@@ -121,10 +121,16 @@ image_push(
 
 image_load(
     name = "load",
+    build_settings = {
+        "registry": ":registry",
+        "repo": ":repo",
+    },
     image = ":go_image",
+    registry = "{{.registry}}",
+    repository = "{{.repo}}",
     tag_list = [
-        "go-image:latest",
-        "go-image:dgst-sha256-{{slice .digest 7}}",
+        "latest",
+        "dgst-sha256-{{slice .digest 7}}",
     ],
     tracks_content = True,
     visibility = ["//:__pkg__"],
@@ -148,10 +154,16 @@ image_push_spec(
 
 image_load_spec(
     name = "load_spec",
+    build_settings = {
+        "registry": ":registry",
+        "repo": ":repo",
+    },
+    registry = "{{.registry}}",
+    repository = "{{.repo}}",
     stamp = "force",
     tag_list = [
-        "go-image-spec:latest",
-        "go-image-spec:dgst-sha256-{{slice .digest 7}}",
+        "spec",
+        "dgst-sha256-{{slice .digest 7}}",
     ],
     tracks_content = True,
 )

--- a/e2e/go/image/BUILD.bazel
+++ b/e2e/go/image/BUILD.bazel
@@ -31,7 +31,9 @@ image_push(
 image_load(
     name = "load",
     image = ":go_image",
-    tag = "foobar:baz",
+    registry = "ghcr.io",
+    repository = "malt3/rules_img/go",
+    tag = "loaded",
     visibility = ["//:__pkg__"],
 )
 

--- a/e2e/go/multiarch/BUILD.bazel
+++ b/e2e/go/multiarch/BUILD.bazel
@@ -62,7 +62,9 @@ image_push(
 image_load(
     name = "load",
     image = ":multiarch_image",
-    tag = "go-multiarch:latest",
+    registry = "ghcr.io",
+    repository = "malt3/rules_img/go",
+    tag = "go-multiarch",
 )
 
 build_test(

--- a/e2e/js/app/BUILD.bazel
+++ b/e2e/js/app/BUILD.bazel
@@ -41,7 +41,9 @@ image_index(
 image_load(
     name = "load",
     image = ":multiarch_image",
-    tag = "302232432727.dkr.ecr.us-east-2.amazonaws.com/account_access_app:latest",
+    registry = "302232432727.dkr.ecr.us-east-2.amazonaws.com",
+    repository = "account_access_app",
+    tag = "latest",
 )
 
 image_push(

--- a/e2e/python/BUILD.bazel
+++ b/e2e/python/BUILD.bazel
@@ -50,13 +50,17 @@ image_index(
 image_load(
     name = "load_single_arch",
     image = ":image",
-    tag = "ghcr.io/malt3/rules_img/python:sideloaded",
+    registry = "ghcr.io",
+    repository = "malt3/rules_img/python",
+    tag = "sideloaded",
 )
 
 image_load(
     name = "load",
     image = ":multiarch_image",
-    tag = "ghcr.io/malt3/rules_img/python:sideloaded",
+    registry = "ghcr.io",
+    repository = "malt3/rules_img/python",
+    tag = "sideloaded",
 )
 
 image_push(

--- a/img/load.bzl
+++ b/img/load.bzl
@@ -24,20 +24,37 @@ image_manifest(
     layers = [":app_layer"],
 )
 
-# Create a load target with a single tag
+# Preferred: the same registry/repository/tag split as image_push. The loaded
+# image name is reconstructed as "my-registry.example.com/my-app:latest".
 image_load(
     name = "load",
+    image = ":my_image",
+    registry = "my-registry.example.com",
+    repository = "my-app",
+    tag = "latest",
+)
+
+# The rules_oci-compatible form still works: when loading into a daemon the image
+# name is just a string, so a single fully-qualified tag (with no
+# registry/repository) is used verbatim.
+image_load(
+    name = "load_legacy",
     image = ":my_image",
     tag = "my-app:latest",
 )
 
-# Load with multiple tags
+# Load with multiple full-reference tags
 image_load(
     name = "load_multi",
     image = ":my_image",
     tag_list = ["my-app:latest", "my-app:v1.0.0"],
 )
 ```
+
+Splitting the name into `registry` / `repository` / `tag` is optional and does
+not change what a local daemon sees; it just keeps the load target aligned with
+a matching `image_push`, making it easy to push the same image to a registry
+later.
 
 Then run:
 ```bash

--- a/img/private/common/deploy_attrs.bzl
+++ b/img/private/common/deploy_attrs.bzl
@@ -244,10 +244,34 @@ The best performance is achieved with:
         default = "auto",
         values = ["auto", "docker", "containerd", "podman", "containerization", "tar", "generic"],
     ),
+    registry = attr.string(
+        doc = """Registry component of the image name to load.
+
+Optional. When set, `repository` must also be set, and each entry in
+`tag` / `tag_list` / `tag_file` is treated as a bare tag: the loaded image name
+is reconstructed as `{registry}/{repository}:{tag}` (mirroring `image_push`).
+
+When omitted (together with `repository`), the tags are used verbatim as full
+image references, preserving the `rules_oci`-compatible behavior.
+
+Subject to [template expansion](/docs/templating.md).
+""",
+    ),
+    repository = attr.string(
+        doc = """Repository component of the image name to load.
+
+Optional. Must be set together with `registry` (see `registry` for details).
+
+Subject to [template expansion](/docs/templating.md).
+""",
+    ),
     tag = attr.string(
         doc = """Tag to apply when loading the image.
 
 Optional - if omitted, the image is loaded without a tag.
+
+When `registry`/`repository` are set, this is a bare tag (e.g. `latest`);
+otherwise it is a full image reference (e.g. `my-app:latest`).
 
 Subject to [template expansion](/docs/templating.md).
 """,

--- a/img/private/common/deploy_helpers.bzl
+++ b/img/private/common/deploy_helpers.bzl
@@ -85,6 +85,30 @@ def resolve_push_registry(ctx):
 
     return registry
 
+def resolve_load_destination(ctx):
+    """Resolve and validate the registry/repository for a load target.
+
+    Unlike push, load has no destination_file or global destination_registry
+    fallback: the registry/repository are taken verbatim from the attributes.
+    They must be set together (to reconstruct `<registry>/<repository>:<tag>`
+    image names) or both left empty (backwards-compatible mode, where the tags
+    are already full image references).
+
+    Args:
+        ctx: Rule context with registry/repository attributes.
+
+    Returns:
+        Tuple (registry, repository) of the (possibly empty) resolved values.
+    """
+    registry = ctx.attr.registry
+    repository = ctx.attr.repository
+    if bool(registry) != bool(repository):
+        fail("image_load/image_load_spec: 'registry' and 'repository' must be set together (or neither); got registry = {}, repository = {}".format(
+            repr(registry),
+            repr(repository),
+        ))
+    return registry, repository
+
 def resolve_push_strategy(ctx):
     """Determine the push strategy, resolving 'auto' from settings.
 

--- a/img/private/load.bzl
+++ b/img/private/load.bzl
@@ -8,7 +8,7 @@ load("//img/private:stamp.bzl", "expand_or_write")
 load("//img/private/common:build.bzl", "TOOLCHAIN", "TOOLCHAINS")
 load("//img/private/common:default_deploy_tool.bzl", "default_deploy_tool")
 load("//img/private/common:deploy_attrs.bzl", "COMMON_LOAD_ATTRS")
-load("//img/private/common:deploy_helpers.bzl", "content_tracking_json_vars", "get_image_providers", "get_tags", "image_target_vars", "resolve_daemon", "resolve_load_strategy")
+load("//img/private/common:deploy_helpers.bzl", "content_tracking_json_vars", "get_image_providers", "get_tags", "image_target_vars", "resolve_daemon", "resolve_load_destination", "resolve_load_strategy")
 load("//img/private/common:transitions.bzl", "reset_platform_transition")
 load("//img/private/providers:deploy_info.bzl", "DeployInfo")
 load("//img/private/providers:deploy_tool_info.bzl", "DeployToolInfo")
@@ -116,7 +116,10 @@ def _image_load_impl(ctx):
     root_symlinks_prefix = symlink_name_prefix(ctx)
     root_symlinks = calculate_root_symlinks(index_info, manifest_info, include_layers = include_layers, symlink_name_prefix = root_symlinks_prefix)
 
+    registry, repository = resolve_load_destination(ctx)
     templates = dict(
+        registry = registry,
+        repository = repository,
         tags = get_tags(ctx),
         daemon = resolve_daemon(ctx),
     )
@@ -245,6 +248,14 @@ Key features:
 
 The rule produces an executable that can be run with `bazel run`.
 
+Image names: when loading into a local daemon the image name is ultimately just
+a string, so a single fully-qualified `tag` (the rules_oci-compatible form) is
+all a daemon needs. The rule also accepts the same `registry` / `repository` /
+`tag` split as `image_push`; the loaded name is simply reconstructed as
+`{registry}/{repository}:{tag}`. Splitting it out is purely a convenience: it
+keeps the load target aligned with a matching `image_push` so the same image is
+easy to push to a registry later.
+
 Output groups:
 - `tarball`: "docker save" compatible tarball with OCI layout (available for both single and multi-platform images).
   For multi-platform images, the first manifest is used as the default in `manifest.json`,
@@ -257,29 +268,42 @@ Example:
 ```python
 load("@rules_img//img:load.bzl", "image_load")
 
-# Load a single-platform image with a single tag
+# Load using separate registry/repository/tag (same API as image_push).
+# The loaded image name is reconstructed as gcr.io/my-project/my-app:latest.
 image_load(
     name = "load_app",
     image = ":my_app",  # References an image_manifest
+    registry = "gcr.io",
+    repository = "my-project/my-app",
+    tag = "latest",
+)
+
+# Load a multi-platform image with the split API
+image_load(
+    name = "load_multiarch",
+    image = ":my_app_index",  # References an image_index
+    registry = "gcr.io",
+    repository = "my-project/my-app",
+    tag = "latest",
+    daemon = "containerd",  # Explicitly use containerd
+)
+
+# The rules_oci-compatible form still works: a single fully-qualified tag with no
+# registry/repository is used verbatim as the loaded image name.
+image_load(
+    name = "load_legacy",
+    image = ":my_app",
     tag = "my-app:latest",
 )
 
-# Load with multiple tags
+# ...including multiple full-reference tags:
 image_load(
     name = "load_multi",
     image = ":my_app",
     tag_list = ["my-app:latest", "my-app:v1.0.0", "my-app:stable"],
 )
 
-# Load a multi-platform image
-image_load(
-    name = "load_multiarch",
-    image = ":my_app_index",  # References an image_index
-    tag = "my-app:latest",
-    daemon = "containerd",  # Explicitly use containerd
-)
-
-# Load with dynamic tagging
+# Load with dynamic tagging (template expansion works with either form)
 image_load(
     name = "load_dynamic",
     image = ":my_app",

--- a/img/private/load_spec.bzl
+++ b/img/private/load_spec.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//img/private/common:deploy_attrs.bzl", "COMMON_LOAD_ATTRS")
-load("//img/private/common:deploy_helpers.bzl", "get_tags", "resolve_daemon", "resolve_load_strategy")
+load("//img/private/common:deploy_helpers.bzl", "get_tags", "resolve_daemon", "resolve_load_destination", "resolve_load_strategy")
 load("//img/private/common:transitions.bzl", "reset_platform_transition")
 load("//img/private/providers:load_config_info.bzl", "LoadConfigInfo")
 load("//img/private/providers:stamp_setting_info.bzl", "StampSettingInfo")
@@ -13,7 +13,11 @@ def _image_load_spec_impl(ctx):
     for name, target in ctx.attr.build_settings.items():
         build_settings[name] = target[BuildSettingInfo].value
 
+    registry, repository = resolve_load_destination(ctx)
+
     return [LoadConfigInfo(
+        registry = registry,
+        repository = repository,
         daemon = resolve_daemon(ctx),
         tags = get_tags(ctx),
         tag_file = ctx.file.tag_file,
@@ -28,8 +32,9 @@ image_load_spec = rule(
     implementation = _image_load_spec_impl,
     doc = """Defines load configuration for container images without referencing a specific image.
 
-This rule captures daemon, tag, and strategy settings that can be attached to
-`image_manifest` or `image_index` targets via their `load_specs` attribute.
+This rule captures registry, repository, daemon, tag, and strategy settings that
+can be attached to `image_manifest` or `image_index` targets via their
+`load_specs` attribute.
 Template strings using Go template syntax (`{{.VAR}}`) are accepted but not
 expanded — expansion happens when the deployment is consumed by the image rule.
 Note that the template strings `{{.image_target_package}}` and `{{.image_target_name}}` are especially useful here.
@@ -43,9 +48,19 @@ Example:
 ```python
 load("@rules_img//img:load.bzl", "image_load_spec")
 
+# Full image reference in a single tag (rules_oci-compatible).
 image_load_spec(
     name = "load_config",
     tag = "{{.image_target_package}}/{{.image_target_name}}:latest",
+    daemon = "containerd",
+)
+
+# Or split into registry/repository/tag (same API as image_push_spec):
+image_load_spec(
+    name = "load_config_split",
+    registry = "gcr.io",
+    repository = "my-project/{{.image_target_package}}/{{.image_target_name}}",
+    tag = "latest",
     daemon = "containerd",
 )
 

--- a/img/private/providers/load_config_info.bzl
+++ b/img/private/providers/load_config_info.bzl
@@ -2,10 +2,13 @@
 
 DOC = """\
 Load configuration for importing images into a container daemon. Captures
-daemon, tags, and strategy without referencing a specific image.
+registry, repository, daemon, tags, and strategy without referencing a specific
+image.
 """
 
 FIELDS = dict(
+    registry = "Registry template string (empty for full-reference tags).",
+    repository = "Repository template string (empty for full-reference tags).",
     daemon = "Resolved daemon string (never 'auto').",
     tags = "List of tag template strings (combined from tag/tag_list).",
     tag_file = "File with newline-delimited tags, or None.",

--- a/img/private/push_metadata.bzl
+++ b/img/private/push_metadata.bzl
@@ -516,6 +516,8 @@ def process_deploy_specs(
         load_config = deployment[LoadConfigInfo]
 
         templates = dict(
+            registry = load_config.registry,
+            repository = load_config.repository,
             tags = load_config.tags,
             daemon = load_config.daemon,
         )

--- a/img/private/repository_rules/pull.bzl
+++ b/img/private/repository_rules/pull.bzl
@@ -229,7 +229,9 @@ alias(
 image_load(
     name = "load",
     image = ":final",
-    tag = {load_tag},
+    registry = {load_registry},
+    repository = {repository},
+    tag = {tag},
     visibility = ["//visibility:public"],
 )
 """.format(
@@ -258,7 +260,7 @@ image_load(
             purl = repr(purl),
             repository = repr(rctx.attr.repository),
             tag = repr(rctx.attr.tag) if rctx.attr.tag else "None",
-            load_tag = repr(registries[0] + "/" + rctx.attr.repository + ((":" + rctx.attr.tag) if rctx.attr.tag else ("@" + digest))),
+            load_registry = repr(registries[0]),
         ),
     )
     rctx.file("REPO.bazel", """\

--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -65,8 +65,8 @@ func DeployProcess(ctx context.Context, args []string) {
 	flagSet.StringVar(&runfilesRootSymlinksPrefix, "runfiles-root-symlinks-prefix", "", "Prefix for runfiles root symlinks")
 	flagSet.Var(&additionalTags, "tag", "Additional tag to apply (can be used multiple times)")
 	flagSet.Var(&additionalTags, "t", "Additional tag to apply (can be used multiple times)")
-	flagSet.StringVar(&overrideRegistry, "registry", "", "Override registry to push to")
-	flagSet.StringVar(&overrideRepository, "repository", "", "Override repository to push to")
+	flagSet.StringVar(&overrideRegistry, "registry", "", "Override registry for push and split-mode load operations (load ops with a registry/repository set; the rules_oci tag-only fallback is left unchanged)")
+	flagSet.StringVar(&overrideRepository, "repository", "", "Override repository for push and split-mode load operations (load ops with a registry/repository set; the rules_oci tag-only fallback is left unchanged)")
 	flagSet.StringVar(&platforms, "platform", "", "Comma-separated list of platforms to load (e.g., linux/amd64). If not set, loads the platform closest to the host (or the single available platform). Use 'all' to load the full multi-platform index. Doesn't affect push, only load.")
 	flagSet.Var(&ociLayouts, "oci-layout", "Path to an OCI layout directory, sparse or standard (can be used multiple times)")
 	flagSet.Var(&explicitLayers, "layer", "Explicit layer in digest=path format (can be used multiple times)")
@@ -319,6 +319,14 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 			}
 			if len(opts.AdditionalTags) > 0 {
 				builder = builder.WithExtraTags(opts.AdditionalTags)
+			}
+			// Overrides apply only to split-mode load ops (non-empty
+			// registry/repository); the loader leaves the rules_oci fallback alone.
+			if opts.OverrideRegistry != "" {
+				builder = builder.WithOverrideRegistry(opts.OverrideRegistry)
+			}
+			if opts.OverrideRepository != "" {
+				builder = builder.WithOverrideRepository(opts.OverrideRepository)
 			}
 			// LoadAll prints the loaded tags itself, so we discard the return value
 			_, err := builder.Build().LoadAll(groupCtx, loadOperations)

--- a/img_tool/cmd/deploy/persistentworker.go
+++ b/img_tool/cmd/deploy/persistentworker.go
@@ -150,6 +150,14 @@ func (h *deployWorkerHandler) processRequest(ctx context.Context, req persistent
 		if len(opts.platforms) > 0 {
 			builder = builder.WithPlatforms(opts.platforms)
 		}
+		// Overrides apply only to split-mode load ops (non-empty
+		// registry/repository); the loader leaves the rules_oci fallback alone.
+		if opts.overrideRegistry != "" {
+			builder = builder.WithOverrideRegistry(opts.overrideRegistry)
+		}
+		if opts.overrideRepository != "" {
+			builder = builder.WithOverrideRepository(opts.overrideRepository)
+		}
 		if _, err := builder.Build().LoadAll(ctx, loadOps); err != nil {
 			return "", fmt.Errorf("load: %w", err)
 		}

--- a/img_tool/cmd/deploymetadata/BUILD.bazel
+++ b/img_tool/cmd/deploymetadata/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
     srcs = [
         "layersources_test.go",
         "merge_test.go",
+        "metadata_load_test.go",
     ],
     embed = [":deploymetadata"],
     deps = ["//pkg/api"],

--- a/img_tool/cmd/deploymetadata/metadata.go
+++ b/img_tool/cmd/deploymetadata/metadata.go
@@ -886,8 +886,22 @@ func loadOperation(baseCommand api.BaseCommandOperation, config map[string]any) 
 		return api.LoadDeployOperation{}, fmt.Errorf("configuration file must contain a non-empty 'daemon' field")
 	}
 
+	// registry and repository are optional. When both are set, the loader and
+	// docker-save reconstruct full image names as "<registry>/<repository>:<tag>".
+	// When absent (the rules_oci-compatible mode) the tags are already full
+	// references and only the 'tags' field is emitted (registry/repository are
+	// omitempty on LoadDeployOperation). Exactly one being set (e.g. a template
+	// that expanded to empty) is a hard error, mirroring the push path.
+	registry, _ := config["registry"].(string)
+	repository, _ := config["repository"].(string)
+	if err := api.ValidateLoadDestination(registry, repository); err != nil {
+		return api.LoadDeployOperation{}, err
+	}
+
 	return api.LoadDeployOperation{
 		BaseCommandOperation: baseCommand,
+		Registry:             registry,
+		Repository:           repository,
 		Tags:                 tags,
 		Daemon:               daemon,
 	}, nil

--- a/img_tool/cmd/deploymetadata/metadata_load_test.go
+++ b/img_tool/cmd/deploymetadata/metadata_load_test.go
@@ -1,0 +1,130 @@
+package deploymetadata
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+)
+
+const loadTestManifest = `{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {"mediaType": "application/vnd.oci.image.config.v1+json", "digest": "` + testConfigDigest + `", "size": 42},
+  "layers": [
+    {"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip", "digest": "` + testLayerDigestA + `", "size": 100}
+  ]
+}`
+
+// resetMetadataFlags resets the package-level flag state that WriteMetadata
+// reads, so each test observes a clean slate.
+func resetMetadataFlags(manifestPath, configPath string) {
+	strategy = "eager"
+	rootPath = manifestPath
+	rootKind = "manifest"
+	configurationPath = configPath
+	manifestPaths = []string{manifestPath}
+	destinationFilePath = ""
+	crossMountStrategy = ""
+	crossMountFromManifestPath = ""
+	manifestTagFiles = nil
+	originalRegistries = nil
+	originalRepository = ""
+	orginalTag = ""
+	originalDigest = ""
+	referrerRootPaths = newIndexedStringFlag()
+	layerCompactStreams = newDoubleIndexedStringFlag()
+	layerSourcesForManifest = nil
+}
+
+func writeLoadMetadata(t *testing.T, configJSON string) api.LoadDeployOperation {
+	t.Helper()
+	tmp := t.TempDir()
+
+	manifestPath := filepath.Join(tmp, "manifest.json")
+	if err := os.WriteFile(manifestPath, []byte(loadTestManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(tmp, "config.json")
+	if err := os.WriteFile(configPath, []byte(configJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	command = "load"
+	resetMetadataFlags(manifestPath, configPath)
+
+	outputPath := filepath.Join(tmp, "deploy.json")
+	if err := WriteMetadata(context.Background(), outputPath); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dm api.DeployManifest
+	if err := json.Unmarshal(data, &dm); err != nil {
+		t.Fatalf("unmarshalling deploy manifest: %v", err)
+	}
+	ops, err := dm.LoadOperations()
+	if err != nil {
+		t.Fatalf("LoadOperations: %v", err)
+	}
+	if len(ops) != 1 {
+		t.Fatalf("got %d load operations, want 1", len(ops))
+	}
+	return ops[0].LoadDeployOperation
+}
+
+func TestLoadOperationTagsOnly(t *testing.T) {
+	op := writeLoadMetadata(t, `{"tags":["my-app:latest"],"daemon":"docker"}`)
+	if op.Registry != "" || op.Repository != "" {
+		t.Errorf("tags-only load op should have empty registry/repository, got %q / %q", op.Registry, op.Repository)
+	}
+	if !reflect.DeepEqual(op.Tags, []string{"my-app:latest"}) {
+		t.Errorf("op.Tags = %v", op.Tags)
+	}
+	if got := op.ImageNames(); !reflect.DeepEqual(got, []string{"my-app:latest"}) {
+		t.Errorf("ImageNames() = %v", got)
+	}
+}
+
+func TestLoadOperationWithRegistryRepository(t *testing.T) {
+	op := writeLoadMetadata(t, `{"registry":"gcr.io","repository":"proj/app","tags":["latest","v1"],"daemon":"containerd"}`)
+	if op.Registry != "gcr.io" || op.Repository != "proj/app" {
+		t.Errorf("registry/repository = %q / %q, want gcr.io / proj/app", op.Registry, op.Repository)
+	}
+	if op.Daemon != "containerd" {
+		t.Errorf("daemon = %q, want containerd", op.Daemon)
+	}
+	want := []string{"gcr.io/proj/app:latest", "gcr.io/proj/app:v1"}
+	if got := op.ImageNames(); !reflect.DeepEqual(got, want) {
+		t.Errorf("ImageNames() = %v, want %v", got, want)
+	}
+}
+
+// TestLoadOperationLoneRegistryErrors verifies that a registry without a
+// repository (e.g. a template that expanded to empty) is a hard error rather
+// than a silent fallback to verbatim mode.
+func TestLoadOperationLoneRegistryErrors(t *testing.T) {
+	tmp := t.TempDir()
+	manifestPath := filepath.Join(tmp, "manifest.json")
+	if err := os.WriteFile(manifestPath, []byte(loadTestManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(tmp, "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"registry":"gcr.io","repository":"","tags":["latest"],"daemon":"docker"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	command = "load"
+	resetMetadataFlags(manifestPath, configPath)
+
+	if err := WriteMetadata(context.Background(), filepath.Join(tmp, "deploy.json")); err == nil {
+		t.Fatal("expected error for registry without repository, got nil")
+	}
+}

--- a/img_tool/cmd/dockersave/BUILD.bazel
+++ b/img_tool/cmd/dockersave/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "dockersave",
@@ -9,7 +9,14 @@ go_library(
     importpath = "github.com/bazel-contrib/rules_img/img_tool/cmd/dockersave",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/api",
         "//pkg/ocilayout",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
     ],
+)
+
+go_test(
+    name = "dockersave_test",
+    srcs = ["dockersave_test.go"],
+    embed = [":dockersave"],
 )

--- a/img_tool/cmd/dockersave/dockersave.go
+++ b/img_tool/cmd/dockersave/dockersave.go
@@ -9,10 +9,15 @@ import (
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/ocilayout"
 )
 
-// readTagsFromConfigFile reads the tags field from a configuration file.
+// readTagsFromConfigFile reads registry/repository/tags from a load
+// configuration file and reconstructs the full image references. When registry
+// and repository are both set, each tag becomes "<registry>/<repository>:<tag>";
+// otherwise the tags are returned verbatim (backwards-compatible full
+// references). See api.QualifyLoadTags.
 func readTagsFromConfigFile(configPath string) ([]string, error) {
 	if configPath == "" {
 		return nil, nil
@@ -42,7 +47,12 @@ func readTagsFromConfigFile(configPath string) ([]string, error) {
 		}
 	}
 
-	return tags, nil
+	registry, _ := config["registry"].(string)
+	repository, _ := config["repository"].(string)
+	if err := api.ValidateLoadDestination(registry, repository); err != nil {
+		return nil, err
+	}
+	return api.QualifyLoadTags(registry, repository, tags), nil
 }
 
 func DockerSaveProcess(ctx context.Context, args []string) {

--- a/img_tool/cmd/dockersave/dockersave_test.go
+++ b/img_tool/cmd/dockersave/dockersave_test.go
@@ -1,0 +1,71 @@
+package dockersave
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestReadTagsFromConfigFile(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name:    "tags only are returned verbatim",
+			content: `{"tags":["my-app:latest","docker.io/library/foo:v1"],"daemon":"docker"}`,
+			want:    []string{"my-app:latest", "docker.io/library/foo:v1"},
+		},
+		{
+			name:    "registry and repository reconstruct full names",
+			content: `{"registry":"gcr.io","repository":"proj/app","tags":["latest","v1"],"daemon":"docker"}`,
+			want:    []string{"gcr.io/proj/app:latest", "gcr.io/proj/app:v1"},
+		},
+		{
+			name:    "empty registry/repository keys behave like the tags-only mode",
+			content: `{"registry":"","repository":"","tags":["my-app:latest"],"daemon":"docker"}`,
+			want:    []string{"my-app:latest"},
+		},
+		{
+			name:    "no tags field yields nil",
+			content: `{"registry":"gcr.io","repository":"proj/app","daemon":"docker"}`,
+			want:    nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.json")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := readTagsFromConfigFile(path)
+			if err != nil {
+				t.Fatalf("readTagsFromConfigFile: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("readTagsFromConfigFile() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadTagsFromConfigFileEmptyPath(t *testing.T) {
+	got, err := readTagsFromConfigFile("")
+	if err != nil || got != nil {
+		t.Fatalf("readTagsFromConfigFile(\"\") = %v, %v; want nil, nil", got, err)
+	}
+}
+
+func TestReadTagsFromConfigFileLoneRegistryErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	// registry set but repository empty (e.g. a template that expanded to "").
+	if err := os.WriteFile(path, []byte(`{"registry":"gcr.io","repository":"","tags":["latest"],"daemon":"docker"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readTagsFromConfigFile(path); err == nil {
+		t.Fatal("expected error for registry without repository, got nil")
+	}
+}

--- a/img_tool/pkg/api/BUILD.bazel
+++ b/img_tool/pkg/api/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "api",
@@ -10,4 +10,10 @@ go_library(
     ],
     importpath = "github.com/bazel-contrib/rules_img/img_tool/pkg/api",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "api_test",
+    srcs = ["deploy_test.go"],
+    embed = [":api"],
 )

--- a/img_tool/pkg/api/deploy.go
+++ b/img_tool/pkg/api/deploy.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 )
 
 type DeployManifest struct {
@@ -140,10 +141,58 @@ type IndexedRegistryTagDeployOperation struct {
 	RegistryTagDeployOperation
 }
 
+// LoadDeployOperation describes loading an image into a local daemon. It mirrors
+// PushTarget's Registry/Repository/Tags shape, but keeps every destination field
+// optional: when only Tags are set (the rules_oci-compatible mode) the tags are
+// already full image references and Registry/Repository are omitted entirely.
+// When Registry and Repository are both set, Tags are bare tags and the full
+// image names are reconstructed as "<registry>/<repository>:<tag>" (see
+// ImageNames).
 type LoadDeployOperation struct {
 	BaseCommandOperation
-	Tags   []string `json:"tags,omitempty"`
-	Daemon string   `json:"daemon,omitempty"`
+	Registry   string   `json:"registry,omitempty"`
+	Repository string   `json:"repository,omitempty"`
+	Tags       []string `json:"tags,omitempty"`
+	Daemon     string   `json:"daemon,omitempty"`
+}
+
+// ImageNames returns the fully-qualified image reference(s) this load operation
+// applies. See QualifyLoadTags for the reconstruction rules.
+func (o LoadDeployOperation) ImageNames() []string {
+	return QualifyLoadTags(o.Registry, o.Repository, o.Tags)
+}
+
+// ValidateLoadDestination reports an error when exactly one of registry and
+// repository is set. Both-set (split mode) and both-empty (verbatim,
+// rules_oci-compatible mode) are valid; a lone registry or repository is a
+// misconfiguration (for example a Go template that expanded to the empty string)
+// that would otherwise silently fall back to verbatim mode. This mirrors the
+// hard error the push path raises for a missing registry/repository, and must be
+// checked against the post-template-expansion values (the Starlark-level guard
+// only sees the raw, unexpanded strings).
+func ValidateLoadDestination(registry, repository string) error {
+	if (registry == "") != (repository == "") {
+		return fmt.Errorf("load configuration: 'registry' and 'repository' must be set together or both empty; got registry=%q repository=%q", registry, repository)
+	}
+	return nil
+}
+
+// QualifyLoadTags reconstructs full image names for a load operation. When both
+// registry and repository are set, each tag is expanded to
+// "<registry>/<repository>:<tag>". When either is empty (backwards-compatible
+// mode) the tags are returned verbatim, because they are already full image
+// references. The returned slice is always a fresh copy so callers may mutate
+// it freely.
+func QualifyLoadTags(registry, repository string, tags []string) []string {
+	if registry == "" || repository == "" {
+		return append([]string(nil), tags...)
+	}
+	base := registry + "/" + repository
+	names := make([]string, len(tags))
+	for i, tag := range tags {
+		names[i] = base + ":" + tag
+	}
+	return names
 }
 
 type IndexedLoadDeployOperation struct {

--- a/img_tool/pkg/api/deploy_test.go
+++ b/img_tool/pkg/api/deploy_test.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestQualifyLoadTags(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		registry   string
+		repository string
+		tags       []string
+		want       []string
+	}{
+		{
+			name: "no registry or repository returns tags verbatim",
+			tags: []string{"my-app:latest", "docker.io/library/foo:v1"},
+			want: []string{"my-app:latest", "docker.io/library/foo:v1"},
+		},
+		{
+			name:       "registry and repository reconstruct full names",
+			registry:   "gcr.io",
+			repository: "my-project/my-app",
+			tags:       []string{"latest", "v1.0.0"},
+			want:       []string{"gcr.io/my-project/my-app:latest", "gcr.io/my-project/my-app:v1.0.0"},
+		},
+		{
+			name:       "registry without repository falls back to verbatim",
+			registry:   "gcr.io",
+			repository: "",
+			tags:       []string{"already/full:latest"},
+			want:       []string{"already/full:latest"},
+		},
+		{
+			name:       "repository without registry falls back to verbatim",
+			registry:   "",
+			repository: "my-app",
+			tags:       []string{"already/full:latest"},
+			want:       []string{"already/full:latest"},
+		},
+		{
+			name:       "no tags with registry yields no names",
+			registry:   "gcr.io",
+			repository: "my-app",
+			tags:       nil,
+			want:       []string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := QualifyLoadTags(tc.registry, tc.repository, tc.tags)
+			if len(got) != len(tc.want) {
+				t.Fatalf("QualifyLoadTags() = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("QualifyLoadTags()[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestValidateLoadDestination(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		registry   string
+		repository string
+		wantErr    bool
+	}{
+		{name: "both empty is valid (verbatim mode)", wantErr: false},
+		{name: "both set is valid (split mode)", registry: "gcr.io", repository: "proj/app", wantErr: false},
+		{name: "registry only is an error", registry: "gcr.io", wantErr: true},
+		{name: "repository only is an error", repository: "proj/app", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateLoadDestination(tc.registry, tc.repository)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateLoadDestination(%q, %q) error = %v, wantErr %v", tc.registry, tc.repository, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestQualifyLoadTagsReturnsFreshSlice guards the documented contract that the// returned slice is always a fresh copy, so callers may append to it without
+// clobbering the operation's own Tags backing array.
+func TestQualifyLoadTagsReturnsFreshSlice(t *testing.T) {
+	tags := []string{"my-app:latest"}
+	got := QualifyLoadTags("", "", tags)
+	got = append(got, "mutated")
+	if tags[0] != "my-app:latest" {
+		t.Fatalf("QualifyLoadTags aliased the input slice: %v", tags)
+	}
+}
+
+// TestLoadDeployOperationOmitsEmptyDestination verifies that a load operation
+// carrying only tags serializes without registry/repository keys (the
+// rules_oci-compatible mode), while a fully-qualified one emits them.
+func TestLoadDeployOperationOmitsEmptyDestination(t *testing.T) {
+	tagsOnly := LoadDeployOperation{
+		BaseCommandOperation: BaseCommandOperation{Command: "load"},
+		Tags:                 []string{"my-app:latest"},
+		Daemon:               "docker",
+	}
+	data, err := json.Marshal(tagsOnly)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "registry") || strings.Contains(string(data), "repository") {
+		t.Fatalf("tags-only load op should omit registry/repository, got %s", data)
+	}
+
+	full := LoadDeployOperation{
+		BaseCommandOperation: BaseCommandOperation{Command: "load"},
+		Registry:             "gcr.io",
+		Repository:           "my-project/my-app",
+		Tags:                 []string{"latest"},
+		Daemon:               "docker",
+	}
+	data, err = json.Marshal(full)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"registry":"gcr.io"`) || !strings.Contains(string(data), `"repository":"my-project/my-app"`) {
+		t.Fatalf("qualified load op should emit registry/repository, got %s", data)
+	}
+
+	if got := full.ImageNames(); !reflect.DeepEqual(got, []string{"gcr.io/my-project/my-app:latest"}) {
+		t.Fatalf("ImageNames() = %v", got)
+	}
+}

--- a/img_tool/pkg/load/BUILD.bazel
+++ b/img_tool/pkg/load/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "load",
@@ -19,4 +19,11 @@ go_library(
         "@com_github_opencontainers_go_digest//:go-digest",
         "@com_github_opencontainers_image_spec//specs-go/v1:specs-go",
     ],
+)
+
+go_test(
+    name = "load_test",
+    srcs = ["loader_test.go"],
+    embed = [":load"],
+    deps = ["//pkg/api"],
 )

--- a/img_tool/pkg/load/loader.go
+++ b/img_tool/pkg/load/loader.go
@@ -21,9 +21,11 @@ import (
 )
 
 type builder struct {
-	vfs       vfs
-	platforms []string
-	extraTags []string
+	vfs                vfs
+	platforms          []string
+	extraTags          []string
+	overrideRegistry   string
+	overrideRepository string
 }
 
 func NewBuilder(vfs vfs) *builder {
@@ -40,28 +42,73 @@ func (b *builder) WithExtraTags(tags []string) *builder {
 	return b
 }
 
+// WithOverrideRegistry sets a deploy-time registry override. It only affects
+// operations that already carry a non-empty registry/repository (split mode);
+// see loader.imageNames.
+func (b *builder) WithOverrideRegistry(registry string) *builder {
+	b.overrideRegistry = registry
+	return b
+}
+
+// WithOverrideRepository sets a deploy-time repository override. It only affects
+// operations that already carry a non-empty registry/repository (split mode);
+// see loader.imageNames.
+func (b *builder) WithOverrideRepository(repository string) *builder {
+	b.overrideRepository = repository
+	return b
+}
+
 func (b *builder) Build() *loader {
 	return &loader{
-		vfs:       b.vfs,
-		platforms: b.platforms,
-		extraTags: b.extraTags,
-		taskSet:   newTaskSet(b.vfs, b.platforms),
+		vfs:                b.vfs,
+		platforms:          b.platforms,
+		extraTags:          b.extraTags,
+		overrideRegistry:   b.overrideRegistry,
+		overrideRepository: b.overrideRepository,
+		taskSet:            newTaskSet(b.vfs, b.platforms),
 	}
 }
 
 type loader struct {
-	vfs             vfs
-	platforms       []string
-	extraTags       []string
-	taskSet         *taskSet
-	clientConn      *containerd.Client
-	triedContainerd bool
-	haveContainerd  bool
+	vfs                vfs
+	platforms          []string
+	extraTags          []string
+	overrideRegistry   string
+	overrideRepository string
+	taskSet            *taskSet
+	clientConn         *containerd.Client
+	triedContainerd    bool
+	haveContainerd     bool
 }
 
-// tags returns the combined list of tags from the operation and extra tags
+// imageNames reconstructs the operation's image names, applying the deploy-time
+// registry/repository overrides. Overrides take effect only in split mode, i.e.
+// when the operation's own registry AND repository are non-empty; when they are
+// empty (the rules_oci-compatible fallback) the tags are already full references
+// and are returned verbatim without applying any override.
+func (l *loader) imageNames(op api.IndexedLoadDeployOperation) []string {
+	registry, repository := op.Registry, op.Repository
+	if registry != "" && repository != "" {
+		if l.overrideRegistry != "" {
+			registry = l.overrideRegistry
+		}
+		if l.overrideRepository != "" {
+			repository = l.overrideRepository
+		}
+	}
+	return api.QualifyLoadTags(registry, repository, op.Tags)
+}
+
+// tags returns the combined list of full image references for the operation.
+// The operation's own tags are reconstructed from registry/repository/tags (see
+// imageNames): they are bare tags when a registry/repository is set, and
+// already-full references otherwise. Extra tags supplied at runtime via --tag
+// are always treated as full references and passed through unchanged.
 func (l *loader) tags(op api.IndexedLoadDeployOperation) []string {
-	allTags := append(op.Tags, l.extraTags...)
+	names := l.imageNames(op)
+	allTags := make([]string, 0, len(names)+len(l.extraTags))
+	allTags = append(allTags, names...)
+	allTags = append(allTags, l.extraTags...)
 	return deduplicateAndSort(allTags)
 }
 

--- a/img_tool/pkg/load/loader_test.go
+++ b/img_tool/pkg/load/loader_test.go
@@ -1,0 +1,115 @@
+package load
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+)
+
+func indexedLoadOp(registry, repository string, tags []string) api.IndexedLoadDeployOperation {
+	return api.IndexedLoadDeployOperation{
+		LoadDeployOperation: api.LoadDeployOperation{
+			Registry:   registry,
+			Repository: repository,
+			Tags:       tags,
+			Daemon:     "docker",
+		},
+	}
+}
+
+func TestLoaderTags(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		op        api.IndexedLoadDeployOperation
+		extraTags []string
+		want      []string
+	}{
+		{
+			name: "backwards-compatible full references",
+			op:   indexedLoadOp("", "", []string{"my-app:latest", "my-app:v1"}),
+			want: []string{"my-app:latest", "my-app:v1"},
+		},
+		{
+			name: "registry and repository reconstruct names",
+			op:   indexedLoadOp("gcr.io", "proj/app", []string{"latest", "v1"}),
+			want: []string{"gcr.io/proj/app:latest", "gcr.io/proj/app:v1"},
+		},
+		{
+			name:      "extra tags are treated as full references",
+			op:        indexedLoadOp("gcr.io", "proj/app", []string{"latest"}),
+			extraTags: []string{"local/name:dev"},
+			want:      []string{"gcr.io/proj/app:latest", "local/name:dev"},
+		},
+		{
+			name:      "duplicates removed and sorted",
+			op:        indexedLoadOp("", "", []string{"b:2", "a:1"}),
+			extraTags: []string{"a:1"},
+			want:      []string{"a:1", "b:2"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			l := &loader{extraTags: tc.extraTags}
+			got := l.tags(tc.op)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("tags() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoaderTagsDoesNotMutateOp guards against aliasing the operation's Tags
+// backing array when appending extra tags.
+func TestLoaderTagsDoesNotMutateOp(t *testing.T) {
+	op := indexedLoadOp("", "", []string{"my-app:latest"})
+	l := &loader{extraTags: []string{"extra:tag"}}
+	_ = l.tags(op)
+	if !reflect.DeepEqual(op.Tags, []string{"my-app:latest"}) {
+		t.Fatalf("tags() mutated op.Tags: %v", op.Tags)
+	}
+}
+
+func TestLoaderTagsWithOverrides(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		op                 api.IndexedLoadDeployOperation
+		overrideRegistry   string
+		overrideRepository string
+		want               []string
+	}{
+		{
+			name:               "both overrides in split mode",
+			op:                 indexedLoadOp("gcr.io", "proj/app", []string{"latest"}),
+			overrideRegistry:   "reg.example.com",
+			overrideRepository: "team/app",
+			want:               []string{"reg.example.com/team/app:latest"},
+		},
+		{
+			name:             "registry-only override in split mode",
+			op:               indexedLoadOp("gcr.io", "proj/app", []string{"latest", "v1"}),
+			overrideRegistry: "reg.example.com",
+			want:             []string{"reg.example.com/proj/app:latest", "reg.example.com/proj/app:v1"},
+		},
+		{
+			name:               "repository-only override in split mode",
+			op:                 indexedLoadOp("gcr.io", "proj/app", []string{"latest"}),
+			overrideRepository: "team/app",
+			want:               []string{"gcr.io/team/app:latest"},
+		},
+		{
+			name:               "overrides ignored in rules_oci fallback (empty registry/repository)",
+			op:                 indexedLoadOp("", "", []string{"my-app:latest"}),
+			overrideRegistry:   "reg.example.com",
+			overrideRepository: "team/app",
+			want:               []string{"my-app:latest"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			l := &loader{overrideRegistry: tc.overrideRegistry, overrideRepository: tc.overrideRepository}
+			got := l.tags(tc.op)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("tags() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…/tag)

image_load / image_load_spec now accept the same registry/repository/tag destination attributes as image_push. A sole tag/tag_list/tag_file (with no registry/repository) retains the rules_oci-compatible behavior: the tags are already full references, rendered verbatim in Docker manifest.json RepoTags and in the OCI index.json annotations.

Deploy manifest: LoadDeployOperation mirrors PushTarget with omitempty Registry/Repository, so a tags-only load emits only the tags field. When both are set, full image names are reconstructed as <registry>/<repository>:<tag> in every consumer (loader, docker-save, deploy-metadata) via api.QualifyLoadTags.

- Validate registry/repository both-or-neither in Starlark, and again in the img tool on the post-expansion values (a template expanding to empty now hard- errors instead of silently falling back to verbatim mode, mirroring push).
- pull.bzl: the generated :load target sets registry/repository/tag separately.
- Deploy-time --registry/--repository flags now override load ops too, but only in split mode (non-empty registry/repository); the rules_oci fallback is left alone. Wired into both the direct and persistent-worker deploy paths.
- e2e: adopt the split attributes for load targets, keeping explicit legacy (rules_oci-compatible) demos and network-free scratch coverage of both modes.
- docs/README: lead with the split syntax, explain that a daemon image name is just a string and the split simply keeps load aligned with a matching push.

Adds unit tests for QualifyLoadTags/ValidateLoadDestination, the loader (incl. overrides), docker-save and deploy-metadata load paths.