### PR TITLE
feat(deploy): add --sink override to redirect push/load into local artifacts

### DIFF
--- a/img_tool/cmd/deploy/BUILD.bazel
+++ b/img_tool/cmd/deploy/BUILD.bazel
@@ -1,10 +1,11 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "deploy",
     srcs = [
         "deploy.go",
         "persistentworker.go",
+        "sink.go",
     ],
     importpath = "github.com/bazel-contrib/rules_img/img_tool/cmd/deploy",
     visibility = ["//visibility:public"],
@@ -17,12 +18,30 @@ go_library(
         "//pkg/deployvfs",
         "//pkg/gateway",
         "//pkg/load",
+        "//pkg/ocilayout",
         "//pkg/persistentworker",
         "//pkg/proto/blobcache",
         "//pkg/push",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_google_go_containerregistry//pkg/v1/remote",
+        "@com_github_google_go_containerregistry//pkg/v1/types",
         "@org_golang_x_sync//errgroup",
+    ],
+)
+
+go_test(
+    name = "deploy_test",
+    srcs = [
+        "sink_test.go",
+        "sink_vfs_test.go",
+    ],
+    embed = [":deploy"],
+    deps = [
+        "//pkg/api",
+        "//pkg/deployvfs",
+        "//pkg/ocilayout",
+        "@com_github_google_go_containerregistry//pkg/v1:pkg",
+        "@com_github_google_go_containerregistry//pkg/v1/types",
     ],
 )

--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -40,9 +40,24 @@ func DeployProcess(ctx context.Context, args []string) {
 		fmt.Fprintf(os.Stderr, "Error parsing args: %v\n", err)
 		os.Exit(1)
 	}
