### PR TITLE
feat(settings): add additional_image_labels_file label_flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ common --@rules_img//img/settings:mtree_image_layout=oci_layer_filesystem_applie
 # note that tools relying on the full reference to look up images will not find
 # them.
 common --@rules_img//img/settings:oci_ref_name=full_reference
+
+# A file of extra image-config labels merged into every image's config.json.
+# The value is a single-file label (not an inline value): point it at a target
+# whose one file lists labels as newline-delimited KEY=VALUE, a JSON object
+# ({"key":"value"}), or a JSON array (["key=value"]). These labels are applied
+# to every image and are NOT template-expanded; per-target `labels`/`label_files`
+# take precedence over the file. Defaults to an empty file (no extra labels).
+common --@rules_img//img/settings:additional_image_labels_file=//path/to:image_labels
 ```
 
 </details>

--- a/img/private/manifest.bzl
+++ b/img/private/manifest.bzl
@@ -509,6 +509,13 @@ def _image_manifest_impl(ctx):
         inputs.append(ctx.file.env_file)
         args.add("--env-file", ctx.file.env_file.path)
 
+    # Build-wide extra labels from the //img/settings:additional_image_labels_file
+    # label_flag. These are merged into every config.json by the tool and are NOT
+    # template-expanded; per-target `labels`/`label_files` take precedence. The flag
+    # defaults to an empty file, so this contributes nothing unless overridden.
+    inputs.append(ctx.file._additional_image_labels_file)
+    args.add("--additional-image-labels-file", ctx.file._additional_image_labels_file.path)
+
     # Image config value overrides (user, working_dir, stop_signal, entrypoint,
     # cmd). The scalar flags are always passed -- even when empty -- so the tool
     # can distinguish the INHERIT_FROM_BASE sentinel (inherit) from an explicit
@@ -930,6 +937,10 @@ See [template expansion](/docs/templating.md) for available stamp variables.
         "_mtree_image_layout": attr.label(
             default = Label("//img/settings:mtree_image_layout"),
             providers = [BuildSettingInfo],
+        ),
+        "_additional_image_labels_file": attr.label(
+            default = Label("//img/settings:additional_image_labels_file"),
+            allow_single_file = True,
         ),
         "push_specs": attr.label_list(
             doc = """Push configurations to produce DeployInfo for this image.

--- a/img/settings/BUILD.bazel
+++ b/img/settings/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:common_settings.bzl", "int_flag", "string_flag")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//img/private:signing_config.bzl", "unset_signing_config")
 
 string_flag(
@@ -318,5 +319,26 @@ string_flag(
         "full_reference",
         "tag_only",
     ],
+    visibility = ["//img/private:__subpackages__"],
+)
+
+# A file of extra image-config labels merged into every image's config.json.
+# The file is parsed by the `kvfile` package (newline-delimited KEY=VALUE, a JSON
+# object, or a JSON array of KEY=VALUE) and is NOT template-expanded. Override it
+# to point at any single-file target, e.g.
+#   common --@rules_img//img/settings:additional_image_labels_file=//path:labels
+# The default is an empty file, so by default no extra labels are added.
+label_flag(
+    name = "additional_image_labels_file",
+    build_setting_default = ":empty_additional_image_labels",
+    visibility = ["//visibility:public"],
+)
+
+# The empty-file default for :additional_image_labels_file. An empty file parses
+# to zero labels, leaving every config.json byte-identical unless the flag is set.
+write_file(
+    name = "empty_additional_image_labels",
+    out = "empty_additional_image_labels.txt",
+    content = [],
     visibility = ["//img/private:__subpackages__"],
 )

--- a/img_tool/cmd/manifest/manifest.go
+++ b/img_tool/cmd/manifest/manifest.go
@@ -22,32 +22,33 @@ import (
 )
 
 var (
-	operatingSystem       string
-	architecture          string
-	variant               string
-	layerFromMetadataArgs fileList
-	configFragment        string
-	configMediaType       string
-	configTemplates       string
-	baseManifest          string
-	baseConfig            string
-	baseDescriptor        string
-	manifestOutput        string
-	configOutput          string
-	descriptorOutput      string
-	digestOutput          string
-	user                  string
-	env                   stringMap
-	envFile               string
-	entrypoint            stringList
-	cmd                   stringList
-	workingDir            string
-	labels                stringMap
-	annotations           stringMap
-	stopSignal            string
-	created               string
-	artifactType          string
-	subjectDescriptor     string
+	operatingSystem           string
+	architecture              string
+	variant                   string
+	layerFromMetadataArgs     fileList
+	configFragment            string
+	configMediaType           string
+	configTemplates           string
+	baseManifest              string
+	baseConfig                string
+	baseDescriptor            string
+	manifestOutput            string
+	configOutput              string
+	descriptorOutput          string
+	digestOutput              string
+	user                      string
+	env                       stringMap
+	envFile                   string
+	entrypoint                stringList
+	cmd                       stringList
+	workingDir                string
+	labels                    stringMap
+	additionalImageLabelsFile string
+	annotations               stringMap
+	stopSignal                string
+	created                   string
+	artifactType              string
+	subjectDescriptor         string
 )
 
 // inheritFromBase is the sentinel value used by the image_manifest rule to
@@ -92,6 +93,7 @@ func ManifestProcess(_ context.Context, args []string) {
 	flagSet.Var(&cmd, "cmd", `Default arguments to the entrypoint (can be specified multiple times).`)
 	flagSet.StringVar(&workingDir, "working-dir", "", `Working directory inside the container.`)
 	flagSet.Var(&labels, "label", `Metadata labels for the container (can be specified multiple times as key=value).`)
+	flagSet.StringVar(&additionalImageLabelsFile, "additional-image-labels-file", "", `A file of extra image-config labels, as JSON ({"KEY":"value"}, {"KEY":["v1","v2"]}, or ["KEY=value"]) or newline-delimited KEY=VALUE text (blank lines and lines starting with '#' are ignored). Merged into every config; values from --label take precedence over the file.`)
 	flagSet.Var(&annotations, "annotation", `Metadata annotations for the manifest (can be specified multiple times as key=value).`)
 	flagSet.StringVar(&stopSignal, "stop-signal", "", `Signal to stop the container.`)
 	flagSet.StringVar(&created, "created", "", `A file containing a datetime string (RFC 3339 format) for when the image was created.`)
@@ -609,6 +611,20 @@ func overlayNewConfigValues(config *specv1.Image, layers []api.Descriptor, templ
 		labelsToApply = templatesData.Labels
 	}
 
+	// Merge in build-wide labels from the --additional-image-labels-file, if
+	// provided. Entries from --label / templates take precedence over the file,
+	// mirroring how --env-file is merged above.
+	if additionalImageLabelsFile != "" {
+		fileLabels, err := readLabelsFile(additionalImageLabelsFile)
+		if err != nil {
+			return fmt.Errorf("failed to read additional image labels file %s: %w", additionalImageLabelsFile, err)
+		}
+		merged := make(map[string]string, len(fileLabels)+len(labelsToApply))
+		maps.Copy(merged, fileLabels)
+		maps.Copy(merged, labelsToApply)
+		labelsToApply = merged
+	}
+
 	if len(labelsToApply) > 0 {
 		if config.Config.Labels == nil {
 			config.Config.Labels = make(map[string]string)
@@ -695,6 +711,17 @@ func readEnvFile(filePath string) (map[string]string, error) {
 	pairs, err := kvfile.ParseFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("reading env file: %w", err)
+	}
+	return kvfile.Flatten(pairs), nil
+}
+
+// readLabelsFile reads a file containing image-config labels in JSON or
+// newline-delimited KEY=VALUE form (see the kvfile package). Duplicate keys
+// keep the last value.
+func readLabelsFile(filePath string) (map[string]string, error) {
+	pairs, err := kvfile.ParseFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading labels file: %w", err)
 	}
 	return kvfile.Flatten(pairs), nil
 }

--- a/img_tool/cmd/manifest/manifest_override_test.go
+++ b/img_tool/cmd/manifest/manifest_override_test.go
@@ -1,6 +1,8 @@
 package manifest
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -20,6 +22,7 @@ func resetManifestFlags() {
 	cmd = stringList{}
 	workingDir = ""
 	labels = stringMap{}
+	additionalImageLabelsFile = ""
 	stopSignal = ""
 }
 
@@ -194,4 +197,80 @@ func nilIfEmpty(s []string) []string {
 		return nil
 	}
 	return s
+}
+
+// TestOverlayNewConfigValuesAdditionalLabels verifies that labels from the
+// --additional-image-labels-file are merged into the config, that per-target
+// --label values take precedence over file entries for matching keys, and that
+// an empty file contributes nothing.
+func TestOverlayNewConfigValuesAdditionalLabels(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile := func(name, content string) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+		return path
+	}
+
+	t.Run("file only", func(t *testing.T) {
+		resetManifestFlags()
+		additionalImageLabelsFile = writeFile("labels.txt", "team=platform\ntier=backend\n")
+
+		cfg := specv1.Image{}
+		if err := overlayNewConfigValues(&cfg, nil, nil); err != nil {
+			t.Fatalf("overlayNewConfigValues: %v", err)
+		}
+		want := map[string]string{"team": "platform", "tier": "backend"}
+		if !reflect.DeepEqual(cfg.Config.Labels, want) {
+			t.Errorf("Labels = %v, want %v", cfg.Config.Labels, want)
+		}
+	})
+
+	t.Run("per-target label overrides file", func(t *testing.T) {
+		resetManifestFlags()
+		additionalImageLabelsFile = writeFile("labels2.txt", "team=platform\nowner=fromfile\n")
+		labels = stringMap{"owner": "fromflag", "extra": "flagonly"}
+
+		cfg := specv1.Image{}
+		if err := overlayNewConfigValues(&cfg, nil, nil); err != nil {
+			t.Fatalf("overlayNewConfigValues: %v", err)
+		}
+		want := map[string]string{
+			"team":  "platform", // from file
+			"owner": "fromflag", // --label wins over file
+			"extra": "flagonly", // from --label
+		}
+		if !reflect.DeepEqual(cfg.Config.Labels, want) {
+			t.Errorf("Labels = %v, want %v", cfg.Config.Labels, want)
+		}
+	})
+
+	t.Run("JSON file", func(t *testing.T) {
+		resetManifestFlags()
+		additionalImageLabelsFile = writeFile("labels.json", `{"team":"platform","tier":"backend"}`)
+
+		cfg := specv1.Image{}
+		if err := overlayNewConfigValues(&cfg, nil, nil); err != nil {
+			t.Fatalf("overlayNewConfigValues: %v", err)
+		}
+		want := map[string]string{"team": "platform", "tier": "backend"}
+		if !reflect.DeepEqual(cfg.Config.Labels, want) {
+			t.Errorf("Labels = %v, want %v", cfg.Config.Labels, want)
+		}
+	})
+
+	t.Run("empty file is a no-op", func(t *testing.T) {
+		resetManifestFlags()
+		additionalImageLabelsFile = writeFile("empty.txt", "")
+
+		cfg := specv1.Image{}
+		if err := overlayNewConfigValues(&cfg, nil, nil); err != nil {
+			t.Fatalf("overlayNewConfigValues: %v", err)
+		}
+		if len(cfg.Config.Labels) != 0 {
+			t.Errorf("Labels = %v, want empty", cfg.Config.Labels)
+		}
+	})
 }

--- a/tests/img_toolchain/testcases/manifest_additional_labels.ini
+++ b/tests/img_toolchain/testcases/manifest_additional_labels.ini
@@ -1,0 +1,29 @@
+[test]
+name = manifest_additional_labels
+description = Test manifest --additional-image-labels-file merging and --label precedence
+
+[file]
+name = labels.txt
+# This is a comment
+team=platform
+tier=backend
+
+# Blank lines are ignored
+owner=fromfile
+
+[command]
+subcommand = manifest
+args = --label owner=fromflag --additional-image-labels-file labels.txt --manifest manifest.json --config config.json
+expect_exit = 0
+
+[assert]
+file_exists = manifest.json
+file_exists = config.json
+file_valid_json = manifest.json
+file_valid_json = config.json
+json_field_exists = config.json, config
+file_contains = config.json, "team":"platform"
+file_contains = config.json, "tier":"backend"
+file_contains = config.json, "owner":"fromflag"
+file_not_contains = config.json, "owner":"fromfile"
+file_not_contains = config.json, "comment"

--- a/tests/img_toolchain/testcases/manifest_additional_labels_json.ini
+++ b/tests/img_toolchain/testcases/manifest_additional_labels_json.ini
@@ -1,0 +1,27 @@
+[test]
+name = manifest_additional_labels_json
+description = manifest --additional-image-labels-file accepts a JSON file; --label still takes precedence
+
+[file]
+name = labels.json
+{
+  "team": "platform",
+  "tier": "backend",
+  "owner": "fromfile"
+}
+
+[command]
+subcommand = manifest
+args = --label owner=fromflag --additional-image-labels-file labels.json --manifest manifest.json --config config.json
+expect_exit = 0
+
+[assert]
+file_exists = manifest.json
+file_exists = config.json
+file_valid_json = manifest.json
+file_valid_json = config.json
+json_field_exists = config.json, config
+file_contains = config.json, "team":"platform"
+file_contains = config.json, "tier":"backend"
+file_contains = config.json, "owner":"fromflag"
+file_not_contains = config.json, "owner":"fromfile"


### PR DESCRIPTION
## Summary

Adds a new `label_flag` build setting, **`//img/settings:additional_image_labels_file`**, that points at a single file of image-config labels which are merged into **every** image's `config.json`.

The file may be in any format the `kvfile` package already supports (auto-detected):
- newline-delimited `KEY=VALUE` text
- a JSON object `{"key": "value"}` / `{"key": ["v1", "v2"]}`
- a JSON array `["key=value"]`

Unlike the per-target `labels` / `label_files` attributes, these labels are **not** template-expanded — the file is threaded directly into the `img manifest` action and merged by the tool. This makes it a good fit for build-wide, org-level metadata set from a single `.bazelrc` line:

```
common --@rules_img//img/settings:additional_image_labels_file=//path/to:image_labels
```

The value is a **single-file label target** (not an inline value). The flag defaults to a generated empty file, so builds that don't set it produce byte-identical output.

## Behavior

Because platform transitions only touch `//command_line_option:platforms`, the setting propagates from `image_index` down to every child `image_manifest`, so it applies to every `config.json` (including multi-platform indexes).

Label precedence (low → high), consistent with how `--env-file` already merges:

```
base image  <  config_fragment  <  additional_image_labels_file  <  per-target labels/label_files
```

i.e. per-target `labels` / `label_files` win over the build-wide file.