### PR TITLE
feat(deploy): add deploy_operations filter to multi_deploy

### DIFF
--- a/docs/multi_deploy.md
+++ b/docs/multi_deploy.md
@@ -9,7 +9,8 @@ Public API for container image multi deploy rule.
 <pre>
 load("@rules_img//img:multi_deploy.bzl", "multi_deploy")
 
-multi_deploy(<a href="#multi_deploy-name">name</a>, <a href="#multi_deploy-deploy_tool">deploy_tool</a>, <a href="#multi_deploy-load_strategy">load_strategy</a>, <a href="#multi_deploy-operations">operations</a>, <a href="#multi_deploy-push_strategy">push_strategy</a>, <a href="#multi_deploy-tool_cfg">tool_cfg</a>)
+multi_deploy(<a href="#multi_deploy-name">name</a>, <a href="#multi_deploy-deploy_operations">deploy_operations</a>, <a href="#multi_deploy-deploy_tool">deploy_tool</a>, <a href="#multi_deploy-load_strategy">load_strategy</a>, <a href="#multi_deploy-operations">operations</a>, <a href="#multi_deploy-push_strategy">push_strategy</a>,
+             <a href="#multi_deploy-tool_cfg">tool_cfg</a>)
 </pre>
 
 Deploys multiple container images in a single coordinated command.
@@ -66,6 +67,7 @@ bazel run //path/to:deploy_all
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="multi_deploy-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="multi_deploy-deploy_operations"></a>deploy_operations |  Which kinds of deploy operations to perform.<br><br>Acts as a filter when assembling the final deploy manifest from all `operations`:<br><br>- `"push"`: include push operations (and their associated registry tag operations). - `"load"`: include load operations.<br><br>Defaults to `["push", "load"]`, performing every operation contributed by the `operations` targets. Narrow it when your images carry both `push_specs` and `load_specs` but a particular deployment should only push or only load -- for example, `["push"]` to push without loading, or `["load"]` to load without pushing.   | List of strings | optional |  `["push", "load"]`  |
 | <a id="multi_deploy-deploy_tool"></a>deploy_tool |  Optional label of a deploy tool target providing `DeployToolInfo` (created with `img_deploy_tool` from `@rules_img//img:deploy_tool.bzl`). When set, overrides `tool_cfg`.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="multi_deploy-load_strategy"></a>load_strategy |  Load strategy to use for all load operations in the deployment.<br><br>Available strategies: - **`auto`** (default): Uses the global default load strategy - **`eager`**: Downloads all layers during the build phase - **`lazy`**: Downloads layers only when needed during the load operation   | String | optional |  `"auto"`  |
 | <a id="multi_deploy-operations"></a>operations |  List of operations to deploy together.<br><br>Each operation must provide DeployInfo (typically from image_push, image_load, image_manifest with push_specs/load_specs, or image_index with push_specs/load_specs). All operations will be merged and executed in the order specified.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |

--- a/img/private/multi_deploy.bzl
+++ b/img/private/multi_deploy.bzl
@@ -51,6 +51,11 @@ def _compute_multi_deploy_metadata(*, ctx):
     merge_args.add("--push-strategy", _multi_deploy_strategy(ctx, "push"))
     merge_args.add("--load-strategy", _multi_deploy_strategy(ctx, "load"))
 
+    # Filter the assembled operations by kind. push_specs contribute push (and
+    # their associated registry_tag) operations; load_specs contribute load
+    # operations. Only the requested kinds are merged into the final manifest.
+    merge_args.add_all(ctx.attr.deploy_operations, before_each = "--operation")
+
     # Add layer hints inputs and output if any exist
     layer_hints_out = None
     if layer_hints_files:
@@ -104,6 +109,12 @@ def _multi_deploy_impl(ctx):
     """Implementation of the multi_deploy rule."""
     if not ctx.attr.operations:
         fail("operations attribute cannot be empty")
+
+    if not ctx.attr.deploy_operations:
+        fail("deploy_operations attribute cannot be empty; specify [\"push\"], [\"load\"], or [\"push\", \"load\"]")
+    for operation in ctx.attr.deploy_operations:
+        if operation not in ("push", "load"):
+            fail("deploy_operations may only contain \"push\" and/or \"load\", got \"{}\"".format(operation))
 
     for operation in ctx.attr.operations:
         if DeployInfo not in operation:
@@ -289,6 +300,21 @@ Available strategies:
 """,
             default = "auto",
             values = ["auto", "eager", "lazy"],
+        ),
+        "deploy_operations": attr.string_list(
+            doc = """Which kinds of deploy operations to perform.
+
+Acts as a filter when assembling the final deploy manifest from all `operations`:
+
+- `"push"`: include push operations (and their associated registry tag operations).
+- `"load"`: include load operations.
+
+Defaults to `["push", "load"]`, performing every operation contributed by the
+`operations` targets. Narrow it when your images carry both `push_specs` and
+`load_specs` but a particular deployment should only push or only load -- for
+example, `["push"]` to push without loading, or `["load"]` to load without pushing.
+""",
+            default = ["push", "load"],
         ),
         "_push_settings": attr.label(
             default = Label("//img/private/settings:push"),

--- a/img_tool/cmd/deploymetadata/merge.go
+++ b/img_tool/cmd/deploymetadata/merge.go
@@ -42,6 +42,16 @@ func DeployMergeProcess(ctx context.Context, args []string) {
 	}
 	flagSet.StringVar(&pushStrategy, "push-strategy", "lazy", `Push strategy to use for all push operations. One of "eager", "lazy", "cas_registry", or "bes".`)
 	flagSet.StringVar(&loadStrategy, "load-strategy", "lazy", `Load strategy to use for all load operations. One of "eager", "lazy".`)
+	var operations []string
+	flagSet.Func("operation", `(Optional, repeatable) restrict the merged operations to a kind: "push" or "load". If omitted, all operations are kept.`, func(value string) error {
+		switch value {
+		case "push", "load":
+			operations = append(operations, value)
+			return nil
+		default:
+			return fmt.Errorf("invalid operation %q (want %q or %q)", value, "push", "load")
+		}
+	})
 	flagSet.Func("layer-hints-input", `(Optional) path to layer hints file to merge. Can be specified multiple times.`, func(value string) error {
 		mergeLayerHintsInputPaths = append(mergeLayerHintsInputPaths, value)
 		return nil
@@ -96,13 +106,41 @@ func DeployMergeProcess(ctx context.Context, args []string) {
 		}
 	}
 
-	if err := MergeDeployManifests(ctx, inputPaths, outputPath); err != nil {
+	if err := MergeDeployManifests(ctx, inputPaths, outputPath, operations); err != nil {
 		fmt.Fprintf(os.Stderr, "Error merging deploy manifests: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func MergeDeployManifests(ctx context.Context, inputPaths []string, outputPath string) error {
+// keepOperation reports whether an operation with the given command should be
+// retained given the requested operation kinds. Push, registry_tag, and referrer
+// (also command "push") operations count as the "push" kind; load operations
+// count as "load". Unrecognized commands are always kept so unknown operation
+// types are never silently dropped.
+func keepOperation(command string, kinds map[string]bool) bool {
+	switch command {
+	case "load":
+		return kinds["load"]
+	case "push", "registry_tag":
+		return kinds["push"]
+	default:
+		return true
+	}
+}
+
+// MergeDeployManifests concatenates the operations of every input manifest into a
+// single manifest written to outputPath. When operations is non-empty, only the
+// requested operation kinds ("push" and/or "load") are retained; an empty
+// operations slice keeps every operation.
+func MergeDeployManifests(ctx context.Context, inputPaths []string, outputPath string, operations []string) error {
+	var kinds map[string]bool
+	if len(operations) > 0 {
+		kinds = make(map[string]bool, len(operations))
+		for _, kind := range operations {
+			kinds[kind] = true
+		}
+	}
+
 	var allOperations []json.RawMessage
 
 	// Read and merge all input deploy manifests
@@ -117,8 +155,22 @@ func MergeDeployManifests(ctx context.Context, inputPaths []string, outputPath s
 			return fmt.Errorf("unmarshalling deploy manifest from %s: %w", inputPath, err)
 		}
 
-		// Append all operations from this manifest
-		allOperations = append(allOperations, deployManifest.Operations...)
+		// Append the operations from this manifest, keeping only the requested
+		// kinds when a filter was provided.
+		for _, rawOp := range deployManifest.Operations {
+			if kinds != nil {
+				var head struct {
+					Command string `json:"command"`
+				}
+				if err := json.Unmarshal(rawOp, &head); err != nil {
+					return fmt.Errorf("unmarshalling operation command from %s: %w", inputPath, err)
+				}
+				if !keepOperation(head.Command, kinds) {
+					continue
+				}
+			}
+			allOperations = append(allOperations, rawOp)
+		}
 	}
 
 	// Create merged deploy manifest with unified settings

--- a/img_tool/cmd/deploymetadata/merge_test.go
+++ b/img_tool/cmd/deploymetadata/merge_test.go
@@ -68,6 +68,74 @@ func TestDeployMergeProcessExpandsArgfile(t *testing.T) {
 	}
 }
 
+func TestMergeDeployManifestsFiltersByOperation(t *testing.T) {
+	tmp := t.TempDir()
+	// A manifest carrying every operation kind we filter on. registry_tag rides
+	// along with push; referrer operations also use the "push" command.
+	input := writeDeployManifest(t, filepath.Join(tmp, "in.json"), "push", "registry_tag", "load")
+
+	cases := []struct {
+		name       string
+		operations []string
+		want       []string
+	}{
+		{"push only", []string{"push"}, []string{"push", "registry_tag"}},
+		{"load only", []string{"load"}, []string{"load"}},
+		{"both", []string{"push", "load"}, []string{"push", "registry_tag", "load"}},
+		{"no filter keeps all", nil, []string{"push", "registry_tag", "load"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			output := filepath.Join(tmp, tc.name+".json")
+			if err := MergeDeployManifests(context.Background(), []string{input}, output, tc.operations); err != nil {
+				t.Fatalf("MergeDeployManifests: %v", err)
+			}
+			if got := mergedCommands(t, output); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("filtered commands = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// An unrecognized command must never be dropped, even when a filter is active.
+func TestMergeDeployManifestsKeepsUnknownCommands(t *testing.T) {
+	tmp := t.TempDir()
+	input := writeDeployManifest(t, filepath.Join(tmp, "in.json"), "push", "mystery", "load")
+	output := filepath.Join(tmp, "out.json")
+
+	if err := MergeDeployManifests(context.Background(), []string{input}, output, []string{"load"}); err != nil {
+		t.Fatalf("MergeDeployManifests: %v", err)
+	}
+	if got, want := mergedCommands(t, output), []string{"mystery", "load"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("filtered commands = %v, want %v", got, want)
+	}
+}
+
+// mergedCommands reads a merged deploy manifest and returns the command of each
+// operation in order.
+func mergedCommands(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading output manifest: %v", err)
+	}
+	var got api.DeployManifest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshalling output manifest: %v", err)
+	}
+	var commands []string
+	for _, raw := range got.Operations {
+		var op struct {
+			Command string `json:"command"`
+		}
+		if err := json.Unmarshal(raw, &op); err != nil {
+			t.Fatalf("unmarshalling operation %s: %v", raw, err)
+		}
+		commands = append(commands, op.Command)
+	}
+	return commands
+}
+
 func writeDeployManifest(t *testing.T, path string, commands ...string) string {
 	t.Helper()
 

--- a/tests/img_toolchain/testcases/deploymerge_all_operations.ini
+++ b/tests/img_toolchain/testcases/deploymerge_all_operations.ini
@@ -1,0 +1,26 @@
+[test]
+name = deploymerge_all_operations
+description = deploy-merge with --operation push --operation load keeps push, registry_tag (tag) and load operations
+
+[file]
+name = input.json
+{"operations":[{"command":"push","registry":"registry.example.com","repository":"team/app","tags":["latest"]},{"command":"registry_tag","registry":"registry.example.com","repository":"team/app","tags":["stable"]},{"command":"load","tags":["registry.example.com/team/app:dev"],"daemon":"docker"}],"settings":{"push_strategy":"eager","load_strategy":"eager"}}
+
+[command]
+subcommand = deploy-merge
+args = --push-strategy lazy --load-strategy lazy --operation push --operation load input.json output.json
+expect_exit = 0
+
+[assert]
+file_exists = output.json
+file_valid_json = output.json
+json_field_exists = output.json, operations
+json_field_exists = output.json, settings
+# push, tag (registry_tag) and load operations are all retained
+file_contains = output.json, "command":"push"
+file_contains = output.json, "command":"registry_tag"
+file_contains = output.json, "command":"load"
+# strategies come from the merge flags, not the inputs
+file_contains = output.json, "push_strategy":"lazy"
+file_contains = output.json, "load_strategy":"lazy"
+file_sha256 = output.json, "143ff1857c49ddd5d05f39bc23478d44e5086a0f4a394ce5151faefb1df31b20"

--- a/tests/img_toolchain/testcases/deploymerge_only_push.ini
+++ b/tests/img_toolchain/testcases/deploymerge_only_push.ini
@@ -1,0 +1,23 @@
+[test]
+name = deploymerge_only_push
+description = deploy-merge with --operation push keeps push operations and drops load
+
+[file]
+name = input.json
+{"operations":[{"command":"push","registry":"registry.example.com","repository":"team/app","tags":["latest"]},{"command":"load","tags":["registry.example.com/team/app:dev"],"daemon":"docker"}],"settings":{"push_strategy":"eager","load_strategy":"eager"}}
+
+[command]
+subcommand = deploy-merge
+args = --push-strategy lazy --load-strategy lazy --operation push input.json output.json
+expect_exit = 0
+
+[assert]
+file_exists = output.json
+file_valid_json = output.json
+json_field_exists = output.json, operations
+json_field_exists = output.json, settings
+# push operations are retained
+file_contains = output.json, "command":"push"
+# load operations are filtered out
+file_not_contains = output.json, "command":"load"
+file_sha256 = output.json, "588da8b3a3834bf847847c726a4e243e48f722bd50ad87bb0a30c7dc38c085cc"

--- a/tests/img_toolchain/testcases/deploymerge_only_tag.ini
+++ b/tests/img_toolchain/testcases/deploymerge_only_tag.ini
@@ -1,0 +1,24 @@
+[test]
+name = deploymerge_only_tag
+description = deploy-merge with --operation push keeps registry_tag (tag) operations and drops load; tag operations ride with the push selector
+
+[file]
+name = input.json
+{"operations":[{"command":"registry_tag","registry":"registry.example.com","repository":"team/app","tags":["stable"]},{"command":"load","tags":["registry.example.com/team/app:dev"],"daemon":"docker"}],"settings":{"push_strategy":"eager","load_strategy":"eager"}}
+
+[command]
+subcommand = deploy-merge
+args = --push-strategy lazy --load-strategy lazy --operation push input.json output.json
+expect_exit = 0
+
+[assert]
+file_exists = output.json
+file_valid_json = output.json
+json_field_exists = output.json, operations
+json_field_exists = output.json, settings
+# registry_tag (tag) operations are retained by the "push" selector
+file_contains = output.json, "command":"registry_tag"
+# there is no standalone push operation and load is filtered out
+file_not_contains = output.json, "command":"push"
+file_not_contains = output.json, "command":"load"
+file_sha256 = output.json, "3c348dccb4a097715c3bff2a20e06f27e179b8b3393c1abede43ac1ac44f6eab"


### PR DESCRIPTION
multi_deploy previously performed every operation contributed by its `operations` targets. Images carrying both `push_specs` and `load_specs` had no way to deploy only a subset (e.g. push without loading).

Add a `deploy_operations` attribute (list of strings, default ["push", "load"]) that filters the assembled deploy manifest:

- "push" keeps push operations and their associated registry_tag operations
- "load" keeps load operations

The filter is applied by the deploy-merge tool through a new repeatable --operation flag. When no filter is passed every operation is kept, so the image-level merge path is unchanged, and unrecognized operation commands are never dropped.

Add tests/img_toolchain cases covering all-ops, push-only and tag-only, asserting both the JSON fields and the output digest.