+	sinkSpec := extractSinkFlag(processedArgs)
+	// A global oci-tar/docker-save sink cannot run under the persistent worker,
+	// so specifying one on the command line forces one-shot mode. A global
+	// distribution/oci sink is compatible with the worker and is applied to
+	// every incoming request.
+	if isPersistentWorker && sinkSpec != "" {
+		kind, _, err := parseSink(sinkSpec)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if !kind.globalOnly() {
+			isPersistentWorker = false
+		}
+	}
 	if isPersistentWorker {
 		jobs := extractJobsFlag(processedArgs)
-		if err := persistentWorker(jobs); err != nil {
+		if err := persistentWorker(jobs, sinkSpec); err != nil {
 			fmt.Fprintf(os.Stderr, "Error in persistent worker: %v\n", err)
 			os.Exit(1)
 		}
@@ -59,6 +74,7 @@ func DeployProcess(ctx context.Context, args []string) {
 	var ociLayouts stringSliceFlag
 	var explicitLayers stringSliceFlag
 	var jobs int
+	var sink string
 
 	flagSet := flag.NewFlagSet("deploy", flag.ContinueOnError)
 	flagSet.Var(&requestFiles, "request-file", "Deploy manifest JSON request file (can be used multiple times)")
@@ -71,6 +87,7 @@ func DeployProcess(ctx context.Context, args []string) {
 	flagSet.Var(&ociLayouts, "oci-layout", "Path to an OCI layout directory, sparse or standard (can be used multiple times)")
 	flagSet.Var(&explicitLayers, "layer", "Explicit layer in digest=path format (can be used multiple times)")
 	flagSet.IntVar(&jobs, "jobs", 16, "Maximum number of parallel push operations")
+	flagSet.StringVar(&sink, "sink", "", "Override the destination of all push/load/registry_tag operations for testing. Format: <type>:<path> where type is one of oci-tar, docker-save, oci, distribution, distribution-flat. No registry or daemon network I/O is performed.")
 
 	if err := flagSet.Parse(args); err != nil {
 		flagSet.Usage()
@@ -125,6 +142,7 @@ func DeployProcess(ctx context.Context, args []string) {
 		OCILayouts:                 []string(ociLayouts),
 		ExplicitLayers:             layerMap,
 		Jobs:                       jobs,
+		Sink:                       sink,
 	}
 
 	if err := DeployWithExtras(ctx, rawRequest, opts); err != nil {
@@ -175,6 +193,7 @@ type DeployOptions struct {
 	OCILayouts                 []string
 	ExplicitLayers             map[string]string
 	Jobs                       int
+	Sink                       string
 }
 
 func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions) error {
@@ -249,6 +268,15 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 	if err != nil {
 		return err
 	}
+
+	// When a --sink override is active, capture every operation into the local
+	// sink instead of pushing to a registry or loading into a daemon. This
+	// performs no registry/daemon network I/O for the destination (source blobs
+	// are still resolved from the VFS as usual).
+	if opts.Sink != "" {
+		return deployToSink(ctx, opts.Sink, vfs, pushOperations, loadOperations, registryTagOperations, opts)
+	}
+
 	if len(pushOperations) == 0 && len(loadOperations) == 0 && len(registryTagOperations) == 0 {
 		return fmt.Errorf("no push, load, or registry_tag operations found in deploy manifest")
 	}
@@ -535,4 +563,52 @@ func extractJobsFlag(args []string) int {
 		}
 	}
 	return 16
+}
+
+// extractSinkFlag pre-scans args for --sink so DeployProcess can decide whether
+// a global oci-tar/docker-save sink must force one-shot mode before the normal
+// flag set is parsed.
+func extractSinkFlag(args []string) string {
+	for i := 0; i < len(args); i++ {
+		key, value, hasValue := strings.Cut(args[i], "=")
+		if key == "--sink" {
+			if !hasValue && i+1 < len(args) {
+				value = args[i+1]
+			}
+			return value
+		}
+	}
+	return ""
+}
+
+// deployToSink builds the requested sink, routes every operation into it, and
+// prints the resulting image references. It performs no registry/daemon network
+// I/O for the destination.
+func deployToSink(ctx context.Context, spec string, vfs *deployvfs.VFS, pushOps []api.IndexedPushDeployOperation, loadOps []api.IndexedLoadDeployOperation, tagOps []api.IndexedRegistryTagDeployOperation, opts DeployOptions) error {
+	kind, path, err := parseSink(spec)
+	if err != nil {
+		return err
+	}
+	s, err := newSink(kind, path)
+	if err != nil {
+		return fmt.Errorf("creating sink: %w", err)
+	}
+	refs, err := routeToSink(ctx, s, vfs, pushOps, loadOps, tagOps, sinkRouteOptions{
+		overrideRegistry:   opts.OverrideRegistry,
+		overrideRepository: opts.OverrideRepository,
+		additionalTags:     opts.AdditionalTags,
+	})
+	if err != nil {
+		s.Close()
+		return err
+	}
+	if err := s.Close(); err != nil {
+		return fmt.Errorf("finalizing sink: %w", err)
+	}
+	stats := vfs.Stats()
+	fmt.Fprintf(os.Stderr, "    blob transfers: %d from disk, %d from disk cache, %d from container registry, %d from remote cache, %d from compact stream\n", stats.BlobsFromLocalDisk.Load(), stats.BlobsFromDiskCache.Load(), stats.BlobsFromRegistry.Load(), stats.BlobsFromRemoteCache.Load(), stats.BlobsFromCompactStream.Load())
+	for _, ref := range refs {
+		fmt.Println(ref)
+	}
+	return nil
 }

--- a/img_tool/cmd/deploy/persistentworker.go
+++ b/img_tool/cmd/deploy/persistentworker.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 
@@ -28,9 +29,15 @@ type deployWorkerHandler struct {
 	jobs          int
 	baseBuilder   *deployvfs.Builder
 	pushTransport http.RoundTripper
+
+	// globalSink, when set, redirects every request's operations into a shared
+	// local sink (distribution/oci) instead of a registry. It is not
+	// concurrency-safe, so access is serialized by sinkMu.
+	globalSink sink
+	sinkMu     sync.Mutex
 }
 
-func newDeployWorkerHandler(jobs int) (*deployWorkerHandler, error) {
+func newDeployWorkerHandler(jobs int, sinkSpec string) (*deployWorkerHandler, error) {
 	// Configure optional registry gateways. When IMG_REGISTRY_*_GATEWAY is set,
 	// push and base-image (pull) requests are routed through the gateway; when
 	// unset, WrapTransport returns the base transport unchanged.
@@ -54,12 +61,30 @@ func newDeployWorkerHandler(jobs int) (*deployWorkerHandler, error) {
 		fmt.Fprintf(os.Stderr, "warning: failed to configure VFS from environment: %v\n", err)
 	}
 
+	h := &deployWorkerHandler{jobs: jobs, baseBuilder: baseBuilder, pushTransport: pushTransport}
+
+	if sinkSpec != "" {
+		// A global distribution/oci sink redirects every request; no pusher is
+		// created because no registry I/O is performed.
+		kind, path, err := parseSink(sinkSpec)
+		if err != nil {
+			return nil, err
+		}
+		s, err := newSink(kind, path)
+		if err != nil {
+			return nil, fmt.Errorf("creating global sink: %w", err)
+		}
+		h.globalSink = s
+		return h, nil
+	}
+
 	opts := []remote.Option{registry.WithAuthFromMultiKeychain(), remote.WithTransport(pushTransport), remote.WithJobs(jobs)}
 	p, err := remote.NewPusher(opts...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to create persistent pusher: %v\n", err)
 	}
-	return &deployWorkerHandler{pusher: p, jobs: jobs, baseBuilder: baseBuilder, pushTransport: pushTransport}, nil
+	h.pusher = p
+	return h, nil
 }
 
 func (h *deployWorkerHandler) HandleRequest(ctx context.Context, req persistentworker.WorkRequest) persistentworker.WorkResponse {
@@ -107,6 +132,18 @@ func (h *deployWorkerHandler) processRequest(ctx context.Context, req persistent
 	vfs, err := vfsBuilder.Build()
 	if err != nil {
 		return "", fmt.Errorf("building VFS: %w", err)
+	}
+
+	// Sink routing bypasses the pusher/loader/tagger entirely (no registry or
+	// daemon network I/O for the destination).
+	if h.globalSink != nil {
+		if opts.sink != "" {
+			return "", fmt.Errorf("--sink cannot be set in a work request when img deploy was started with a global --sink")
+		}
+		return h.routeGlobalSink(ctx, vfs, dm, opts)
+	}
+	if opts.sink != "" {
+		return h.routePerRequestSink(ctx, vfs, dm, opts)
 	}
 
 	var output strings.Builder
@@ -164,6 +201,86 @@ func (h *deployWorkerHandler) processRequest(ctx context.Context, req persistent
 	}
 
 	return output.String(), nil
+}
+
+// sinkOperations extracts the push, load and registry_tag operations from a
+// deploy manifest.
+func sinkOperations(dm api.DeployManifest) ([]api.IndexedPushDeployOperation, []api.IndexedLoadDeployOperation, []api.IndexedRegistryTagDeployOperation, error) {
+	pushOps, err := dm.PushOperations()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	loadOps, err := dm.LoadOperations()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	tagOps, err := dm.RegistryTagOperations()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return pushOps, loadOps, tagOps, nil
+}
+
+// routeGlobalSink captures a request's operations into the shared global sink.
+// Access is serialized because the incremental dir sinks are not concurrency-
+// safe, and the sink is flushed after each request so its on-disk state stays
+// valid between requests.
+func (h *deployWorkerHandler) routeGlobalSink(ctx context.Context, vfs *deployvfs.VFS, dm api.DeployManifest, opts *workerOpts) (string, error) {
+	pushOps, loadOps, tagOps, err := sinkOperations(dm)
+	if err != nil {
+		return "", err
+	}
+	h.sinkMu.Lock()
+	defer h.sinkMu.Unlock()
+	refs, err := routeToSink(ctx, h.globalSink, vfs, pushOps, loadOps, tagOps, sinkRouteOptions{
+		overrideRegistry:   opts.overrideRegistry,
+		overrideRepository: opts.overrideRepository,
+	})
+	if err != nil {
+		return "", err
+	}
+	if err := h.globalSink.Close(); err != nil {
+		return "", fmt.Errorf("flushing sink: %w", err)
+	}
+	return refsOutput(refs), nil
+}
+
+// routePerRequestSink captures a request's operations into an isolated,
+// request-scoped oci-tar/docker-save sink.
+func (h *deployWorkerHandler) routePerRequestSink(ctx context.Context, vfs *deployvfs.VFS, dm api.DeployManifest, opts *workerOpts) (string, error) {
+	kind, path, err := parseSink(opts.sink)
+	if err != nil {
+		return "", err
+	}
+	s, err := newSink(kind, path)
+	if err != nil {
+		return "", fmt.Errorf("creating sink: %w", err)
+	}
+	pushOps, loadOps, tagOps, err := sinkOperations(dm)
+	if err != nil {
+		return "", err
+	}
+	refs, err := routeToSink(ctx, s, vfs, pushOps, loadOps, tagOps, sinkRouteOptions{
+		overrideRegistry:   opts.overrideRegistry,
+		overrideRepository: opts.overrideRepository,
+	})
+	if err != nil {
+		s.Close()
+		return "", err
+	}
+	if err := s.Close(); err != nil {
+		return "", fmt.Errorf("finalizing sink: %w", err)
+	}
+	return refsOutput(refs), nil
+}
+
+func refsOutput(refs []string) string {
+	var output strings.Builder
+	for _, ref := range refs {
+		output.WriteString(ref)
+		output.WriteByte('\n')
+	}
+	return output.String()
 }
 
 func (h *deployWorkerHandler) pushOps(ctx context.Context, vfs *deployvfs.VFS, ops []api.IndexedPushDeployOperation, strategy string, opts *workerOpts) ([]string, error) {
@@ -251,6 +368,7 @@ type workerOpts struct {
 	overrideRegistry   string
 	overrideRepository string
 	platforms          []string
+	sink               string
 }
 
 func parseWorkerArgs(args []string) (*workerOpts, error) {
@@ -333,6 +451,22 @@ func parseWorkerArgs(args []string) (*workerOpts, error) {
 			for j, p := range opts.platforms {
 				opts.platforms[j] = strings.TrimSpace(p)
 			}
+		case key == "--sink":
+			if !hasValue {
+				if i+1 >= len(args) {
+					return nil, fmt.Errorf("--sink requires a value")
+				}
+				i++
+				value = args[i]
+			}
+			kind, _, err := parseSink(value)
+			if err != nil {
+				return nil, err
+			}
+			if kind.globalOnly() {
+				return nil, fmt.Errorf("--sink %q may only be set on the img deploy command line, not in a work request", value)
+			}
+			opts.sink = value
 		}
 	}
 
@@ -342,8 +476,8 @@ func parseWorkerArgs(args []string) (*workerOpts, error) {
 	return opts, nil
 }
 
-func persistentWorker(jobs int) error {
-	handler, err := newDeployWorkerHandler(jobs)
+func persistentWorker(jobs int, sinkSpec string) error {
+	handler, err := newDeployWorkerHandler(jobs, sinkSpec)
 	if err != nil {
 		return err
 	}

--- a/img_tool/cmd/deploy/sink.go
+++ b/img_tool/cmd/deploy/sink.go
@@ -1,0 +1,490 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	registryv1 "github.com/google/go-containerregistry/pkg/v1"
+	registrytypes "github.com/google/go-containerregistry/pkg/v1/types"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/deployvfs"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/ocilayout"
+)
+
+// sinkKind identifies a --sink destination type.
+type sinkKind int
+
+const (
+	sinkNone sinkKind = iota
+	sinkOCITar
+	sinkDockerSave
+	sinkOCIDir
+	sinkDistribution
+	sinkDistributionFlat
+)
+
+// parseSink parses a --sink spec of the form "<type>:<path>".
+func parseSink(spec string) (sinkKind, string, error) {
+	typ, path, ok := strings.Cut(spec, ":")
+	if !ok || path == "" {
+		return sinkNone, "", fmt.Errorf("--sink must be in the form <type>:<path>, got %q", spec)
+	}
+	switch typ {
+	case "oci-tar":
+		return sinkOCITar, path, nil
+	case "docker-save":
+		return sinkDockerSave, path, nil
+	case "oci":
+		return sinkOCIDir, path, nil
+	case "distribution":
+		return sinkDistribution, path, nil
+	case "distribution-flat":
+		return sinkDistributionFlat, path, nil
+	}
+	return sinkNone, "", fmt.Errorf("unknown --sink type %q (want oci-tar, docker-save, oci, distribution, or distribution-flat)", typ)
+}
+
+// globalOnly reports whether a sink kind may only be set on the top-level
+// command line (never inside a persistent-worker request). The incremental,
+// dir-backed sinks are global-only; the isolated tar sinks may be per-request.
+func (k sinkKind) globalOnly() bool {
+	switch k {
+	case sinkOCIDir, sinkDistribution, sinkDistributionFlat:
+		return true
+	}
+	return false
+}
+
+// newSink opens/creates the sink for a parsed kind + path.
+func newSink(kind sinkKind, path string) (sink, error) {
+	switch kind {
+	case sinkOCITar:
+		return newTarSink(path, false), nil
+	case sinkDockerSave:
+		return newTarSink(path, true), nil
+	case sinkOCIDir:
+		return newOCIDirSink(path)
+	case sinkDistribution:
+		return newDistributionSink(path, false), nil
+	case sinkDistributionFlat:
+		return newDistributionSink(path, true), nil
+	}
+	return nil, fmt.Errorf("unknown --sink kind %d", kind)
+}
+
+// sink is a destination that captures push/load/registry_tag operations instead
+// of pushing to a registry or loading into a daemon. Close finalizes the sink;
+// for the incremental dir-backed sinks it is safe to call repeatedly (it flushes
+// the current on-disk state), which the persistent worker relies on to keep the
+// output valid between requests.
+type sink interface {
+	AddImage(ctx context.Context, img sinkImage) error
+	Close() error
+}
+
+// resolvedRoot is one operation's root (image manifest or index) resolved from
+// the VFS, with its child image manifests' blob sources.
+type resolvedRoot struct {
+	RootData     []byte
+	MediaType    registrytypes.MediaType
+	ArtifactType string
+	IsIndex      bool
+	Children     []ocilayout.ManifestInput
+	Platform     *registryv1.Platform
+}
+
+// sinkImage is one operation routed to a sink: its resolved root plus the full
+// image references (registry/repo:tag) it applies to. Registry/Repository carry
+// the destination for distribution sinks when Refs is empty (a digest-only push).
+type sinkImage struct {
+	Refs       []string
+	Registry   string
+	Repository string
+	Root       resolvedRoot
+}
+
+// sinkRouteOptions carries the deploy-time overrides and extra tags applied
+// while routing operations into a sink.
+type sinkRouteOptions struct {
+	overrideRegistry   string
+	overrideRepository string
+	additionalTags     []string
+}
+
+// routeToSink captures every push, load and registry_tag operation into s and
+// returns the sorted, de-duplicated list of full image references written. It
+// does not Close s (the caller decides when to finalize).
+func routeToSink(ctx context.Context, s sink, vfs *deployvfs.VFS, pushOps []api.IndexedPushDeployOperation, loadOps []api.IndexedLoadDeployOperation, tagOps []api.IndexedRegistryTagDeployOperation, opts sinkRouteOptions) ([]string, error) {
+	var written []string
+	add := func(registry, repository string, refs []string, rootKind, rootDigest string) error {
+		root, err := resolveRoot(ctx, vfs, rootKind, rootDigest)
+		if err != nil {
+			return err
+		}
+		if err := s.AddImage(ctx, sinkImage{Refs: refs, Registry: registry, Repository: repository, Root: root}); err != nil {
+			return err
+		}
+		written = append(written, refs...)
+		return nil
+	}
+
+	for _, op := range pushOps {
+		registry, repository := op.Registry, op.Repository
+		if opts.overrideRegistry != "" {
+			registry = opts.overrideRegistry
+		}
+		if opts.overrideRepository != "" {
+			repository = opts.overrideRepository
+		}
+		bareTags := deduplicateAndSortTags(append(slices.Clone(op.Tags), opts.additionalTags...))
+		refs := api.QualifyLoadTags(registry, repository, bareTags)
+		if err := add(registry, repository, refs, op.RootKind, op.Root.Digest); err != nil {
+			return nil, fmt.Errorf("push %s/%s: %w", registry, repository, err)
+		}
+	}
+
+	for _, op := range loadOps {
+		registry, repository := op.Registry, op.Repository
+		if registry != "" && repository != "" {
+			if opts.overrideRegistry != "" {
+				registry = opts.overrideRegistry
+			}
+			if opts.overrideRepository != "" {
+				repository = opts.overrideRepository
+			}
+		}
+		refs := api.QualifyLoadTags(registry, repository, op.Tags)
+		refs = append(refs, opts.additionalTags...)
+		refs = deduplicateAndSortTags(refs)
+		// distribution derives its repo from the parsed refs (rules_oci fallback)
+		// or from registry/repository (split mode); pass whatever the op set.
+		if err := add(registry, repository, refs, op.RootKind, op.Root.Digest); err != nil {
+			return nil, fmt.Errorf("load %s: %w", op.Root.Digest, err)
+		}
+	}
+
+	for _, op := range tagOps {
+		registry, repository := op.Registry, op.Repository
+		if opts.overrideRegistry != "" {
+			registry = opts.overrideRegistry
+		}
+		if opts.overrideRepository != "" {
+			repository = opts.overrideRepository
+		}
+		refs := api.QualifyLoadTags(registry, repository, deduplicateAndSortTags(op.Tags))
+		if err := add(registry, repository, refs, op.RootKind, op.Root.Digest); err != nil {
+			return nil, fmt.Errorf("registry_tag %s/%s: %w", registry, repository, err)
+		}
+	}
+
+	return deduplicateAndSortTags(written), nil
+}
+
+// resolveRoot resolves an operation's root (and its children) from the VFS.
+func resolveRoot(ctx context.Context, vfs *deployvfs.VFS, rootKind, rootDigest string) (resolvedRoot, error) {
+	h, err := registryv1.NewHash(rootDigest)
+	if err != nil {
+		return resolvedRoot{}, err
+	}
+	src := vfsBlobSource{vfs: vfs}
+
+	if rootKind == "index" {
+		index, err := vfs.ImageIndex(h)
+		if err != nil {
+			return resolvedRoot{}, fmt.Errorf("getting image index %s: %w", rootDigest, err)
+		}
+		rawIndex, err := index.RawManifest()
+		if err != nil {
+			return resolvedRoot{}, err
+		}
+		im, err := index.IndexManifest()
+		if err != nil {
+			return resolvedRoot{}, err
+		}
+		root := resolvedRoot{RootData: rawIndex, MediaType: im.MediaType, IsIndex: true}
+		for _, desc := range im.Manifests {
+			img, err := vfs.Image(desc.Digest)
+			if err != nil {
+				return resolvedRoot{}, fmt.Errorf("getting image %s: %w", desc.Digest, err)
+			}
+			raw, err := img.RawManifest()
+			if err != nil {
+				return resolvedRoot{}, err
+			}
+			manifest, err := img.Manifest()
+			if err != nil {
+				return resolvedRoot{}, err
+			}
+			desc := desc
+			root.Children = append(root.Children, ocilayout.ManifestInputFromVFS(src, manifest, raw, desc.Platform))
+		}
+		return root, nil
+	}
+
+	img, err := vfs.Image(h)
+	if err != nil {
+		return resolvedRoot{}, fmt.Errorf("getting image %s: %w", rootDigest, err)
+	}
+	raw, err := img.RawManifest()
+	if err != nil {
+		return resolvedRoot{}, err
+	}
+	manifest, err := img.Manifest()
+	if err != nil {
+		return resolvedRoot{}, err
+	}
+	return resolvedRoot{
+		RootData:     raw,
+		MediaType:    manifest.MediaType,
+		ArtifactType: manifestArtifactType(manifest),
+		IsIndex:      false,
+		Children:     []ocilayout.ManifestInput{ocilayout.ManifestInputFromVFS(src, manifest, raw, nil)},
+	}, nil
+}
+
+// manifestArtifactType mirrors ocilayout's internal artifactTypeOf: the config
+// media type when it is not a standard image config, else "".
+func manifestArtifactType(m *registryv1.Manifest) string {
+	if m.Config.MediaType != "" && !m.Config.MediaType.IsConfig() {
+		return string(m.Config.MediaType)
+	}
+	return ""
+}
+
+// vfsBlobSource adapts the deploy VFS to ocilayout.BlobSource. It mirrors the
+// load pipeline's vfsBlobSource: layers first, then manifest/index blobs.
+type vfsBlobSource struct {
+	vfs *deployvfs.VFS
+}
+
+func (v vfsBlobSource) OpenBlob(ctx context.Context, hexDigest string) (io.ReadCloser, int64, error) {
+	hash := registryv1.Hash{Algorithm: "sha256", Hex: hexDigest}
+	layer, err := v.vfs.Layer(hash)
+	if err != nil {
+		layer, err = v.vfs.ManifestBlob(hash)
+		if err != nil {
+			return nil, 0, fmt.Errorf("blob %s not found in VFS", hexDigest)
+		}
+	}
+	size, err := layer.Size()
+	if err != nil {
+		return nil, 0, fmt.Errorf("getting size for blob %s: %w", hexDigest, err)
+	}
+	rc, err := layer.Compressed()
+	if err != nil {
+		return nil, 0, fmt.Errorf("opening blob %s: %w", hexDigest, err)
+	}
+	return rc, size, nil
+}
+
+// tarSink accumulates every root and writes one OCI layout tar (optionally with
+// a Docker manifest.json) at Close. index.json references all roots.
+type tarSink struct {
+	b        *ocilayout.Builder
+	path     string
+	docker   bool
+	rootRefs []rootRef
+}
+
+type rootRef struct {
+	isIndex bool
+	refs    []string
+}
+
+func newTarSink(path string, docker bool) *tarSink {
+	format := ocilayout.OCILayout().WithIndexStyle(ocilayout.IndexMultiRoot)
+	if docker {
+		format = ocilayout.DockerSave().WithIndexStyle(ocilayout.IndexMultiRoot)
+	}
+	return &tarSink{
+		b:      ocilayout.New(format).WithMissingBlobsHint(ocilayout.OutputGroupTarball),
+		path:   path,
+		docker: docker,
+	}
+}
+
+func (s *tarSink) AddImage(ctx context.Context, img sinkImage) error {
+	root := img.Root
+	s.b.AddRoot(ocilayout.RootInput{
+		ManifestData: root.RootData,
+		MediaType:    root.MediaType,
+		ArtifactType: root.ArtifactType,
+		IsIndex:      root.IsIndex,
+		OCITags:      img.Refs,
+		Children:     root.Children,
+		Platform:     root.Platform,
+	})
+	if s.docker {
+		s.rootRefs = append(s.rootRefs, rootRef{isIndex: root.IsIndex, refs: img.Refs})
+	}
+	return nil
+}
+
+func (s *tarSink) Close() error {
+	if s.docker {
+		s.b.WithTags(s.dockerRepoTags())
+	}
+	return s.b.WriteTar(context.Background(), s.path)
+}
+
+// dockerRepoTags picks the RepoTags for manifest.json: the refs of the first
+// single-architecture image root (mirroring firstSingleArchManifest), else the
+// first root's refs.
+func (s *tarSink) dockerRepoTags() []string {
+	for _, r := range s.rootRefs {
+		if !r.isIndex && len(r.refs) > 0 {
+			return r.refs
+		}
+	}
+	for _, r := range s.rootRefs {
+		if len(r.refs) > 0 {
+			return r.refs
+		}
+	}
+	return nil
+}
+
+// ociDirSink merges images into an OCI layout directory via ocilayout.Editor.
+type ociDirSink struct {
+	e *ocilayout.Editor
+}
+
+func newOCIDirSink(dir string) (*ociDirSink, error) {
+	if _, err := os.Stat(filepath.Join(dir, "oci-layout")); err == nil {
+		e, err := ocilayout.OpenDir(dir)
+		if err != nil {
+			return nil, err
+		}
+		return &ociDirSink{e: e}, nil
+	}
+	e, err := ocilayout.CreateDir(dir, ocilayout.OCILayout())
+	if err != nil {
+		return nil, err
+	}
+	return &ociDirSink{e: e}, nil
+}
+
+func (s *ociDirSink) AddImage(ctx context.Context, img sinkImage) error {
+	root := img.Root
+	if !root.IsIndex {
+		if len(root.Children) == 0 {
+			return fmt.Errorf("manifest root has no image manifest")
+		}
+		return s.e.AddManifest(ctx, root.Children[0], img.Refs...)
+	}
+	for i := range root.Children {
+		if err := s.e.AddManifestBlobs(ctx, root.Children[i]); err != nil {
+			return err
+		}
+	}
+	indexHash, _, err := registryv1.SHA256(bytes.NewReader(root.RootData))
+	if err != nil {
+		return err
+	}
+	if err := s.e.AddBlob(ctx, indexHash, ocilayout.BlobFromBytes(root.RootData)); err != nil {
+		return err
+	}
+	for _, d := range ocilayout.DescriptorsForTags(img.Refs, root.MediaType, root.RootData, indexHash, "", false) {
+		if err := s.e.AddIndexEntry(d); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *ociDirSink) Close() error { return s.e.Close() }
+
+// distributionSink writes images into a static distribution-spec layout.
+type distributionSink struct {
+	w *ocilayout.DistributionWriter
+}
+
+func newDistributionSink(dir string, flat bool) *distributionSink {
+	return &distributionSink{w: ocilayout.NewDistributionWriter(dir, flat)}
+}
+
+func (s *distributionSink) AddImage(ctx context.Context, img sinkImage) error {
+	targets := make(map[ocilayout.DistributionRef][]string)
+	var order []ocilayout.DistributionRef
+	addTarget := func(ref ocilayout.DistributionRef, tag string) {
+		if _, ok := targets[ref]; !ok {
+			order = append(order, ref)
+			targets[ref] = nil
+		}
+		if tag != "" {
+			targets[ref] = append(targets[ref], tag)
+		}
+	}
+
+	if len(img.Refs) == 0 {
+		if img.Registry == "" || img.Repository == "" {
+			return nil // no destination to place a digest-only image
+		}
+		addTarget(ocilayout.DistributionRef{Registry: img.Registry, Name: img.Repository}, "")
+	} else {
+		for _, ref := range img.Refs {
+			dref, tag, err := parseDistributionRef(ref)
+			if err != nil {
+				return err
+			}
+			addTarget(dref, tag)
+		}
+	}
+
+	for _, ref := range order {
+		if err := s.w.AddImage(ctx, ocilayout.DistributionImage{
+			Ref:      ref,
+			RootData: img.Root.RootData,
+			Children: img.Root.Children,
+			Tags:     deduplicateAndSortTags(targets[ref]),
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *distributionSink) Close() error { return s.w.Close() }
+
+// parseDistributionRef splits a full image reference into its distribution
+// repository and tag components.
+func parseDistributionRef(ref string) (ocilayout.DistributionRef, string, error) {
+	parsed, err := name.ParseReference(ref, name.WithDefaultRegistry(""))
+	if err != nil {
+		return ocilayout.DistributionRef{}, "", fmt.Errorf("parsing image reference %q: %w", ref, err)
+	}
+	dref := ocilayout.DistributionRef{
+		Registry: parsed.Context().RegistryStr(),
+		Name:     parsed.Context().RepositoryStr(),
+	}
+	tag := ""
+	if t, ok := parsed.(name.Tag); ok {
+		tag = t.TagStr()
+	}
+	return dref, tag, nil
+}
+
+func deduplicateAndSortTags(tags []string) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+	out := slices.Clone(tags)
+	sort.Strings(out)
+	out = slices.Compact(out)
+	filtered := out[:0]
+	for _, t := range out {
+		if t != "" {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
+}

--- a/img_tool/cmd/deploy/sink_test.go
+++ b/img_tool/cmd/deploy/sink_test.go
@@ -1,0 +1,271 @@
+package deploy
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	registryv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/ocilayout"
+)
+
+// skipIfColonFilenamesUnsupported skips tests that materialize the distribution
+// layout, whose paths contain a ':' (blobs/sha256:<hex>) that Windows disallows.
+func skipIfColonFilenamesUnsupported(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("distribution layout uses ':' in filenames, unsupported on Windows")
+	}
+}
+
+func TestParseSink(t *testing.T) {
+	cases := []struct {
+		spec     string
+		wantKind sinkKind
+		wantPath string
+		wantErr  bool
+	}{
+		{"oci-tar:/tmp/out.tar", sinkOCITar, "/tmp/out.tar", false},
+		{"docker-save:/tmp/out.tar", sinkDockerSave, "/tmp/out.tar", false},
+		{"oci:/tmp/dir", sinkOCIDir, "/tmp/dir", false},
+		{"distribution:/tmp/reg", sinkDistribution, "/tmp/reg", false},
+		{"distribution-flat:/tmp/reg", sinkDistributionFlat, "/tmp/reg", false},
+		{"oci-tar:", sinkNone, "", true},
+		{"bogus:/tmp/x", sinkNone, "", true},
+		{"noseparator", sinkNone, "", true},
+	}
+	for _, tc := range cases {
+		kind, path, err := parseSink(tc.spec)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("parseSink(%q) err=%v wantErr=%v", tc.spec, err, tc.wantErr)
+			continue
+		}
+		if err != nil {
+			continue
+		}
+		if kind != tc.wantKind || path != tc.wantPath {
+			t.Errorf("parseSink(%q) = (%d, %q), want (%d, %q)", tc.spec, kind, path, tc.wantKind, tc.wantPath)
+		}
+	}
+}
+
+func TestSinkGlobalOnly(t *testing.T) {
+	global := []sinkKind{sinkOCIDir, sinkDistribution, sinkDistributionFlat}
+	perRequest := []sinkKind{sinkOCITar, sinkDockerSave}
+	for _, k := range global {
+		if !k.globalOnly() {
+			t.Errorf("kind %d should be global-only", k)
+		}
+	}
+	for _, k := range perRequest {
+		if k.globalOnly() {
+			t.Errorf("kind %d should be allowed per-request", k)
+		}
+	}
+}
+
+func TestParseDistributionRef(t *testing.T) {
+	ref, tag, err := parseDistributionRef("reg.example/team/foo:v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Registry != "reg.example" || ref.Name != "team/foo" || tag != "v1" {
+		t.Errorf("parseDistributionRef = (%+v, %q)", ref, tag)
+	}
+}
+
+func sha256Hash(b []byte) registryv1.Hash {
+	h, _, _ := registryv1.SHA256(bytes.NewReader(b))
+	return h
+}
+
+// testRoot builds a resolvedRoot for a deterministic single-manifest image
+// backed by in-memory blobs.
+func testRoot(seed string) resolvedRoot {
+	src := ocilayout.NewMemBlobSource()
+	cfg := []byte(`{"architecture":"amd64","os":"linux"}`)
+	layer := []byte(seed + "-layer")
+	src.Add(sha256Hash(cfg).Hex, cfg).Add(sha256Hash(layer).Hex, layer)
+	m := &registryv1.Manifest{
+		SchemaVersion: 2,
+		MediaType:     types.OCIManifestSchema1,
+		Config:        registryv1.Descriptor{MediaType: types.OCIConfigJSON, Digest: sha256Hash(cfg), Size: int64(len(cfg))},
+		Layers:        []registryv1.Descriptor{{MediaType: types.OCILayer, Digest: sha256Hash(layer), Size: int64(len(layer))}},
+	}
+	data, _ := json.Marshal(m)
+	return resolvedRoot{
+		RootData:  data,
+		MediaType: types.OCIManifestSchema1,
+		IsIndex:   false,
+		Children:  []ocilayout.ManifestInput{ocilayout.ManifestInputFromVFS(src, m, data, nil)},
+	}
+}
+
+func tarNames(t *testing.T, data []byte) map[string]bool {
+	t.Helper()
+	names := map[string]bool{}
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		names[hdr.Name] = true
+		if hdr.Typeflag != tar.TypeDir {
+			io.Copy(io.Discard, tr)
+		}
+	}
+	return names
+}
+
+func TestOCITarSink(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.tar")
+	s, err := newSink(sinkOCITar, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddImage(context.Background(), sinkImage{Refs: []string{"reg.example/foo:latest"}, Root: testRoot("a")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := tarNames(t, data)
+	for _, want := range []string{"oci-layout", "index.json"} {
+		if !names[want] {
+			t.Errorf("oci-tar missing %s", want)
+		}
+	}
+	if names["manifest.json"] {
+		t.Errorf("oci-tar must not contain a Docker manifest.json")
+	}
+}
+
+func TestDockerSaveSink(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.tar")
+	s, err := newSink(sinkDockerSave, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddImage(context.Background(), sinkImage{Refs: []string{"reg.example/foo:latest"}, Root: testRoot("a")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddImage(context.Background(), sinkImage{Refs: []string{"reg.example/bar:latest"}, Root: testRoot("b")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := tarNames(t, data)
+	if !names["manifest.json"] {
+		t.Errorf("docker-save missing manifest.json")
+	}
+}
+
+func TestOCIDirSinkIncremental(t *testing.T) {
+	dir := t.TempDir()
+	s, err := newSink(sinkOCIDir, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddImage(context.Background(), sinkImage{Refs: []string{"reg.example/foo:latest"}, Root: testRoot("a")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddImage(context.Background(), sinkImage{Refs: []string{"reg.example/bar:latest"}, Root: testRoot("b")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "index.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var idx registryv1.IndexManifest
+	if err := json.Unmarshal(data, &idx); err != nil {
+		t.Fatal(err)
+	}
+	if len(idx.Manifests) != 2 {
+		t.Fatalf("index.json manifests: got %d want 2", len(idx.Manifests))
+	}
+	for i, d := range idx.Manifests {
+		if d.Annotations["io.containerd.image.name"] == "" {
+			t.Errorf("descriptor[%d] missing image-name annotation", i)
+		}
+	}
+
+	// Re-opening the existing directory and adding a tag must merge, not clobber.
+	s2, err := newSink(sinkOCIDir, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s2.AddImage(context.Background(), sinkImage{Refs: []string{"reg.example/foo:v2"}, Root: testRoot("a")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, _ = os.ReadFile(filepath.Join(dir, "index.json"))
+	if err := json.Unmarshal(data, &idx); err != nil {
+		t.Fatal(err)
+	}
+	if len(idx.Manifests) != 3 {
+		t.Fatalf("after merge: got %d descriptors want 3", len(idx.Manifests))
+	}
+}
+
+func TestDistributionSinkRoutes(t *testing.T) {
+	skipIfColonFilenamesUnsupported(t)
+	dir := t.TempDir()
+	s, err := newSink(sinkDistribution, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddImage(context.Background(), sinkImage{
+		Refs:       []string{"reg.example/team/foo:latest"},
+		Registry:   "reg.example",
+		Repository: "team/foo",
+		Root:       testRoot("a"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "reg.example", "v2", "team/foo", "tags", "list")); err != nil {
+		t.Errorf("distribution sink did not write tags/list: %v", err)
+	}
+}
+
+func TestDeduplicateAndSortTags(t *testing.T) {
+	got := deduplicateAndSortTags([]string{"b", "a", "", "b", "c"})
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	}
+}

--- a/img_tool/cmd/deploy/sink_vfs_test.go
+++ b/img_tool/cmd/deploy/sink_vfs_test.go
@@ -1,0 +1,209 @@
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	registryv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/deployvfs"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/ocilayout"
+)
+
+// buildLayoutAndManifest writes a real single-manifest image into an OCI layout
+// directory and returns that directory plus a matching deploy manifest with one
+// push operation. The VFS resolves blobs from the layout, so this exercises the
+// full VFS -> resolveRoot -> sink path with no network I/O.
+func buildLayoutAndManifest(t *testing.T, registry, repository string, tags []string) (string, api.DeployManifest) {
+	t.Helper()
+	layoutDir := t.TempDir()
+
+	src := ocilayout.NewMemBlobSource()
+	cfg := []byte(`{"architecture":"amd64","os":"linux"}`)
+	layer := []byte("integration-layer-content")
+	src.Add(sha256Hash(cfg).Hex, cfg).Add(sha256Hash(layer).Hex, layer)
+	m := &registryv1.Manifest{
+		SchemaVersion: 2,
+		MediaType:     types.OCIManifestSchema1,
+		Config:        registryv1.Descriptor{MediaType: types.OCIConfigJSON, Digest: sha256Hash(cfg), Size: int64(len(cfg))},
+		Layers:        []registryv1.Descriptor{{MediaType: types.OCILayer, Digest: sha256Hash(layer), Size: int64(len(layer))}},
+	}
+	data, _ := json.Marshal(m)
+	mi := ocilayout.ManifestInputFromVFS(src, m, data, nil)
+	if err := ocilayout.New(ocilayout.OCILayout()).AddManifest(mi).WriteDir(context.Background(), layoutDir); err != nil {
+		t.Fatalf("writing layout: %v", err)
+	}
+
+	manifestDigest := sha256Hash(data)
+	op := api.PushDeployOperation{
+		BaseCommandOperation: api.BaseCommandOperation{
+			Command:  "push",
+			RootKind: "manifest",
+			Root:     api.Descriptor{MediaType: string(types.OCIManifestSchema1), Digest: manifestDigest.String(), Size: int64(len(data))},
+			Manifests: []api.ManifestDeployInfo{{
+				Descriptor: api.Descriptor{MediaType: string(types.OCIManifestSchema1), Digest: manifestDigest.String(), Size: int64(len(data))},
+				Config:     api.Descriptor{MediaType: string(types.OCIConfigJSON), Digest: m.Config.Digest.String(), Size: m.Config.Size},
+				LayerBlobs: []api.LayerBlob{{Descriptor: api.Descriptor{MediaType: string(types.OCILayer), Digest: m.Layers[0].Digest.String(), Size: m.Layers[0].Size}}},
+			}},
+		},
+		PushTarget: api.PushTarget{Registry: registry, Repository: repository, Tags: tags},
+	}
+	raw, _ := json.Marshal(op)
+	dm := api.DeployManifest{
+		Operations: []json.RawMessage{raw},
+		Settings:   api.DeploySettings{PushStrategy: "eager"},
+	}
+	return layoutDir, dm
+}
+
+func TestRouteToSinkOCITarFromVFS(t *testing.T) {
+	layoutDir, dm := buildLayoutAndManifest(t, "reg.example", "team/foo", []string{"latest"})
+	vfs, err := deployvfs.NewBuilder(dm).WithOCILayout(layoutDir).Build()
+	if err != nil {
+		t.Fatalf("building VFS: %v", err)
+	}
+	pushOps, err := dm.PushOperations()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tarPath := filepath.Join(t.TempDir(), "out.tar")
+	s, err := newSink(sinkOCITar, tarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs, err := routeToSink(context.Background(), s, vfs, pushOps, nil, nil, sinkRouteOptions{})
+	if err != nil {
+		t.Fatalf("routeToSink: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(refs) != 1 || refs[0] != "reg.example/team/foo:latest" {
+		t.Errorf("written refs = %v, want [reg.example/team/foo:latest]", refs)
+	}
+	data, err := os.ReadFile(tarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := tarNames(t, data)
+	if !names["index.json"] || !names["oci-layout"] {
+		t.Errorf("oci-tar missing marker/index; entries=%v", names)
+	}
+	// The manifest, config and layer blobs must all be streamed into the tar.
+	blobCount := 0
+	for n := range names {
+		if len(n) > len("blobs/sha256/") && n[:len("blobs/sha256/")] == "blobs/sha256/" {
+			blobCount++
+		}
+	}
+	if blobCount != 3 {
+		t.Errorf("expected 3 blobs (manifest, config, layer), got %d", blobCount)
+	}
+}
+
+func TestRouteToSinkDistributionFromVFS(t *testing.T) {
+	skipIfColonFilenamesUnsupported(t)
+	layoutDir, dm := buildLayoutAndManifest(t, "reg.example", "team/foo", []string{"latest"})
+	vfs, err := deployvfs.NewBuilder(dm).WithOCILayout(layoutDir).Build()
+	if err != nil {
+		t.Fatalf("building VFS: %v", err)
+	}
+	pushOps, err := dm.PushOperations()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	s, err := newSink(sinkDistribution, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := routeToSink(context.Background(), s, vfs, pushOps, nil, nil, sinkRouteOptions{}); err != nil {
+		t.Fatalf("routeToSink: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	repoRoot := filepath.Join(dir, "reg.example", "v2", "team/foo")
+	if _, err := os.Stat(filepath.Join(repoRoot, "manifests", "latest")); err != nil {
+		t.Errorf("distribution sink missing tag symlink: %v", err)
+	}
+	var tl struct {
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot, "tags", "list"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &tl); err != nil {
+		t.Fatal(err)
+	}
+	if tl.Name != "team/foo" || len(tl.Tags) != 1 || tl.Tags[0] != "latest" {
+		t.Errorf("tags/list = %+v", tl)
+	}
+}
+
+// The --registry / --repository overrides redirect the destination repository.
+func TestRouteToSinkOverrides(t *testing.T) {
+	skipIfColonFilenamesUnsupported(t)
+	layoutDir, dm := buildLayoutAndManifest(t, "reg.example", "team/foo", []string{"latest"})
+	vfs, err := deployvfs.NewBuilder(dm).WithOCILayout(layoutDir).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pushOps, _ := dm.PushOperations()
+
+	dir := t.TempDir()
+	s, _ := newSink(sinkDistribution, dir)
+	refs, err := routeToSink(context.Background(), s, vfs, pushOps, nil, nil, sinkRouteOptions{
+		overrideRegistry:   "other.example",
+		overrideRepository: "bar",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0] != "other.example/bar:latest" {
+		t.Errorf("overridden refs = %v", refs)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "other.example", "v2", "bar", "manifests", "latest")); err != nil {
+		t.Errorf("override not applied to distribution layout: %v", err)
+	}
+}
+
+// TestDeployWithExtrasSink drives the one-shot entry point the CLI calls after
+// flag parsing, confirming a --sink override lands the image in the sink with no
+// registry/daemon I/O.
+func TestDeployWithExtrasSink(t *testing.T) {
+	layoutDir, dm := buildLayoutAndManifest(t, "reg.example", "team/foo", []string{"latest"})
+	raw, err := json.Marshal(dm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tarPath := filepath.Join(t.TempDir(), "out.tar")
+	if err := DeployWithExtras(context.Background(), raw, DeployOptions{
+		Sink:       "oci-tar:" + tarPath,
+		OCILayouts: []string{layoutDir},
+		Jobs:       4,
+	}); err != nil {
+		t.Fatalf("DeployWithExtras: %v", err)
+	}
+	data, err := os.ReadFile(tarPath)
+	if err != nil {
+		t.Fatalf("sink tar not written: %v", err)
+	}
+	if names := tarNames(t, data); !names["index.json"] {
+		t.Errorf("sink tar missing index.json")
+	}
+}

--- a/img_tool/pkg/load/loader.go
+++ b/img_tool/pkg/load/loader.go
@@ -364,7 +364,7 @@ func (l *loader) streamDockerTar(ctx context.Context, op api.IndexedLoadDeployOp
 			if err != nil {
 				return nil, fmt.Errorf("getting manifest for %s: %w", desc.Digest, err)
 			}
-			b.AddManifest(manifestInputFromVFS(blobSource, manifest, rawManifest, desc.Platform))
+			b.AddManifest(ocilayout.ManifestInputFromVFS(blobSource, manifest, rawManifest, desc.Platform))
 		}
 
 		if err := b.WriteToWriter(ctx, w); err != nil {
@@ -395,7 +395,7 @@ func (l *loader) streamDockerTar(ctx context.Context, op api.IndexedLoadDeployOp
 			WithTags(normalizedTags).
 			WithOCITags(normalizedTags).
 			WithProgress(progressFn).
-			AddManifest(manifestInputFromVFS(blobSource, manifest, rawManifest, nil))
+			AddManifest(ocilayout.ManifestInputFromVFS(blobSource, manifest, rawManifest, nil))
 		if err := b.WriteToWriter(ctx, w); err != nil {
 			return nil, err
 		}
@@ -403,25 +403,6 @@ func (l *loader) streamDockerTar(ctx context.Context, op api.IndexedLoadDeployOp
 	}
 
 	return nil, fmt.Errorf("no manifest or index provided")
-}
-
-// manifestInputFromVFS builds an ocilayout.ManifestInput whose config and layer
-// blobs stream from the VFS-backed blob source.
-func manifestInputFromVFS(src ocilayout.BlobSource, manifest *registryv1.Manifest, rawManifest []byte, platform *registryv1.Platform) ocilayout.ManifestInput {
-	mi := ocilayout.ManifestInput{
-		Manifest:     manifest,
-		ManifestData: rawManifest,
-		Config:       ocilayout.BlobFromSource(src, manifest.Config.Digest.Hex, manifest.Config.Size),
-		Platform:     platform,
-	}
-	for _, layer := range manifest.Layers {
-		mi.Layers = append(mi.Layers, ocilayout.LayerInput{
-			Descriptor: layer,
-			Blob:       ocilayout.BlobFromSource(src, layer.Digest.Hex, layer.Size),
-			Present:    true,
-		})
-	}
-	return mi
 }
 
 func (l *loader) makeManifestFilter() ocilayout.ManifestFilter {

--- a/img_tool/pkg/ocilayout/BUILD.bazel
+++ b/img_tool/pkg/ocilayout/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "copy_linux.go",
         "copy_other.go",
         "descriptors.go",
+        "distribution.go",
         "doc.go",
         "editor.go",
         "engine.go",
@@ -31,8 +32,10 @@ go_test(
     name = "ocilayout_test",
     srcs = [
         "builder_test.go",
+        "distribution_test.go",
         "editor_test.go",
         "golden_test.go",
+        "multiroot_test.go",
     ],
     embed = [":ocilayout"],
     deps = [

--- a/img_tool/pkg/ocilayout/builder.go
+++ b/img_tool/pkg/ocilayout/builder.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
 // ManifestInput is everything the builder needs about one image manifest,
@@ -44,6 +45,52 @@ type LayerInput struct {
 	SparseMeta *SparseLayerDescriptor
 }
 
+// ManifestInputFromVFS builds a ManifestInput whose config and layer blobs
+// stream from src (typically a VFS-backed BlobSource). It is shared by the load
+// pipeline and the deploy sinks so a single copy of the VFS→layout conversion
+// exists.
+func ManifestInputFromVFS(src BlobSource, manifest *v1.Manifest, rawManifest []byte, platform *v1.Platform) ManifestInput {
+	mi := ManifestInput{
+		Manifest:     manifest,
+		ManifestData: rawManifest,
+		Config:       BlobFromSource(src, manifest.Config.Digest.Hex, manifest.Config.Size),
+		Platform:     platform,
+	}
+	for _, layer := range manifest.Layers {
+		mi.Layers = append(mi.Layers, LayerInput{
+			Descriptor: layer,
+			Blob:       BlobFromSource(src, layer.Digest.Hex, layer.Size),
+			Present:    true,
+		})
+	}
+	return mi
+}
+
+// RootInput describes one root of an IndexMultiRoot layout. A root is either a
+// single image manifest or a multi-arch index; in both cases Children carries
+// the concrete image manifests whose config and layer blobs must be written
+// (for a manifest root, Children holds that single manifest).
+type RootInput struct {
+	// ManifestData is the exact raw bytes of the root object (an image manifest
+	// or an image index). It is hashed for the digest and, for an index root,
+	// written as a nested blob.
+	ManifestData []byte
+	// MediaType is the media type of the root object.
+	MediaType types.MediaType
+	// ArtifactType is set for non-image config media types; "" otherwise.
+	ArtifactType string
+	// IsIndex reports whether ManifestData is an image index (vs a manifest).
+	IsIndex bool
+	// OCITags are the full image names used for this root's index.json
+	// annotations. Empty produces a single clean descriptor.
+	OCITags []string
+	// Children are the image manifests referenced by this root, in order. Their
+	// manifest/config/layer blobs are written to the layout.
+	Children []ManifestInput
+	// Platform is carried for the first-single-arch docker-manifest selection.
+	Platform *v1.Platform
+}
+
 // Builder accumulates manifests, tags and a Format, then writes a complete
 // layout in one go.
 type Builder struct {
@@ -60,6 +107,7 @@ type Builder struct {
 	missingHint  string // MissingBlobsError.OutputGroup
 
 	manifests []ManifestInput
+	roots     []RootInput // IndexMultiRoot roots (added via AddRoot)
 	rootIndex *Blob
 }
 
@@ -111,6 +159,13 @@ func (b *Builder) WithMissingBlobsHint(outputGroup string) *Builder {
 // AddManifest adds an image manifest to the layout.
 func (b *Builder) AddManifest(m ManifestInput) *Builder {
 	b.manifests = append(b.manifests, m)
+	return b
+}
+
+// AddRoot adds one root to an IndexMultiRoot layout. Call it once per image or
+// index to be referenced from the combined index.json.
+func (b *Builder) AddRoot(r RootInput) *Builder {
+	b.roots = append(b.roots, r)
 	return b
 }
 

--- a/img_tool/pkg/ocilayout/distribution.go
+++ b/img_tool/pkg/ocilayout/distribution.go
@@ -1,0 +1,337 @@
+package ocilayout
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+// DistributionWriter materializes images into a static, read-only container
+// registry layout that mirrors the OCI distribution-spec paths a webserver
+// would serve for parameter-less GETs:
+//
+//	<root>/<name>/blobs/sha256:<hex>          config + layer blobs
+//	<root>/<name>/manifests/sha256:<hex>      manifests/indexes, stored once per digest
+//	<root>/<name>/manifests/<tag>             same-dir relative symlink -> sha256:<hex>
+//	<root>/<name>/tags/list                   generated {"name","tags":[...]}
+//	<root>/<name>/referrers/sha256:<subject>  generated referrers index
+//
+// The <root> is <dir>/<registry>/v2 (per-registry split) or <dir>/v2 (flat,
+// registry stripped). It is safe to write into a fresh, non-existent directory
+// or one that already holds content: blobs and manifests are content-addressed
+// and written idempotently, and tags/list + referrers are (re)generated from the
+// on-disk state at Close, so pre-existing content is preserved and merged.
+//
+// A DistributionWriter is NOT safe for concurrent use; callers that share one
+// across goroutines (e.g. the deploy persistent worker) must serialize access.
+type DistributionWriter struct {
+	root string
+	flat bool
+	opts WriteBlobOptions
+
+	// blobPaths maps a blob hex to the first on-disk file written for it, so a
+	// later repository can hardlink (or copy) instead of re-streaming.
+	blobPaths map[string]string
+	// touched records every repository root written to, so Close knows which
+	// tags/list and referrers files to regenerate.
+	touched map[string]DistributionRef
+}
+
+// DistributionRef identifies one repository within the layout. Name is the
+// repository (e.g. "library/busybox"); Registry is the host component used for
+// the per-registry split and ignored in flat mode.
+type DistributionRef struct {
+	Registry string
+	Name     string
+}
+
+// DistributionImage is one root (image manifest or index) to write under a
+// repository, together with its concrete child image manifests and the bare
+// tags that should point at the root.
+type DistributionImage struct {
+	Ref DistributionRef
+	// RootData is the exact raw bytes of the root object (manifest or index).
+	RootData []byte
+	// Children are the concrete image manifests whose config/layer blobs must
+	// be written. For a single-manifest root this holds that one manifest (its
+	// bytes equal RootData).
+	Children []ManifestInput
+	// Tags are bare tags (e.g. "latest") symlinked to the root digest.
+	Tags []string
+}
+
+// NewDistributionWriter returns a writer rooted at dir. When flat is true the
+// registry component is stripped (a single v2/ tree); otherwise each registry
+// gets its own <registry>/v2 subtree.
+func NewDistributionWriter(dir string, flat bool) *DistributionWriter {
+	return &DistributionWriter{
+		root:      dir,
+		flat:      flat,
+		blobPaths: make(map[string]string),
+		touched:   make(map[string]DistributionRef),
+	}
+}
+
+// WithLinkStrategy configures how blobs shared between repositories are
+// materialized (see Builder.WithLinkStrategy).
+func (w *DistributionWriter) WithLinkStrategy(useSymlinks, requireLink bool) *DistributionWriter {
+	w.opts.UseSymlinks = useSymlinks
+	w.opts.RequireLink = requireLink
+	return w
+}
+
+// AddImage writes one root's blobs and manifests under img.Ref and records its
+// tags. Blobs and manifests already present on disk are left untouched.
+func (w *DistributionWriter) AddImage(ctx context.Context, img DistributionImage) error {
+	repoRoot := w.repoRoot(img.Ref)
+	w.touched[repoRoot] = img.Ref
+
+	for i := range img.Children {
+		child := img.Children[i]
+		if !child.Config.isZero() {
+			if err := w.putBlob(ctx, repoRoot, child.Manifest.Config.Digest.Hex, child.Config); err != nil {
+				return fmt.Errorf("writing config blob: %w", err)
+			}
+		}
+		for _, l := range child.Layers {
+			if l.Blob.isZero() {
+				continue
+			}
+			if err := w.putBlob(ctx, repoRoot, l.Descriptor.Digest.Hex, l.Blob); err != nil {
+				return fmt.Errorf("writing layer blob %s: %w", l.Descriptor.Digest, err)
+			}
+		}
+		if _, err := w.putManifest(repoRoot, child.ManifestData); err != nil {
+			return fmt.Errorf("writing child manifest: %w", err)
+		}
+	}
+
+	rootHash, err := w.putManifest(repoRoot, img.RootData)
+	if err != nil {
+		return fmt.Errorf("writing root manifest: %w", err)
+	}
+	for _, tag := range img.Tags {
+		if err := w.putTag(repoRoot, tag, rootHash); err != nil {
+			return fmt.Errorf("tagging %q: %w", tag, err)
+		}
+	}
+	return nil
+}
+
+// Close regenerates tags/list and referrers for every repository written to.
+func (w *DistributionWriter) Close() error {
+	for repoRoot, ref := range w.touched {
+		if err := w.writeTagsList(repoRoot, ref.Name); err != nil {
+			return fmt.Errorf("writing tags/list for %s: %w", ref.Name, err)
+		}
+		if err := w.writeReferrers(repoRoot); err != nil {
+			return fmt.Errorf("writing referrers for %s: %w", ref.Name, err)
+		}
+	}
+	return nil
+}
+
+func (w *DistributionWriter) repoRoot(ref DistributionRef) string {
+	name := filepath.FromSlash(ref.Name)
+	if w.flat {
+		return filepath.Join(w.root, "v2", name)
+	}
+	return filepath.Join(w.root, ref.Registry, "v2", name)
+}
+
+// putBlob writes blobs/sha256:<hex> under repoRoot, hardlinking (or copying)
+// from an already-materialized copy of the same blob when possible. It is a
+// no-op if the destination already exists.
+func (w *DistributionWriter) putBlob(ctx context.Context, repoRoot, hex string, b Blob) error {
+	rel := "blobs/sha256:" + hex
+	dst := filepath.Join(repoRoot, filepath.FromSlash(rel))
+	if fileExists(dst) {
+		if _, ok := w.blobPaths[hex]; !ok {
+			w.blobPaths[hex] = dst
+		}
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	if first, ok := w.blobPaths[hex]; ok {
+		if err := copyFile(first, dst, w.opts.UseSymlinks); err == nil {
+			return nil
+		}
+		// Linking failed (e.g. cross-device); fall back to a full write below.
+	}
+	sink := &DirectorySink{basePath: repoRoot}
+	if err := sink.WriteBlob(ctx, rel, b, w.opts); err != nil {
+		return err
+	}
+	w.blobPaths[hex] = dst
+	return nil
+}
+
+// putManifest stores data once at manifests/sha256:<hex> and returns its digest.
+func (w *DistributionWriter) putManifest(repoRoot string, data []byte) (v1.Hash, error) {
+	h := hashBytes(data)
+	dst := filepath.Join(repoRoot, "manifests", "sha256:"+h.Hex)
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return v1.Hash{}, err
+	}
+	if !fileExists(dst) {
+		if err := os.WriteFile(dst, data, blobMode); err != nil {
+			return v1.Hash{}, err
+		}
+	}
+	return h, nil
+}
+
+// putTag creates a same-dir relative symlink manifests/<tag> -> sha256:<hex>.
+func (w *DistributionWriter) putTag(repoRoot, tag string, h v1.Hash) error {
+	if tag == "" {
+		return nil
+	}
+	mdir := filepath.Join(repoRoot, "manifests")
+	if err := os.MkdirAll(mdir, 0o755); err != nil {
+		return err
+	}
+	link := filepath.Join(mdir, tag)
+	_ = os.Remove(link) // idempotent re-tag
+	return os.Symlink("sha256:"+h.Hex, link)
+}
+
+// writeTagsList regenerates tags/list from the tag symlinks present in the
+// manifests directory (every entry whose name is not a digest).
+func (w *DistributionWriter) writeTagsList(repoRoot, name string) error {
+	mdir := filepath.Join(repoRoot, "manifests")
+	entries, err := os.ReadDir(mdir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	tags := []string{}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ":") {
+			continue // a sha256:<hex> manifest file, not a tag
+		}
+		tags = append(tags, e.Name())
+	}
+	sort.Strings(tags)
+	data, err := marshalIndent(struct {
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	}{Name: name, Tags: tags})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(repoRoot, "tags"), 0o755); err != nil {
+		return err
+	}
+	return writeFileAtomic(filepath.Join(repoRoot, "tags", "list"), data)
+}
+
+// referrerManifest is the subset of a manifest inspected to build a referrers
+// listing.
+type referrerManifest struct {
+	MediaType    string `json:"mediaType"`
+	ArtifactType string `json:"artifactType"`
+	Config       struct {
+		MediaType string `json:"mediaType"`
+	} `json:"config"`
+	Subject *v1.Descriptor `json:"subject"`
+}
+
+// writeReferrers (re)generates referrers/sha256:<subject> for every subject
+// referenced by a manifest under repoRoot, following the distribution-spec
+// "listing referrers" format (an OCI image index of referrer descriptors).
+func (w *DistributionWriter) writeReferrers(repoRoot string) error {
+	mdir := filepath.Join(repoRoot, "manifests")
+	entries, err := os.ReadDir(mdir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	bySubject := make(map[string][]v1.Descriptor)
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), "sha256:") {
+			continue // tag symlink, not a manifest
+		}
+		data, err := os.ReadFile(filepath.Join(mdir, e.Name()))
+		if err != nil {
+			return err
+		}
+		var m referrerManifest
+		if json.Unmarshal(data, &m) != nil || m.Subject == nil {
+			continue
+		}
+		artifactType := m.ArtifactType
+		if artifactType == "" {
+			artifactType = m.Config.MediaType
+		}
+		desc := v1.Descriptor{
+			MediaType:    types.MediaType(m.MediaType),
+			Size:         int64(len(data)),
+			Digest:       hashBytes(data),
+			ArtifactType: artifactType,
+		}
+		subject := m.Subject.Digest.String()
+		bySubject[subject] = append(bySubject[subject], desc)
+	}
+	if len(bySubject) == 0 {
+		return nil
+	}
+
+	rdir := filepath.Join(repoRoot, "referrers")
+	if err := os.MkdirAll(rdir, 0o755); err != nil {
+		return err
+	}
+	for subject, descs := range bySubject {
+		sort.Slice(descs, func(i, j int) bool { return descs[i].Digest.String() < descs[j].Digest.String() })
+		index := v1.IndexManifest{SchemaVersion: 2, MediaType: types.OCIImageIndex, Manifests: descs}
+		data, err := marshalIndent(index)
+		if err != nil {
+			return err
+		}
+		if err := writeFileAtomic(filepath.Join(rdir, subject), data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// writeFileAtomic writes data to path via a temp file + rename in the same dir.
+func writeFileAtomic(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return nil
+}

--- a/img_tool/pkg/ocilayout/distribution_test.go
+++ b/img_tool/pkg/ocilayout/distribution_test.go
@@ -1,0 +1,300 @@
+package ocilayout
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+// skipIfColonFilenamesUnsupported skips tests that materialize the distribution
+// layout on disk. Its paths contain a ':' (blobs/sha256:<hex>,
+// manifests/sha256:<hex>) to match the OCI distribution-spec URLs, and ':' is a
+// reserved character in Windows filenames.
+func skipIfColonFilenamesUnsupported(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("distribution layout uses ':' in filenames, unsupported on Windows")
+	}
+}
+
+func distRepoRoot(dir string, flat bool, ref DistributionRef) string {
+	if flat {
+		return filepath.Join(dir, "v2", ref.Name)
+	}
+	return filepath.Join(dir, ref.Registry, "v2", ref.Name)
+}
+
+// distImage builds a DistributionImage from a deterministic single-manifest
+// image backed by in-memory blobs.
+func distImage(ref DistributionRef, seed string, tags []string) DistributionImage {
+	mi, _ := goldenImage("amd64", []byte(seed+"-a"), []byte(seed+"-b"))
+	return DistributionImage{
+		Ref:      ref,
+		RootData: mi.ManifestData,
+		Children: []ManifestInput{mi},
+		Tags:     tags,
+	}
+}
+
+func TestDistributionFreshManifest(t *testing.T) {
+	skipIfColonFilenamesUnsupported(t)
+	dir := t.TempDir()
+	ref := DistributionRef{Registry: "reg.example", Name: "team/foo"}
+	img := distImage(ref, "fresh", []string{"latest"})
+
+	w := NewDistributionWriter(dir, false)
+	if err := w.AddImage(context.Background(), img); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	repoRoot := distRepoRoot(dir, false, ref)
+	manifestHex := hashBytes(img.RootData).Hex
+
+	// Manifest stored once by digest, with the exact bytes.
+	mpath := filepath.Join(repoRoot, "manifests", "sha256:"+manifestHex)
+	got, err := os.ReadFile(mpath)
+	if err != nil {
+		t.Fatalf("reading manifest: %v", err)
+	}
+	if string(got) != string(img.RootData) {
+		t.Errorf("manifest content mismatch")
+	}
+
+	// Tag is a same-dir relative symlink to the digest file.
+	target, err := os.Readlink(filepath.Join(repoRoot, "manifests", "latest"))
+	if err != nil {
+		t.Fatalf("reading tag symlink: %v", err)
+	}
+	if target != "sha256:"+manifestHex {
+		t.Errorf("tag symlink target: got %q want %q", target, "sha256:"+manifestHex)
+	}
+
+	// Config + layer blobs present under blobs/.
+	cfgHex := img.Children[0].Manifest.Config.Digest.Hex
+	if _, err := os.Stat(filepath.Join(repoRoot, "blobs", "sha256:"+cfgHex)); err != nil {
+		t.Errorf("missing config blob: %v", err)
+	}
+	for _, l := range img.Children[0].Layers {
+		if _, err := os.Stat(filepath.Join(repoRoot, "blobs", "sha256:"+l.Descriptor.Digest.Hex)); err != nil {
+			t.Errorf("missing layer blob %s: %v", l.Descriptor.Digest.Hex, err)
+		}
+	}
+
+	// tags/list generated.
+	var tl struct {
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot, "tags", "list"))
+	if err != nil {
+		t.Fatalf("reading tags/list: %v", err)
+	}
+	if err := json.Unmarshal(data, &tl); err != nil {
+		t.Fatal(err)
+	}
+	if tl.Name != ref.Name || len(tl.Tags) != 1 || tl.Tags[0] != "latest" {
+		t.Errorf("tags/list = %+v, want name=%s tags=[latest]", tl, ref.Name)
+	}
+}
+
+func TestDistributionFlatStripsRegistry(t *testing.T) {
+	skipIfColonFilenamesUnsupported(t)
+	dir := t.TempDir()
+	ref := DistributionRef{Registry: "reg.example", Name: "foo"}
+	w := NewDistributionWriter(dir, true)
+	if err := w.AddImage(context.Background(), distImage(ref, "flat", []string{"v1"})); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// Flat layout: <dir>/v2/foo, no registry component.
+	if _, err := os.Stat(filepath.Join(dir, "v2", "foo", "tags", "list")); err != nil {
+		t.Errorf("flat layout missing v2/foo/tags/list: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "reg.example")); err == nil {
+		t.Errorf("flat layout should not create a registry directory")
+	}
+}
+
+// A second session merges tags into the existing tags/list and leaves the
+// existing content in place.
+func TestDistributionIncrementalMerge(t *testing.T) {
+	skipIfColonFilenamesUnsupported(t)
+	dir := t.TempDir()
+	ref := DistributionRef{Registry: "reg.example", Name: "foo"}
+
+	w1 := NewDistributionWriter(dir, false)
+	if err := w1.AddImage(context.Background(), distImage(ref, "merge", []string{"v1"})); err != nil {
+		t.Fatal(err)
+	}
+	if err := w1.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second, independent writer over the same directory, new tag on the same image.
+	w2 := NewDistributionWriter(dir, false)
+	if err := w2.AddImage(context.Background(), distImage(ref, "merge", []string{"v2"})); err != nil {
+		t.Fatal(err)
+	}
+	if err := w2.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	repoRoot := distRepoRoot(dir, false, ref)
+	var tl struct {
+		Tags []string `json:"tags"`
+	}
+	data, _ := os.ReadFile(filepath.Join(repoRoot, "tags", "list"))
+	if err := json.Unmarshal(data, &tl); err != nil {
+		t.Fatal(err)
+	}
+	if len(tl.Tags) != 2 || tl.Tags[0] != "v1" || tl.Tags[1] != "v2" {
+		t.Errorf("merged tags/list = %v, want sorted [v1 v2]", tl.Tags)
+	}
+}
+
+// The same blob shared by two repositories is hardlinked (or, on filesystems
+// without hardlink support, at least present with identical content).
+func TestDistributionBlobHardlink(t *testing.T) {
+	skipIfColonFilenamesUnsupported(t)
+	dir := t.TempDir()
+	refA := DistributionRef{Registry: "reg.example", Name: "a"}
+	refB := DistributionRef{Registry: "reg.example", Name: "b"}
+	imgA := distImage(refA, "shared", []string{"latest"})
+	// Same content, different repository.
+	imgB := imgA
+	imgB.Ref = refB
+
+	w := NewDistributionWriter(dir, false)
+	if err := w.AddImage(context.Background(), imgA); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.AddImage(context.Background(), imgB); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	layerHex := imgA.Children[0].Layers[0].Descriptor.Digest.Hex
+	pathA := filepath.Join(distRepoRoot(dir, false, refA), "blobs", "sha256:"+layerHex)
+	pathB := filepath.Join(distRepoRoot(dir, false, refB), "blobs", "sha256:"+layerHex)
+	statA, err := os.Stat(pathA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	statB, err := os.Stat(pathB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(statA, statB) {
+		// Fallback: content must at least be identical.
+		a, _ := os.ReadFile(pathA)
+		b, _ := os.ReadFile(pathB)
+		if string(a) != string(b) {
+			t.Errorf("shared blob differs between repos and is not hardlinked")
+		}
+	}
+}
+
+// A manifest with a subject is recorded in referrers/sha256:<subject>.
+func TestDistributionReferrers(t *testing.T) {
+	skipIfColonFilenamesUnsupported(t)
+	dir := t.TempDir()
+	ref := DistributionRef{Registry: "reg.example", Name: "foo"}
+
+	subject := v1.Hash{Algorithm: "sha256", Hex: "1111111111111111111111111111111111111111111111111111111111111111"}
+	cfg := []byte(`{}`)
+	src := NewMemBlobSource().Add(hashBytes(cfg).Hex, cfg)
+	m := &v1.Manifest{
+		SchemaVersion: 2,
+		MediaType:     types.OCIManifestSchema1,
+		Config:        v1.Descriptor{MediaType: "application/vnd.example.sig", Digest: hashBytes(cfg), Size: int64(len(cfg))},
+		Subject:       &v1.Descriptor{MediaType: types.OCIManifestSchema1, Digest: subject, Size: 100},
+	}
+	data, _ := json.Marshal(m)
+	sig := ManifestInput{Manifest: m, ManifestData: data, Config: BlobFromSource(src, m.Config.Digest.Hex, m.Config.Size)}
+
+	w := NewDistributionWriter(dir, false)
+	if err := w.AddImage(context.Background(), DistributionImage{
+		Ref:      ref,
+		RootData: data,
+		Children: []ManifestInput{sig},
+		Tags:     nil,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	repoRoot := distRepoRoot(dir, false, ref)
+	refData, err := os.ReadFile(filepath.Join(repoRoot, "referrers", subject.String()))
+	if err != nil {
+		t.Fatalf("reading referrers file: %v", err)
+	}
+	var idx v1.IndexManifest
+	if err := json.Unmarshal(refData, &idx); err != nil {
+		t.Fatal(err)
+	}
+	if idx.MediaType != types.OCIImageIndex {
+		t.Errorf("referrers index media type = %s", idx.MediaType)
+	}
+	if len(idx.Manifests) != 1 {
+		t.Fatalf("referrers manifests: got %d want 1", len(idx.Manifests))
+	}
+	d := idx.Manifests[0]
+	if d.Digest != hashBytes(data) {
+		t.Errorf("referrer digest = %s want %s", d.Digest, hashBytes(data))
+	}
+	if d.ArtifactType != "application/vnd.example.sig" {
+		t.Errorf("referrer artifactType = %q want application/vnd.example.sig", d.ArtifactType)
+	}
+}
+
+// Adding two tags to one digest stores the manifest once and creates both tag
+// symlinks.
+func TestDistributionContentOnceTwoTags(t *testing.T) {
+	skipIfColonFilenamesUnsupported(t)
+	dir := t.TempDir()
+	ref := DistributionRef{Registry: "reg.example", Name: "foo"}
+	img := distImage(ref, "twotags", []string{"a", "b"})
+
+	w := NewDistributionWriter(dir, false)
+	if err := w.AddImage(context.Background(), img); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	repoRoot := distRepoRoot(dir, false, ref)
+	entries, err := os.ReadDir(filepath.Join(repoRoot, "manifests"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	digestFiles, tagLinks := 0, 0
+	for _, e := range entries {
+		if e.Name() == "sha256:"+hashBytes(img.RootData).Hex {
+			digestFiles++
+		} else {
+			tagLinks++
+		}
+	}
+	if digestFiles != 1 {
+		t.Errorf("expected the manifest stored once, found %d digest files", digestFiles)
+	}
+	if tagLinks != 2 {
+		t.Errorf("expected 2 tag symlinks, found %d", tagLinks)
+	}
+}

--- a/img_tool/pkg/ocilayout/editor.go
+++ b/img_tool/pkg/ocilayout/editor.go
@@ -106,7 +106,21 @@ func (e *Editor) AddManifest(ctx context.Context, m ManifestInput, tags ...strin
 	if e.index == nil {
 		return fmt.Errorf("ocilayout: AddManifest requires an index.json root layout")
 	}
+	if err := e.AddManifestBlobs(ctx, m); err != nil {
+		return err
+	}
+	descs := DescriptorsForTags(tags, m.Manifest.MediaType, m.ManifestData, hashBytes(m.ManifestData), artifactTypeOf(m.Manifest), e.format.tagOnly())
+	for _, d := range descs {
+		e.AddIndexEntry(d)
+	}
+	return nil
+}
 
+// AddManifestBlobs writes the manifest, config and layer blobs of m (each via
+// the idempotent AddBlob) without touching index.json. Use it for the child
+// manifests of an index root, whose blobs must be present but which should not
+// appear as top-level index.json entries.
+func (e *Editor) AddManifestBlobs(ctx context.Context, m ManifestInput) error {
 	mfstDigest := hashBytes(m.ManifestData)
 	if err := e.AddBlob(ctx, mfstDigest, BlobFromBytes(m.ManifestData)); err != nil {
 		return fmt.Errorf("adding manifest blob: %w", err)
@@ -121,11 +135,6 @@ func (e *Editor) AddManifest(ctx context.Context, m ManifestInput, tags ...strin
 		if err := e.AddBlob(ctx, l.Descriptor.Digest, l.Blob); err != nil {
 			return fmt.Errorf("adding layer blob %s: %w", l.Descriptor.Digest, err)
 		}
-	}
-
-	descs := DescriptorsForTags(tags, m.Manifest.MediaType, m.ManifestData, mfstDigest, artifactTypeOf(m.Manifest), e.format.tagOnly())
-	for _, d := range descs {
-		e.AddIndexEntry(d)
 	}
 	return nil
 }

--- a/img_tool/pkg/ocilayout/engine.go
+++ b/img_tool/pkg/ocilayout/engine.go
@@ -105,7 +105,7 @@ func (b *Builder) buildPlan(ctx context.Context) (*plan, error) {
 		if err != nil {
 			return nil, fmt.Errorf("reading root index: %w", err)
 		}
-	} else if len(b.manifests) == 0 {
+	} else if len(b.manifests) == 0 && b.format.indexStyle != IndexMultiRoot {
 		return nil, fmt.Errorf("ocilayout: no manifest provided")
 	}
 
@@ -193,20 +193,62 @@ func (b *Builder) buildPlan(ctx context.Context) (*plan, error) {
 			b.addManifestBlobs(p, m)
 		}
 
+	case IndexMultiRoot:
+		// One combined index.json referencing every root. Image-manifest roots
+		// are referenced directly; index roots are stored as nested blobs and
+		// referenced by their own digest. Descriptors are deduplicated on
+		// (digest, ref.name) so re-adding the same root/tag is a no-op.
+		seen := make(map[string]struct{})
+		descs := make([]v1.Descriptor, 0, len(b.roots))
+		for _, r := range b.roots {
+			rootDigest := hashBytes(r.ManifestData)
+			for _, d := range DescriptorsForTags(r.OCITags, r.MediaType, r.ManifestData, rootDigest, r.ArtifactType, b.format.tagOnly()) {
+				key := d.Digest.String() + "|" + refName(d)
+				if _, ok := seen[key]; ok {
+					continue
+				}
+				seen[key] = struct{}{}
+				descs = append(descs, d)
+			}
+			if r.IsIndex {
+				p.blobs = append(p.blobs, blobEntry{blobPath(rootDigest.Hex), BlobFromBytes(r.ManifestData)})
+			}
+			for i := range r.Children {
+				b.addManifestBlobs(p, r.Children[i])
+			}
+		}
+		data, err := marshalIndent(v1.IndexManifest{SchemaVersion: 2, MediaType: mediaTypeOCIImageIndex, Manifests: descs})
+		if err != nil {
+			return nil, err
+		}
+		p.rootFile = fileEntry{"index.json", data}
+
 	default:
 		return nil, fmt.Errorf("ocilayout: unknown index style %d", b.format.indexStyle)
 	}
 
 	if b.format.dockerManifest {
-		def := b.manifests[0]
-		if indexMode {
-			def = b.manifests[defaultIdx]
+		var def ManifestInput
+		if b.format.indexStyle == IndexMultiRoot {
+			// Point manifest.json at the first single-architecture image
+			// manifest: the first manifest root, else the first child of the
+			// first index root.
+			def = firstSingleArchManifest(b.roots)
+		} else {
+			def = b.manifests[0]
+			if indexMode {
+				def = b.manifests[defaultIdx]
+			}
 		}
-		data, err := dockerManifestBytes(def, b.repoTags)
-		if err != nil {
-			return nil, err
+		// A multi-root layout with no image manifests (zero ops) has nothing to
+		// reference from manifest.json; skip it rather than emit a broken entry.
+		if def.Manifest != nil {
+			data, err := dockerManifestBytes(def, b.repoTags)
+			if err != nil {
+				return nil, err
+			}
+			p.dockerFile = &fileEntry{"manifest.json", data}
 		}
-		p.dockerFile = &fileEntry{"manifest.json", data}
 	}
 
 	return p, nil
@@ -247,6 +289,24 @@ func sparseLayerDescriptor(l LayerInput) SparseLayerDescriptor {
 		Size:        l.Descriptor.Size,
 		Annotations: l.Descriptor.Annotations,
 	}
+}
+
+// firstSingleArchManifest picks the manifest a Docker manifest.json should
+// reference for an IndexMultiRoot layout: the first manifest root, else the
+// first child of the first index root. Returns a zero ManifestInput (nil
+// Manifest) when there are no image manifests at all.
+func firstSingleArchManifest(roots []RootInput) ManifestInput {
+	for _, r := range roots {
+		if !r.IsIndex && len(r.Children) > 0 {
+			return r.Children[0]
+		}
+	}
+	for _, r := range roots {
+		if len(r.Children) > 0 {
+			return r.Children[0]
+		}
+	}
+	return ManifestInput{}
 }
 
 func dockerManifestBytes(m ManifestInput, repoTags []string) ([]byte, error) {

--- a/img_tool/pkg/ocilayout/format.go
+++ b/img_tool/pkg/ocilayout/format.go
@@ -30,6 +30,13 @@ const (
 	// IndexRootDescriptor writes root.descriptor.json instead of index.json
 	// (sparse layout).
 	IndexRootDescriptor
+	// IndexMultiRoot writes a generated annotated index.json referencing every
+	// root added via Builder.AddRoot: image-manifest roots are referenced
+	// directly, index roots are stored as nested blobs and referenced by their
+	// own index digest. Unlike the single-root styles it accepts N independent
+	// roots, so it is used by the deploy oci-tar/docker-save sinks that combine
+	// all operations into one layout.
+	IndexMultiRoot
 )
 
 // BlobPolicy selects whether layer bodies are written.

--- a/img_tool/pkg/ocilayout/multiroot_test.go
+++ b/img_tool/pkg/ocilayout/multiroot_test.go
@@ -1,0 +1,200 @@
+package ocilayout
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+// tarEntries reads a tar into a name->content map.
+func tarEntries(t *testing.T, data []byte) map[string][]byte {
+	t.Helper()
+	out := make(map[string][]byte)
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading tar: %v", err)
+		}
+		if hdr.Typeflag == tar.TypeDir {
+			out[hdr.Name] = nil
+			continue
+		}
+		b, _ := io.ReadAll(tr)
+		out[hdr.Name] = b
+	}
+	return out
+}
+
+// rootInputFromManifest wraps a single-manifest ManifestInput as a RootInput.
+func rootInputFromManifest(mi ManifestInput, tags []string) RootInput {
+	return RootInput{
+		ManifestData: mi.ManifestData,
+		MediaType:    mi.Manifest.MediaType,
+		ArtifactType: artifactTypeOf(mi.Manifest),
+		IsIndex:      false,
+		OCITags:      tags,
+		Children:     []ManifestInput{mi},
+		Platform:     mi.Platform,
+	}
+}
+
+// A single-manifest IndexMultiRoot docker-save must be byte-identical to the
+// existing single-manifest DockerSave path (functional equivalence, and here
+// even byte equivalence, with the image_load "tarball" output group).
+func TestMultiRootSingleEqualsDockerSave(t *testing.T) {
+	mi, _ := goldenImage("amd64", []byte("layer-a-content"), []byte("layer-b-content"))
+
+	var single bytes.Buffer
+	if err := New(DockerSave()).
+		WithTags([]string{"repo:latest"}).
+		WithOCITags([]string{"repo:latest"}).
+		AddManifest(mi).
+		WriteToWriter(context.Background(), &single); err != nil {
+		t.Fatal(err)
+	}
+
+	var multi bytes.Buffer
+	if err := New(DockerSave().WithIndexStyle(IndexMultiRoot)).
+		WithTags([]string{"repo:latest"}).
+		AddRoot(rootInputFromManifest(mi, []string{"repo:latest"})).
+		WriteToWriter(context.Background(), &multi); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(single.Bytes(), multi.Bytes()) {
+		t.Errorf("IndexMultiRoot single-manifest docker-save differs from DockerSave single path")
+	}
+}
+
+// Two manifest roots combine into one index.json referencing both, with all
+// (deduplicated) blobs present.
+func TestMultiRootTwoManifests(t *testing.T) {
+	miA, _ := goldenImage("amd64", []byte("A-a"), []byte("A-b"))
+	miB, _ := goldenImage("arm64", []byte("B-a"), []byte("B-b"))
+
+	var buf bytes.Buffer
+	if err := New(OCILayout().WithIndexStyle(IndexMultiRoot)).
+		AddRoot(rootInputFromManifest(miA, []string{"reg.example/a:latest"})).
+		AddRoot(rootInputFromManifest(miB, []string{"reg.example/b:latest"})).
+		WriteToWriter(context.Background(), &buf); err != nil {
+		t.Fatal(err)
+	}
+	entries := tarEntries(t, buf.Bytes())
+
+	var idx v1.IndexManifest
+	if err := json.Unmarshal(entries["index.json"], &idx); err != nil {
+		t.Fatalf("parsing index.json: %v", err)
+	}
+	if len(idx.Manifests) != 2 {
+		t.Fatalf("index.json manifests: got %d want 2", len(idx.Manifests))
+	}
+	// Both manifest blobs and both differing layer blobs must be present.
+	wantBlobs := []string{
+		blobPath(hashBytes(miA.ManifestData).Hex),
+		blobPath(hashBytes(miB.ManifestData).Hex),
+		blobPath(miA.Layers[0].Descriptor.Digest.Hex),
+		blobPath(miB.Layers[0].Descriptor.Digest.Hex),
+	}
+	for _, b := range wantBlobs {
+		if _, ok := entries[b]; !ok {
+			t.Errorf("missing blob %s", b)
+		}
+	}
+	// The shared config appears once; each descriptor carries the containerd
+	// image-name annotation.
+	for i, d := range idx.Manifests {
+		if d.Annotations["io.containerd.image.name"] == "" {
+			t.Errorf("descriptor[%d] missing io.containerd.image.name annotation", i)
+		}
+	}
+}
+
+// An index root is stored as a nested blob and referenced by its own digest;
+// its child manifests' blobs are written but not listed at the top level.
+func TestMultiRootIndexRoot(t *testing.T) {
+	mi1, _ := goldenImage("amd64", []byte("idx-amd64-a"), []byte("idx-amd64-b"))
+	mi2, _ := goldenImage("arm64", []byte("idx-arm64-a"), []byte("idx-arm64-b"))
+	idxData := goldenIndexData(mi1, mi2)
+
+	var buf bytes.Buffer
+	if err := New(OCILayout().WithIndexStyle(IndexMultiRoot)).
+		AddRoot(RootInput{
+			ManifestData: idxData,
+			MediaType:    types.OCIImageIndex,
+			IsIndex:      true,
+			OCITags:      []string{"reg.example/multi:latest"},
+			Children:     []ManifestInput{mi1, mi2},
+		}).
+		WriteToWriter(context.Background(), &buf); err != nil {
+		t.Fatal(err)
+	}
+	entries := tarEntries(t, buf.Bytes())
+
+	var idx v1.IndexManifest
+	if err := json.Unmarshal(entries["index.json"], &idx); err != nil {
+		t.Fatalf("parsing index.json: %v", err)
+	}
+	if len(idx.Manifests) != 1 {
+		t.Fatalf("index.json should reference the single index root, got %d", len(idx.Manifests))
+	}
+	if idx.Manifests[0].Digest != hashBytes(idxData) {
+		t.Errorf("root descriptor digest %s != index digest %s", idx.Manifests[0].Digest, hashBytes(idxData))
+	}
+	// The nested index blob and both child manifests must be present.
+	for _, b := range []string{
+		blobPath(hashBytes(idxData).Hex),
+		blobPath(hashBytes(mi1.ManifestData).Hex),
+		blobPath(hashBytes(mi2.ManifestData).Hex),
+	} {
+		if _, ok := entries[b]; !ok {
+			t.Errorf("missing blob %s", b)
+		}
+	}
+}
+
+// Re-adding the same root+tag is deduplicated; a new tag adds a descriptor.
+func TestMultiRootDedup(t *testing.T) {
+	mi, _ := goldenImage("amd64", []byte("dedup-a"), []byte("dedup-b"))
+
+	var buf bytes.Buffer
+	if err := New(OCILayout().WithIndexStyle(IndexMultiRoot)).
+		AddRoot(rootInputFromManifest(mi, []string{"reg.example/x:latest"})).
+		AddRoot(rootInputFromManifest(mi, []string{"reg.example/x:latest"})). // dup
+		AddRoot(rootInputFromManifest(mi, []string{"reg.example/x:v2"})).     // new tag
+		WriteToWriter(context.Background(), &buf); err != nil {
+		t.Fatal(err)
+	}
+	var idx v1.IndexManifest
+	if err := json.Unmarshal(tarEntries(t, buf.Bytes())["index.json"], &idx); err != nil {
+		t.Fatal(err)
+	}
+	if len(idx.Manifests) != 2 {
+		t.Fatalf("expected 2 deduplicated descriptors (latest, v2), got %d", len(idx.Manifests))
+	}
+}
+
+// The existing five goldens must remain byte-identical after adding the new
+// IndexMultiRoot arm (a guard that this change did not perturb emission order).
+func TestGoldensUnchangedSanity(t *testing.T) {
+	// This mirrors TestGoldenOCILayoutSingle's inputs and simply re-asserts the
+	// pinned whole-tar hash to make the "did I break the goldens?" check local
+	// to this file too.
+	mi, _ := goldenImage("amd64", []byte("layer-a-content"), []byte("layer-b-content"))
+	var buf bytes.Buffer
+	if err := New(OCILayout()).AddManifest(mi).WriteToWriter(context.Background(), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if got := sha256hex(buf.Bytes()); got != "20993216aafbb2f710cf56af33afdc0bd75ea0e14687dfb4feca5e661dcf1c5c" {
+		t.Errorf("OCILayout single golden changed: %s", got)
+	}
+}


### PR DESCRIPTION
## What

Adds a global `--sink <type>:<path>` flag to `img deploy` that overrides the destination ("sink") of **all** push/load/registry_tag operations for testing purposes. When active, the tool performs **no registry or daemon network I/O for the destination** — source blobs are still resolved from the VFS as usual (runfiles, OCI layouts, base-image registry, CAS, …).

### Sink types

- **`oci-tar:<file>`** — stream a fresh OCI layout tar. `index.json` references *all* roots from all eligible operations/requests.
- **`docker-save:<file>`** — like `oci-tar` plus a Docker `manifest.json` pointing at the first single-architecture image. Functionally equivalent to the `image_load` rule's `tarball` output group (and byte-identical for the single-image case).
- **`oci:<dir>`** — merge into an OCI layout directory. Created if missing; existing blobs/index entries are merged without duplication. `index.json` carries the image-name annotations (`io.containerd.image.name`, `com.apple.containerization.image.name`, `org.opencontainers.image.ref.name`).
- **`distribution:<dir>`** — static read-only registry layout mirroring the OCI distribution-spec paths under `<dir>/<registry>/v2/<name>/`: `blobs/sha256:<digest>`, content-once `manifests/sha256:<digest>` with same-dir relative tag symlinks, generated `tags/list`, and `referrers/<subject-digest>` listings. Correct on both fresh and pre-existing directories; blobs hardlink across repositories with a copy fallback.
- **`distribution-flat:<dir>`** — same, with the registry component stripped (single `v2/` tree).

### Scope rules

- `distribution` / `distribution-flat` / `oci` are **command-line only** and apply to the first batch *and* every incoming persistent-worker request (shared sink, serialized by a mutex, flushed after each request).
- `oci-tar` / `docker-save` may be set on the command line (which **disables persistent-worker mode**) **or** inside an individual work request's arguments (isolated per request). `distribution`/`oci` are rejected inside a work request.

## How

Most of this reuses `pkg/ocilayout`, the single Builder/Editor/Sink for all layout formats:

- New `IndexMultiRoot` index style + `Builder.AddRoot` combine N roots (image manifests or nested indexes) into one annotated `index.json`. Added as a new `buildPlan` switch arm — the existing byte-pinned goldens are unchanged.
- New `pkg/ocilayout/distribution.go` `DistributionWriter` (reuses `copyFile`, `hashBytes`, `DescriptorsForTags`).
- `Editor.AddManifestBlobs` (blobs-only) so index roots don't list child descriptors; `manifestInputFromVFS` promoted to exported `ocilayout.ManifestInputFromVFS`, shared with the load pipeline.
- Deploy-specific glue (`cmd/deploy/sink.go`) holds the `Sink` interface, adapters, and the operation→layout conversion; both `DeployWithExtras` and the persistent-worker handler route into it. No new package, so no `deleted_packages` churn.

## Testing

- Unit tests for the multi-root builder (incl. docker-save byte-equivalence), the distribution writer (fresh + incremental merge, symlink targets, cross-repo hardlink, referrers format, content-once), the sink adapters, `parseSink`/validation, and a real `deployvfs.VFS`→sink integration test plus a `DeployWithExtras` end-to-end test.
- The 5 existing `pkg/ocilayout` byte-pinned goldens are verified unchanged.
- `go test -race` green for `pkg/ocilayout`, `pkg/load`, `cmd/deploy`; `go vet` and `gofmt` clean.
- Manual CLI smoke test of all five sink types against a real deploy manifest + OCI layout: outputs inspected and correct, with 0 blob transfers from any registry (no network).
