### PR TITLE
harden(bcr): reject archive entries that escape the destination dir

### DIFF
--- a/modules/rules_img_internal_tools/release/bcr/bcr.go
+++ b/modules/rules_img_internal_tools/release/bcr/bcr.go
@@ -326,17 +326,31 @@ func extractSourceArchive(sourceArchive, destination string, stripPrefix string)
 			if !strings.HasPrefix(hdr.Name, stripPrefix) {
 				continue
 			}
-			hdr.Name = hdr.Name[len(stripPrefix)+1:]
+			hdr.Name = strings.TrimPrefix(hdr.Name[len(stripPrefix):], "/")
+		}
+		// Guard against Zip Slip / directory traversal: an entry name may
+		// contain a ".." element that escapes the destination once the joined
+		// path is cleaned. Reject the raw (prefix-stripped) name directly, so
+		// the traversal element is caught before it is ever used to build a
+		// filesystem path.
+		if strings.Contains(hdr.Name, "..") {
+			return fmt.Errorf("invalid file path in archive (contains \"..\"): %s", hdr.Name)
+		}
+		target := filepath.Join(destination, hdr.Name)
+		// Defense in depth: even without a "..", ensure the resolved path
+		// stays within the destination directory.
+		if target != destination && !strings.HasPrefix(target, destination+string(os.PathSeparator)) {
+			return fmt.Errorf("invalid file path in archive (escapes destination): %s", hdr.Name)
 		}
 		fInfo := hdr.FileInfo()
 		if fInfo.IsDir() {
-			os.Mkdir(filepath.Join(destination, hdr.Name), fInfo.Mode())
+			os.Mkdir(target, fInfo.Mode())
 			continue
 		}
 		if !fInfo.Mode().IsRegular() {
 			return fmt.Errorf("unsupported file type: %s", hdr.Name)
 		}
-		file, err := os.Create(filepath.Join(destination, hdr.Name))
+		file, err := os.Create(target)
 		if err != nil {
 			return fmt.Errorf("failed to create file: %v", err)
 		}


### PR DESCRIPTION
## What

CodeQL's `go/zipslip` query flags the tar extraction in the BCR release tool (`modules/rules_img_internal_tools/release/bcr/bcr.go`) as a Zip Slip sink. Entry names were only checked for a leading `.` or `/`, so a name containing `..` (e.g. `foo/../../../etc/passwd`) could resolve outside the destination once `filepath.Join` cleans it. When `strip_prefix` is set, the name is re-sliced *after* that check and never re-validated.

This tool runs at **release time** over **known inputs** — our own source archives produced by the build — not attacker-controlled data. There is no untrusted-input path here, so this isn't an exploitable issue. The change is cheap **defense in depth** that also satisfies the scanner and makes the extraction more robust.

## Changes

- Validate that the joined target stays within `destination` (after prefix stripping); this covers `..` traversal and absolute paths.
- Reuse the validated target for the `mkdir`/`create` calls.
- Strip the prefix via `strings.TrimPrefix` to avoid a slice-out-of-range panic when an entry name equals `strip_prefix` exactly.

`go build` and `go vet` pass on the package.
