### PR TITLE
feat(deploy): accept compact streams and bare paths in --layer

### DIFF
--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -85,7 +85,7 @@ func DeployProcess(ctx context.Context, args []string) {
 	flagSet.StringVar(&overrideRepository, "repository", "", "Override repository for push and split-mode load operations (load ops with a registry/repository set; the rules_oci tag-only fallback is left unchanged)")
 	flagSet.StringVar(&platforms, "platform", "", "Comma-separated list of platforms to load (e.g., linux/amd64). If not set, loads the platform closest to the host (or the single available platform). Use 'all' to load the full multi-platform index. Doesn't affect push, only load.")
 	flagSet.Var(&ociLayouts, "oci-layout", "Path to an OCI layout directory, sparse or standard (can be used multiple times)")
-	flagSet.Var(&explicitLayers, "layer", "Explicit layer in digest=path format (can be used multiple times)")
+	flagSet.Var(&explicitLayers, "layer", "Layer as digest=path or a bare path (can be used multiple times). The file may be a raw compressed layer blob or a compact stream (.cstream), auto-detected. For a bare path: a raw blob is hashed to derive its digest; a .cstream must embed its compressed digest.")
 	flagSet.IntVar(&jobs, "jobs", 16, "Maximum number of parallel push operations")
 	flagSet.StringVar(&sink, "sink", "", "Override the destination of all push/load/registry_tag operations for testing. Format: <type>:<path> where type is one of oci-tar, docker-save, oci, distribution, distribution-flat. No registry or daemon network I/O is performed.")
 
@@ -103,17 +103,6 @@ func DeployProcess(ctx context.Context, args []string) {
 		fmt.Fprintln(os.Stderr, "Error: at least one --request-file is required")
 		flagSet.Usage()
 		os.Exit(1)
-	}
-
-	// Parse explicit layers into a map
-	layerMap := make(map[string]string)
-	for _, layerFlag := range explicitLayers {
-		digest, filePath, ok := strings.Cut(layerFlag, "=")
-		if !ok {
-			fmt.Fprintf(os.Stderr, "Error: --layer must be in format digest=path, got %q\n", layerFlag)
-			os.Exit(1)
-		}
-		layerMap[digest] = filePath
 	}
 
 	// Parse platforms
@@ -140,7 +129,7 @@ func DeployProcess(ctx context.Context, args []string) {
 		PlatformList:               platformList,
 		RunfilesRootSymlinksPrefix: runfilesRootSymlinksPrefix,
 		OCILayouts:                 []string(ociLayouts),
-		ExplicitLayers:             layerMap,
+		Layers:                     []string(explicitLayers),
 		Jobs:                       jobs,
 		Sink:                       sink,
 	}
@@ -191,7 +180,7 @@ type DeployOptions struct {
 	PlatformList               []string
 	RunfilesRootSymlinksPrefix string
 	OCILayouts                 []string
-	ExplicitLayers             map[string]string
+	Layers                     []string // raw --layer specs: "digest=path" or bare "path" (raw blob or .cstream)
 	Jobs                       int
 	Sink                       string
 }
@@ -248,8 +237,8 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 	for _, layoutPath := range opts.OCILayouts {
 		vfsBuilder = vfsBuilder.WithOCILayout(layoutPath)
 	}
-	for digest, filePath := range opts.ExplicitLayers {
-		vfsBuilder = vfsBuilder.WithExplicitLayer(digest, filePath)
+	for _, spec := range opts.Layers {
+		vfsBuilder = vfsBuilder.WithLayer(spec)
 	}
 	vfs, err := vfsBuilder.Build()
 	if err != nil {

--- a/img_tool/cmd/deploy/persistentworker.go
+++ b/img_tool/cmd/deploy/persistentworker.go
@@ -123,8 +123,8 @@ func (h *deployWorkerHandler) processRequest(ctx context.Context, req persistent
 	for _, layoutPath := range opts.ociLayouts {
 		vfsBuilder = vfsBuilder.WithOCILayout(layoutPath)
 	}
-	for digest, filePath := range opts.explicitLayers {
-		vfsBuilder = vfsBuilder.WithExplicitLayer(digest, filePath)
+	for _, spec := range opts.layers {
+		vfsBuilder = vfsBuilder.WithLayer(spec)
 	}
 	if opts.runfilesPrefix != "" {
 		vfsBuilder = vfsBuilder.WithRunfilesRootSymlinksPrefix(opts.runfilesPrefix)
@@ -363,7 +363,7 @@ func (h *deployWorkerHandler) registryTagOps(ctx context.Context, vfs *deployvfs
 type workerOpts struct {
 	requestFiles       []string
 	ociLayouts         []string
-	explicitLayers     map[string]string
+	layers             []string // raw --layer specs: "digest=path" or bare "path" (raw blob or .cstream)
 	runfilesPrefix     string
 	overrideRegistry   string
 	overrideRepository string
@@ -372,9 +372,7 @@ type workerOpts struct {
 }
 
 func parseWorkerArgs(args []string) (*workerOpts, error) {
-	opts := &workerOpts{
-		explicitLayers: make(map[string]string),
-	}
+	opts := &workerOpts{}
 
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -407,11 +405,7 @@ func parseWorkerArgs(args []string) (*workerOpts, error) {
 				i++
 				value = args[i]
 			}
-			digest, path, ok := strings.Cut(value, "=")
-			if !ok {
-				return nil, fmt.Errorf("--layer must be in format digest=path, got %q", value)
-			}
-			opts.explicitLayers[digest] = path
+			opts.layers = append(opts.layers, value)
 		case key == "--runfiles-root-symlinks-prefix":
 			if !hasValue {
 				if i+1 >= len(args) {

--- a/img_tool/pkg/compactstream/inspect.go
+++ b/img_tool/pkg/compactstream/inspect.go
@@ -91,6 +91,18 @@ func (i *Info) ReconstructedSize() uint64 {
 	return i.StreamUncompressedSize + i.ReferencedBytes()
 }
 
+// MagicSize is the number of leading bytes that identify a compact stream.
+// A caller can peek this many bytes and pass them to HasMagic to detect a
+// compact stream without parsing the full header.
+const MagicSize = len(magic)
+
+// HasMagic reports whether prefix begins with the compact stream signature.
+// It only inspects the first MagicSize bytes, so a shorter prefix (e.g. from a
+// truncated read) reports false rather than erroring.
+func HasMagic(prefix []byte) bool {
+	return len(prefix) >= MagicSize && string(prefix[:MagicSize]) == magic
+}
+
 // ReadHeader reads and validates the fixed-size compact stream header from
 // r. It consumes exactly headerSize bytes, leaving r positioned at the start
 // of the CAS reference table.

--- a/img_tool/pkg/deployvfs/compactstream.go
+++ b/img_tool/pkg/deployvfs/compactstream.go
@@ -2,6 +2,7 @@ package deployvfs
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -13,6 +14,122 @@ import (
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/cas"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/compactstream"
 )
+
+// WithCompactStreamLayer registers a .cstream index file that reconstructs the
+// layer with the given digest. Unlike WithExplicitLayer (which serves a raw
+// compressed blob verbatim), the layer is rebuilt on demand from the stream.
+func (b *Builder) WithCompactStreamLayer(digest string, filePath string) *Builder {
+	if b.compactStreamLayers == nil {
+		b.compactStreamLayers = make(map[string]string)
+	}
+	b.compactStreamLayers[digest] = filePath
+	return b
+}
+
+// WithLayer classifies a single --layer spec and registers it with the builder.
+// The spec is either "digest=path" or a bare "path". The file at path may be a
+// raw compressed layer blob or a compact stream (.cstream) index:
+//
+//   - compact stream: reconstructed on demand (WithCompactStreamLayer). For a
+//     bare path the layer digest is taken from the stream's embedded compressed
+//     digest, which is therefore required; a "digest=path" spec supplies it
+//     explicitly (and, when the stream also embeds one, the two must match).
+//   - raw layer blob: served verbatim (WithExplicitLayer). For a bare path the
+//     digest is computed by hashing the file; a "digest=path" spec supplies it.
+//
+// Classification does file I/O; any error is deferred to Build() via
+// layerSpecErr so the fluent With* chain stays error-free. The first error wins.
+func (b *Builder) WithLayer(spec string) *Builder {
+	if b.layerSpecErr != nil {
+		return b
+	}
+	digest, filePath, hasDigest := strings.Cut(spec, "=")
+	if !hasDigest {
+		filePath = spec
+		digest = ""
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		b.layerSpecErr = fmt.Errorf("--layer %q: %w", spec, err)
+		return b
+	}
+	defer f.Close()
+
+	// Detect a compact stream by its leading magic. A short read just means the
+	// file is not a compact stream (a raw blob may be smaller than the magic).
+	var prefix [compactstream.MagicSize]byte
+	n, readErr := io.ReadFull(f, prefix[:])
+	if readErr == nil && compactstream.HasMagic(prefix[:n]) {
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			b.layerSpecErr = fmt.Errorf("--layer %q: %w", spec, err)
+			return b
+		}
+		header, err := compactstream.ReadHeader(f)
+		if err != nil {
+			b.layerSpecErr = fmt.Errorf("--layer %q: reading compact stream header: %w", spec, err)
+			return b
+		}
+		var embedded string
+		if header.HasCompressedStreamInfo {
+			embedded = "sha256:" + hex.EncodeToString(header.CompressedStreamDigest)
+		}
+		key := digest
+		if !hasDigest {
+			if embedded == "" {
+				b.layerSpecErr = fmt.Errorf("--layer %q: compact stream does not embed a compressed digest; pass it as digest=path", spec)
+				return b
+			}
+			key = embedded
+		} else if embedded != "" && !strings.EqualFold(embedded, digest) {
+			b.layerSpecErr = fmt.Errorf("--layer %q: provided digest %s does not match compact stream's embedded compressed digest %s", spec, digest, embedded)
+			return b
+		}
+		return b.WithCompactStreamLayer(key, filePath)
+	}
+
+	// Not a compact stream: treat as a raw compressed layer blob. A real read
+	// error (as opposed to a short file / EOF, which just means "not a compact
+	// stream") is fatal.
+	if readErr != nil && readErr != io.EOF && readErr != io.ErrUnexpectedEOF {
+		b.layerSpecErr = fmt.Errorf("--layer %q: %w", spec, readErr)
+		return b
+	}
+	key := digest
+	if !hasDigest {
+		// A bare raw layer path is self-describing only by its content, so derive
+		// the layer digest by hashing the file from disk.
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			b.layerSpecErr = fmt.Errorf("--layer %q: %w", spec, err)
+			return b
+		}
+		h := sha256.New()
+		if _, err := io.Copy(h, f); err != nil {
+			b.layerSpecErr = fmt.Errorf("--layer %q: hashing layer file: %w", spec, err)
+			return b
+		}
+		key = "sha256:" + hex.EncodeToString(h.Sum(nil))
+	}
+	return b.WithExplicitLayer(key, filePath)
+}
+
+// layerFromExplicitCompactStream reconstructs a layer from a .cstream registered
+// via the --layer flag (see WithLayer / WithCompactStreamLayer). The stream ships
+// without a content-addressed input directory, so its CAS references are resolved
+// from the disk cache / remote cache (see casDirStore).
+func (b *Builder) layerFromExplicitCompactStream(desc api.Descriptor) (blobEntry, error) {
+	if len(b.compactStreamLayers) == 0 {
+		return blobEntry{}, &BlobSourceError{Source: "explicit compact stream", Digest: desc.Digest, Kind: BlobSourceUnconfigured, Message: "no compact stream layers configured"}
+	}
+	compactStreamPath, found := b.compactStreamLayers[desc.Digest]
+	if !found {
+		return blobEntry{}, &BlobSourceError{Source: "explicit compact stream", Digest: desc.Digest, Kind: BlobSourceBlobMissing, Message: fmt.Sprintf("digest not in compact stream layer map (%d entries)", len(b.compactStreamLayers))}
+	}
+	if _, err := os.Stat(compactStreamPath); err != nil {
+		return blobEntry{}, &BlobSourceError{Source: "explicit compact stream", Digest: desc.Digest, Kind: BlobSourceOther, Message: fmt.Sprintf("file %s", compactStreamPath), Err: err}
+	}
+	return b.layerFromCompactStream(compactStreamPath, "", desc), nil
+}
 
 // layerFromOCILayoutCompactStream reconstructs a layer from a compact stream stored
 // inside an explicit OCI layout directory (--oci-layout). The stream is looked up at

--- a/img_tool/pkg/deployvfs/compactstream_test.go
+++ b/img_tool/pkg/deployvfs/compactstream_test.go
@@ -299,3 +299,237 @@ func TestBuilderContext(t *testing.T) {
 		t.Error("Clone did not carry the context")
 	}
 }
+
+// buildCompactStreamFileAt writes a compact stream to path that reconstructs to
+// prefix + casBlob + suffix via a single CAS reference to casBlob. When
+// embedDigest is true it records the reconstructed bytes' digest and size in the
+// header (SetCompressedStreamInfo), which is what a bare `--layer=<path>` relies
+// on to learn the layer digest. It returns the layer descriptor (digest = sha256
+// of the reconstructed bytes; no re-compression) and the reconstructed bytes.
+func buildCompactStreamFileAt(t *testing.T, path string, prefix, casBlob, suffix []byte, embedDigest bool) (api.Descriptor, []byte) {
+	t.Helper()
+	casDigest := sha256.Sum256(casBlob)
+	reconstructed := append(append(append([]byte(nil), prefix...), casBlob...), suffix...)
+	layerDigest := sha256.Sum256(reconstructed)
+
+	var buf bytes.Buffer
+	w := compactstream.NewWriter(&buf, compactstream.HashAlgoSHA256, 32, compactstream.StreamCompressionNone, compactstream.OriginalCompressionInfo{}, 0)
+	if err := w.WriteStreamBytes(prefix); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteCASRef(casDigest[:], uint64(len(casBlob))); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteStreamBytes(suffix); err != nil {
+		t.Fatal(err)
+	}
+	if embedDigest {
+		if err := w.SetCompressedStreamInfo(layerDigest[:], uint64(len(reconstructed))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	writeBlobFile(t, path, buf.Bytes())
+
+	return api.Descriptor{Digest: "sha256:" + hex.EncodeToString(layerDigest[:]), Size: int64(len(reconstructed))}, reconstructed
+}
+
+// shipDiskCacheBlob writes a content-addressed blob into a Bazel disk cache so
+// that compact-stream reconstruction can resolve a CAS reference from it.
+func shipDiskCacheBlob(t *testing.T, diskCache string, content []byte) {
+	t.Helper()
+	d := sha256.Sum256(content)
+	writeBlobFile(t, diskCacheBlobPath(diskCache, "sha256:"+hex.EncodeToString(d[:])), content)
+}
+
+// TestWithLayerBareCompactStream verifies a bare `--layer=<path>.cstream` is
+// detected, keyed by its embedded compressed digest, and reconstructs (resolving
+// its CAS reference from the disk cache).
+func TestWithLayerBareCompactStream(t *testing.T) {
+	csPath := filepath.Join(t.TempDir(), "layer.cstream")
+	casBlob := []byte("bare-input-content")
+	desc, want := buildCompactStreamFileAt(t, csPath, []byte("A"), casBlob, []byte("Z"), true)
+
+	diskCache := t.TempDir()
+	shipDiskCacheBlob(t, diskCache, casBlob)
+
+	b := NewBuilder(api.DeployManifest{}).WithDiskCache(diskCache).WithLayer(csPath)
+	if b.layerSpecErr != nil {
+		t.Fatalf("WithLayer: %v", b.layerSpecErr)
+	}
+	if got, ok := b.compactStreamLayers[desc.Digest]; !ok || got != csPath {
+		t.Fatalf("compactStreamLayers[%s] = %q (ok=%v), want %q", desc.Digest, got, ok, csPath)
+	}
+	entry, err := b.layerFromExplicitCompactStream(desc)
+	if err != nil {
+		t.Fatalf("layerFromExplicitCompactStream: %v", err)
+	}
+	if entry.Location != "compact_stream" {
+		t.Errorf("Location = %q, want compact_stream", entry.Location)
+	}
+	if got := readAllClose(t, mustOpen(t, entry)); !bytes.Equal(got, want) {
+		t.Fatalf("reconstructed = %q, want %q", got, want)
+	}
+	if n := b.stats.BlobsFromCompactStream.Load(); n != 1 {
+		t.Errorf("BlobsFromCompactStream = %d, want 1", n)
+	}
+}
+
+// TestWithLayerBareCompactStreamMissingEmbeddedDigest verifies that a bare path
+// to a compact stream without an embedded compressed digest is rejected (there
+// is no other way to learn which layer it reconstructs).
+func TestWithLayerBareCompactStreamMissingEmbeddedDigest(t *testing.T) {
+	csPath := filepath.Join(t.TempDir(), "layer.cstream")
+	buildCompactStreamFileAt(t, csPath, []byte("A"), []byte("in"), []byte("Z"), false /* embedDigest */)
+
+	_, err := NewBuilder(api.DeployManifest{}).WithLayer(csPath).Build()
+	if err == nil || !strings.Contains(err.Error(), "does not embed a compressed digest") {
+		t.Fatalf("expected embedded-digest error, got %v", err)
+	}
+}
+
+// TestWithLayerCompactStreamDigestForm verifies the `digest=path` form for a
+// compact stream: a matching digest reconstructs, and a mismatching digest is
+// rejected against the stream's embedded compressed digest.
+func TestWithLayerCompactStreamDigestForm(t *testing.T) {
+	csPath := filepath.Join(t.TempDir(), "layer.cstream")
+	casBlob := []byte("digest-form-input")
+	desc, want := buildCompactStreamFileAt(t, csPath, []byte("A"), casBlob, []byte("Z"), true)
+
+	diskCache := t.TempDir()
+	shipDiskCacheBlob(t, diskCache, casBlob)
+
+	b := NewBuilder(api.DeployManifest{}).WithDiskCache(diskCache).WithLayer(desc.Digest + "=" + csPath)
+	if b.layerSpecErr != nil {
+		t.Fatalf("WithLayer (matching digest): %v", b.layerSpecErr)
+	}
+	entry, err := b.layerFromExplicitCompactStream(desc)
+	if err != nil {
+		t.Fatalf("layerFromExplicitCompactStream: %v", err)
+	}
+	if got := readAllClose(t, mustOpen(t, entry)); !bytes.Equal(got, want) {
+		t.Fatalf("reconstructed = %q, want %q", got, want)
+	}
+
+	wrong := "sha256:" + strings.Repeat("a", 64)
+	_, err = NewBuilder(api.DeployManifest{}).WithLayer(wrong + "=" + csPath).Build()
+	if err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("expected digest-mismatch error, got %v", err)
+	}
+}
+
+// TestLayerFromExplicitCompactStreamResolvesRefsFromRemoteCAS verifies that a
+// `--layer` compact stream resolves its CAS references from the remote cache
+// when no input directory or disk cache ships them.
+func TestLayerFromExplicitCompactStreamResolvesRefsFromRemoteCAS(t *testing.T) {
+	csPath := filepath.Join(t.TempDir(), "layer.cstream")
+	casBlob := []byte("remote-input-content")
+	desc, want := buildCompactStreamFileAt(t, csPath, []byte("<"), casBlob, []byte(">"), true)
+
+	casDigest := sha256.Sum256(casBlob)
+	remote := &stubCASReader{blobs: map[string][]byte{hex.EncodeToString(casDigest[:]): casBlob}}
+
+	b := NewBuilder(api.DeployManifest{}).WithCASReader(remote).WithLayer(csPath)
+	if b.layerSpecErr != nil {
+		t.Fatalf("WithLayer: %v", b.layerSpecErr)
+	}
+	entry, err := b.layerFromExplicitCompactStream(desc)
+	if err != nil {
+		t.Fatalf("layerFromExplicitCompactStream: %v", err)
+	}
+	if got := readAllClose(t, mustOpen(t, entry)); !bytes.Equal(got, want) {
+		t.Fatalf("reconstructed = %q, want %q", got, want)
+	}
+}
+
+// TestWithLayerBareRawLayerHashesFile verifies a bare `--layer=<path>` to a raw
+// (non-cstream) layer blob is hashed from disk to derive its digest and served
+// verbatim via the explicit-layer source.
+func TestWithLayerBareRawLayerHashesFile(t *testing.T) {
+	blob := []byte("this is a raw compressed layer blob, not a compact stream")
+	blobPath := filepath.Join(t.TempDir(), "layer.tar.gz")
+	writeBlobFile(t, blobPath, blob)
+	sum := sha256.Sum256(blob)
+	desc := api.Descriptor{Digest: "sha256:" + hex.EncodeToString(sum[:]), Size: int64(len(blob))}
+
+	b := NewBuilder(api.DeployManifest{}).WithLayer(blobPath)
+	if b.layerSpecErr != nil {
+		t.Fatalf("WithLayer: %v", b.layerSpecErr)
+	}
+	entry, err := b.layerFromExplicit(desc)
+	if err != nil {
+		t.Fatalf("layerFromExplicit: %v", err)
+	}
+	if entry.Location != "file" {
+		t.Errorf("Location = %q, want file", entry.Location)
+	}
+	if got := readAllClose(t, mustOpen(t, entry)); !bytes.Equal(got, blob) {
+		t.Fatalf("blob = %q, want %q", got, blob)
+	}
+}
+
+// TestWithLayerRawLayerDigestFormIsTrusted verifies the `digest=path` form for a
+// raw layer registers under the supplied digest without hashing the file.
+func TestWithLayerRawLayerDigestFormIsTrusted(t *testing.T) {
+	blob := []byte("raw blob bytes")
+	blobPath := filepath.Join(t.TempDir(), "layer.bin")
+	writeBlobFile(t, blobPath, blob)
+
+	// A digest that does NOT match the file's hash; digest=path is trusted as-is.
+	desc := api.Descriptor{Digest: "sha256:" + strings.Repeat("b", 64), Size: int64(len(blob))}
+	b := NewBuilder(api.DeployManifest{}).WithLayer(desc.Digest + "=" + blobPath)
+	if b.layerSpecErr != nil {
+		t.Fatalf("WithLayer: %v", b.layerSpecErr)
+	}
+	entry, err := b.layerFromExplicit(desc)
+	if err != nil {
+		t.Fatalf("layerFromExplicit: %v", err)
+	}
+	if got := readAllClose(t, mustOpen(t, entry)); !bytes.Equal(got, blob) {
+		t.Fatalf("blob = %q, want %q", got, blob)
+	}
+}
+
+// TestWithLayerOpenError verifies an unreadable --layer path surfaces at Build().
+func TestWithLayerOpenError(t *testing.T) {
+	if _, err := NewBuilder(api.DeployManifest{}).WithLayer(filepath.Join(t.TempDir(), "nope")).Build(); err == nil {
+		t.Fatal("expected error for nonexistent --layer path")
+	}
+}
+
+// TestLayerFromExplicitCompactStreamErrors covers the structured error kinds the
+// source returns (it is aggregated by layerBlob, which requires *BlobSourceError).
+func TestLayerFromExplicitCompactStreamErrors(t *testing.T) {
+	desc := api.Descriptor{Digest: "sha256:" + strings.Repeat("a", 64)}
+	var bse *BlobSourceError
+
+	// Nothing configured -> unconfigured.
+	if _, err := NewBuilder(api.DeployManifest{}).layerFromExplicitCompactStream(desc); !errors.As(err, &bse) || bse.Kind != BlobSourceUnconfigured {
+		t.Fatalf("expected BlobSourceUnconfigured, got %v", err)
+	}
+
+	// Configured, but this digest is not registered -> blob missing.
+	other := NewBuilder(api.DeployManifest{}).WithCompactStreamLayer("sha256:"+strings.Repeat("c", 64), "/some.cstream")
+	if _, err := other.layerFromExplicitCompactStream(desc); !errors.As(err, &bse) || bse.Kind != BlobSourceBlobMissing {
+		t.Fatalf("expected BlobSourceBlobMissing, got %v", err)
+	}
+
+	// Registered but the file is gone -> other.
+	missing := NewBuilder(api.DeployManifest{}).WithCompactStreamLayer(desc.Digest, filepath.Join(t.TempDir(), "gone.cstream"))
+	if _, err := missing.layerFromExplicitCompactStream(desc); !errors.As(err, &bse) || bse.Kind != BlobSourceOther {
+		t.Fatalf("expected BlobSourceOther, got %v", err)
+	}
+}
+
+// TestCloneCopiesCompactStreamLayers verifies Clone() deep-copies the
+// compact-stream layer map so per-request worker clones do not leak into the base.
+func TestCloneCopiesCompactStreamLayers(t *testing.T) {
+	b := NewBuilder(api.DeployManifest{}).WithCompactStreamLayer("sha256:abc", "/p")
+	clone := b.Clone()
+	clone.WithCompactStreamLayer("sha256:def", "/q")
+	if _, leaked := b.compactStreamLayers["sha256:def"]; leaked {
+		t.Fatal("mutating clone leaked into the original compactStreamLayers")
+	}
+}

--- a/img_tool/pkg/deployvfs/deployvfs.go
+++ b/img_tool/pkg/deployvfs/deployvfs.go
@@ -318,9 +318,15 @@ type Builder struct {
 	containerRegistryOptions   []remote.Option
 	runfilesRootSymlinksPrefix string
 	ociLayouts                 []string            // paths to OCI layout directories (sparse or standard)
-	explicitLayers             map[string]string   // digest -> file path
+	explicitLayers             map[string]string   // digest -> file path (raw compressed layer blob)
+	compactStreamLayers        map[string]string   // layer digest -> .cstream file path (reconstructed on demand)
 	layerHints                 map[string][]string // digest -> []paths
 	stats                      *Stats
+	// layerSpecErr holds the first error encountered while classifying a --layer
+	// spec in WithLayer (detecting a compact stream, reading its embedded digest,
+	// or hashing a raw layer file). It is deferred until Build() so the fluent
+	// With* chain stays error-free, mirroring how layer hints surface at Build().
+	layerSpecErr error
 	// ctx scopes long-running, lazily-triggered work created by the resulting
 	// VFS — notably on-demand compact-stream reconstruction, which may fetch CAS
 	// blobs from the remote cache. It is captured into blob openers so that
@@ -344,6 +350,12 @@ func (b *Builder) Clone() *Builder {
 		clone.explicitLayers = make(map[string]string, len(b.explicitLayers))
 		for k, v := range b.explicitLayers {
 			clone.explicitLayers[k] = v
+		}
+	}
+	if b.compactStreamLayers != nil {
+		clone.compactStreamLayers = make(map[string]string, len(b.compactStreamLayers))
+		for k, v := range b.compactStreamLayers {
+			clone.compactStreamLayers[k] = v
 		}
 	}
 	clone.layerHints = nil
@@ -416,6 +428,11 @@ func (b *Builder) rlocation(runfilesPath string) (string, error) {
 }
 
 func (b *Builder) Build() (*VFS, error) {
+	// Surface any error captured while classifying a --layer spec (see WithLayer).
+	if b.layerSpecErr != nil {
+		return nil, b.layerSpecErr
+	}
+
 	// Try to load layer hints if available
 	if err := b.loadLayerHints(); err != nil {
 		// Layer hints are optional, log but don't fail
@@ -585,15 +602,16 @@ func (b *Builder) ingest() (map[string]blobEntry, map[string]blobEntry, map[stri
 func (b *Builder) layerBlob(operationIndex int, manifestIndex int, layerIndex int, strategy string, layer api.LayerBlob) (blobEntry, error) {
 	// we try the following sources, in order:
 	// 1. OCI layouts (--oci-layout flags, supports both sparse and standard formats)
-	// 2. explicit layer files (--layer flags)
+	// 2. explicit layer files (--layer flags pointing at a raw compressed blob)
 	// 3. runfiles tree
-	// 4. compact stream in an OCI layout (--oci-layout, <layout>/blobs/<algo>/<hex>.cstream)
-	// 5. compact stream in runfiles (.cstream + .inputfilecas content-addressed directory)
-	// 6. registry (if the layer records upstream sources, i.e. it came from a pulled base image)
-	// 7. layer hints (local paths from BUILD_WORKSPACE_DIRECTORY, populated by lazy builds)
-	// 8. bazel disk cache (if configured via IMG_DISK_CACHE)
-	// 9. bazel remote cache (if configured via IMG_REAPI_ENDPOINT)
-	// 10. stub blob (cas_registry strategy where all blobs are assumed to already be in the remote CAS)
+	// 4. explicit compact stream (--layer flag pointing at a .cstream index)
+	// 5. compact stream in an OCI layout (--oci-layout, <layout>/blobs/<algo>/<hex>.cstream)
+	// 6. compact stream in runfiles (.cstream + .inputfilecas content-addressed directory)
+	// 7. registry (if the layer records upstream sources, i.e. it came from a pulled base image)
+	// 8. layer hints (local paths from BUILD_WORKSPACE_DIRECTORY, populated by lazy builds)
+	// 9. bazel disk cache (if configured via IMG_DISK_CACHE)
+	// 10. bazel remote cache (if configured via IMG_REAPI_ENDPOINT)
+	// 11. stub blob (cas_registry strategy where all blobs are assumed to already be in the remote CAS)
 
 	desc := layer.Descriptor
 
@@ -610,6 +628,11 @@ func (b *Builder) layerBlob(operationIndex int, manifestIndex int, layerIndex in
 		sourceErrors = append(sourceErrors, err.(*BlobSourceError))
 	}
 	if entry, err := b.layerFromFile(operationIndex, manifestIndex, layerIndex, desc); err == nil {
+		return entry, nil
+	} else {
+		sourceErrors = append(sourceErrors, err.(*BlobSourceError))
+	}
+	if entry, err := b.layerFromExplicitCompactStream(desc); err == nil {
 		return entry, nil
 	} else {
 		sourceErrors = append(sourceErrors, err.(*BlobSourceError))


### PR DESCRIPTION
## What

The deploy VFS could reconstruct compact-stream (`.cstream`) layers only from on-disk files (an `--oci-layout` dir or the runfiles sparse layout). This extends the deploy `--layer` flag so it can point directly at a `.cstream` index, and supports a bare path (no `digest=`) for both raw layers and compact streams:

| form | raw layer blob | compact stream |
| --- | --- | --- |
| `--layer=digest=path` | served verbatim | reconstructed (digest known) |
| `--layer=path` | hashed from disk to derive the digest | reconstructed; **requires** an embedded compressed digest |

## How

`Builder.WithLayer` classifies each spec by peeking the compact-stream magic:
- a `.cstream` is registered in a `compactStreamLayers` lookup table (keyed by the layer's compressed digest) and reconstructed on demand via a new `layerFromExplicitCompactStream` source (inserted at the top of the reconstruction group in `layerBlob`);
- a raw blob is served verbatim via the existing explicit-layer source, hashing the file to derive its digest when none is supplied.

Classification errors are deferred to `Build()`. The `.cstream`'s referenced input blobs resolve from the disk/remote cache via the existing `casDirStore`, matching the other compact-stream sources. The deploy `--layer` flag is a manual CLI affordance (no Bazel rule passes it), so the semantics change is self-contained.