### PR TITLE
chore(renovate): enable dashboard, disable automatic PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "dependencyDashboard": true,
   "labels": ["dependencies"],
   "packageRules": [
     {
@@ -19,6 +20,10 @@
       "groupName": "Go dependencies",
       "matchManagers": ["gomod"],
       "excludePackageNames": ["github.com/malt3/go-containerregistry"]
+    },
+    {
+      "matchPackagePatterns": ["*"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Enables the Renovate dependency dashboard issue for visibility into available updates
- Disables automatic PR creation via a catch-all `enabled: false` package rule
- Preserves existing grouping rules (container images, forked go-containerregistry, Go dependencies) so updates remain organized on the dashboard