### PR TITLE
feat: push all image blobs at build time, split blob/manifest staging repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,15 +144,24 @@ common --@rules_img//img/settings:docker_config_path=/home/user/.docker/config.j
 # logs and the build still succeeds; "enabled" fails the build on a push failure.
 common --@rules_img//img/settings:push_at_build_time=enabled
 
-# What the push-at-build-time actions push. "blobs" uploads only the layer blobs;
-# "blobs_and_manifests" (default) also pushes the config and manifest(s)/tags.
+# What the push-at-build-time actions push. "blobs" uploads every image blob (all
+# layer blobs and the config blob), one action each; "blobs_and_manifests"
+# (default) additionally pushes the config and manifest(s)/tags so the whole image
+# exists in the registry after the build.
 common --@rules_img//img/settings:push_at_build_time_content=blobs_and_manifests
 
-# Optional staging repository for layer blobs. When set, layer blobs are pushed
-# to this repository (within the destination registry) and cross-mounted into
-# the image's real repository when the manifest is pushed. Applies to both
-# push-at-build-time and `bazel run` pushes.
-common --@rules_img//img/settings:push_at_build_time_repository=staging-blobs
+# Optional staging repository for image blobs. When set, every blob (layers and
+# config) is pushed to this repository (within the destination registry) and
+# cross-mounted into the image's real repository when the manifest is pushed.
+# Applies to both push-at-build-time and `bazel run` pushes.
+common --@rules_img//img/settings:push_at_build_time_blob_repository=staging-blobs
+
+# Optional staging repository for manifests, used only by push-at-build-time in
+# "blobs_and_manifests" mode. When set, the manifest(s)/index (and the config
+# uploaded alongside them) are written to this repository instead of the image's
+# real repository. It does not change where layer blobs are mounted from (that is
+# push_at_build_time_blob_repository) and does not affect the `bazel run` deploy.
+common --@rules_img//img/settings:push_at_build_time_manifest_repository=staging-manifests
 
 # Forbid `img deploy` (image_push / multi_deploy) from uploading layer blob bytes.
 # Layers may still be cross-mounted server-side or skipped when already present,

--- a/docs/authenticating-build-actions.md
+++ b/docs/authenticating-build-actions.md
@@ -6,8 +6,8 @@ from inside a **build action**:
 - **Lazily pulled base-image layers** — layer blobs are fetched by a build action
   (mnemonic `DownloadBlob`) instead of during repository fetching.
 - **Push at build time** — [`push_at_build_time`](push-strategies.md#push-at-build-time)
-  uploads layer blobs (and, optionally, the config and manifest(s)) as build
-  actions.
+  uploads image blobs (all layers and the config) and, optionally, the manifest(s)
+  as build actions.
 
 Both need to reach the registry and authenticate. This page explains how.
 
@@ -30,9 +30,9 @@ The registry permissions differ per operation:
   helper path is never baked into a potentially-remote action.)
 - **Push at build time needs write access**, and the scope depends on
   `push_at_build_time_content`:
-  - `blobs` — writes only to `/v2/<repo>/blobs/` (blob uploads). A credential that
-    may upload blobs but may not read them or write manifests is sufficient (see
-    the multi-tenant note in [Push Strategies](push-strategies.md#blobs-at-build-time-manifest-afterwards-blobs)).
+  - `blobs` — writes only to `/v2/<repo>/blobs/` (blob uploads: every layer and
+    the config). A credential that may upload blobs but may not read them or write
+    manifests is sufficient (see the multi-tenant note in [Push Strategies](push-strategies.md#blobs-at-build-time-manifest-afterwards-blobs)).
   - `blobs_and_manifests` — additionally writes `/v2/<repo>/manifests/<ref>` (the
     config, manifest, and tags), so it also needs manifest write access.
 

--- a/docs/push-strategies.md
+++ b/docs/push-strategies.md
@@ -236,8 +236,9 @@ target, it pushes image content to the registry *as part of the build itself*.
 When `push_at_build_time` is enabled, every `image_manifest` / `image_index` that
 has `push_specs`, as well as every `image_push` target, gains extra build actions
 (mnemonic `PushImage`) that upload content directly to the registry: one action
-per layer, plus (optionally) one for the config and manifest(s). The actions are
-wired as Bazel [validation actions], so they run whenever the target is built
+per image blob (each layer and each config), plus — in `blobs_and_manifests` mode
+— one more action per push that writes the config and manifest(s)/tags. The actions
+are wired as Bazel [validation actions], so they run whenever the target is built
 (with `--run_validations`, on by default) without sitting on the critical path of
 the target's normal outputs.
 
@@ -248,9 +249,9 @@ not push them a second time.
 
 Two content modes are available, selected with `push_at_build_time_content`:
 
-- **`blobs`** — only the layer blobs are pushed at build time (one `PushImage`
-  action per layer). The config and manifest(s)/tags are *not* pushed at build
-  time; you push them afterwards with `image_push` / `multi_deploy`.
+- **`blobs`** — every image blob is pushed at build time: one `PushImage` action
+  per layer and one per config blob. The manifest(s)/tags are *not* pushed at build
+  time; you write them afterwards with `image_push` / `multi_deploy`.
 - **`blobs_and_manifests`** (default) — layers, config, and manifest(s)/tags are
   all pushed at build time. The image exists in the registry as soon as the build
   finishes; no separate push step is required.
@@ -261,8 +262,8 @@ Two content modes are available, selected with `push_at_build_time_content`:
 The two content modes are illustrated below (see [Modes in detail](#modes-in-detail)
 for the reasoning behind each).
 
-**`blobs`** — layer blobs are pushed from the build cluster at build time; the config
-and manifest are pushed afterwards:
+**`blobs`** — all image blobs (layers and the config) are pushed from the build
+cluster at build time; the manifest(s)/tags are pushed afterwards:
 
 ![Push at build time (blobs)](visuals/push-at-build-time-blobs-light.svg#gh-light-mode-only)
 ![Push at build time (blobs)](visuals/push-at-build-time-blobs-dark.svg#gh-dark-mode-only)
@@ -283,14 +284,14 @@ This is especially valuable for large images and high-fan-out CI.
 ### Modes in detail
 
 #### Blobs at build time, manifest afterwards (`blobs`)
-Pair this mode with the [lazy push strategy](#lazy-push). Because the layer blobs
-are already uploaded at build time, the follow-up `image_push` / `multi_deploy`
-only has to write the config and manifest — and with the lazy strategy the layer
-tarballs are never materialized on, or downloaded to, the machine running Bazel.
-The net effect: layers are uploaded once, in parallel, from the build cluster, and
-Bazel never touches layer bytes.
+Pair this mode with the [lazy push strategy](#lazy-push). Because every blob (all
+layers and the config) is already uploaded at build time, the follow-up
+`image_push` / `multi_deploy` only has to write the manifest — and with the lazy
+strategy the layer tarballs are never materialized on, or downloaded to, the
+machine running Bazel. The net effect: blobs are uploaded once, in parallel, from
+the build cluster, and Bazel never touches layer bytes.
 
-Since the layers are already in the registry, tell the follow-up push to reference
+Since the blobs are already in the registry, tell the follow-up push to reference
 them instead of re-uploading:
 
 ```bash
@@ -303,7 +304,12 @@ common --@rules_img//img/settings:forbid_layer_push=enabled
 
 Optionally push the blobs to a shared staging repository and have the manifest push
 cross-mount them into each image's real repository with
-`--@rules_img//img/settings:push_at_build_time_repository=<repo>`.
+`--@rules_img//img/settings:push_at_build_time_blob_repository=<repo>`. In
+`blobs_and_manifests` mode you can additionally stage the manifests themselves in a
+separate repository with
+`--@rules_img//img/settings:push_at_build_time_manifest_repository=<repo>`; this
+only redirects where the build-time manifest push writes the manifest(s) and config
+— the layer blobs are still cross-mounted from the blob repository.
 
 Registries expose a blob to any repository the caller can read, so the manifest push
 does not have to re-upload the layers it finds in the staging repository — it
@@ -317,11 +323,11 @@ This split is also a good fit for **multi-tenant** setups, because blob uploads 
 manifest/tag writes use *different* credentials. In most cases it is acceptable to
 hand every user of the remote execution cluster a shared machine account that may
 *upload* blobs (`HEAD` / `POST` / `PUT` to `/v2/.../blobs/`) but may not read
-existing blobs or write manifests. Any user can then upload layers at build time
-with that restricted machine account, while the config, manifest, and tags are
-written afterwards with the individual (local) Bazel user's own credentials. A
-leaked or misused build-action credential can then only add blobs — it cannot read
-other tenants' layers or publish images under their tags.
+existing blobs or write manifests. Any user can then upload every image blob (all
+layers and the config) at build time with that restricted machine account, while
+the manifest and tags are written afterwards with the individual (local) Bazel
+user's own credentials. A leaked or misused build-action credential can then only
+add blobs — it cannot read other tenants' layers or publish images under their tags.
 
 #### Everything at build time (`blobs_and_manifests`)
 The image is fully pushed by the time the build action finishes — the simplest to
@@ -361,7 +367,7 @@ pulls (`layer_handling`), plus write access:
 # green; "enabled" fails the build if a push fails; "disabled" (default) is off.
 common --@rules_img//img/settings:push_at_build_time=enabled
 
-# Choose what to push: "blobs" (layers only) or "blobs_and_manifests" (default).
+# Choose what to push: "blobs" (all layers and the config) or "blobs_and_manifests" (default).
 common --@rules_img//img/settings:push_at_build_time_content=blobs_and_manifests
 ```
 

--- a/img/private/index.bzl
+++ b/img/private/index.bzl
@@ -220,6 +220,7 @@ def _image_index_impl(ctx):
         allow_manifest_tags = True,
         push_at_build_time_mode = push_at_build_time.mode,
         push_at_build_time_content = push_at_build_time.content,
+        push_at_build_time_manifest_repository = push_at_build_time.manifest_repository,
         push_at_build_time_gateway = push_at_build_time.gateway,
         push_at_build_time_push_gateway = push_at_build_time.push_gateway,
         push_at_build_time_pull_gateway = push_at_build_time.pull_gateway,

--- a/img/private/manifest.bzl
+++ b/img/private/manifest.bzl
@@ -599,6 +599,7 @@ def _image_manifest_impl(ctx):
         allow_manifest_tags = False,
         push_at_build_time_mode = push_at_build_time.mode,
         push_at_build_time_content = push_at_build_time.content,
+        push_at_build_time_manifest_repository = push_at_build_time.manifest_repository,
         push_at_build_time_gateway = push_at_build_time.gateway,
         push_at_build_time_push_gateway = push_at_build_time.push_gateway,
         push_at_build_time_pull_gateway = push_at_build_time.pull_gateway,

--- a/img/private/providers/push_at_build_time_settings_info.bzl
+++ b/img/private/providers/push_at_build_time_settings_info.bzl
@@ -7,6 +7,7 @@ Collection of active push-at-build-time settings.
 FIELDS = dict(
     mode = "One of 'disabled', 'best_effort', or 'enabled'.",
     content = "One of 'blobs' or 'blobs_and_manifests'.",
+    manifest_repository = "Repository the build-time manifest push (content='blobs_and_manifests') uploads manifest(s)/index and config to instead of the image's real repository, or '' to use the real repository. Does not affect blob cross-mounting.",
     gateway = "Shared OCI distribution gateway endpoint (IMG_REGISTRY_GATEWAY), or '' if unset. Fallback for both push and pull.",
     push_gateway = "Push OCI distribution gateway endpoint (IMG_REGISTRY_PUSH_GATEWAY), or '' if unset.",
     pull_gateway = "Pull OCI distribution gateway endpoint (IMG_REGISTRY_PULL_GATEWAY), or '' if unset.",

--- a/img/private/providers/push_config_info.bzl
+++ b/img/private/providers/push_config_info.bzl
@@ -21,7 +21,7 @@ FIELDS = dict(
     stamp_settings = "StampSettingInfo provider for stamp resolution.",
     tracks_content = "Bool: when True, expose the image digest to templates and re-stamp tags on content change.",
     signing = "struct(config_info, best_effort, targets) describing how to sign this push, or None.",
-    blob_repository = "When non-empty, the staging repository that layer blobs are pushed to and cross-mounted from. Empty means blobs go to the image's own repository.",
+    blob_repository = "When non-empty, the staging repository that image blobs are pushed to and cross-mounted from. At build time every blob (layers and config) is staged here; layers are cross-mounted into the image's real repository. Empty means blobs go to the image's own repository.",
     forbid_layer_push = "Bool: when True, `img deploy` refuses to upload layer blob bytes (layers must be cross-mounted or already present).",
 )
 

--- a/img/private/providers/push_settings_info.bzl
+++ b/img/private/providers/push_settings_info.bzl
@@ -12,7 +12,7 @@ FIELDS = dict(
     credential_helper_oci_registry = "Credential helper used only for OCI registry operations (push, tag). Takes precedence over credential_helper for registry auth. Uses $IMG_CREDENTIAL_HELPER_OCI_REGISTRY env var if not set. See docs/credential-helpers.md.",
     credential_helper_remote_cache = "Credential helper used only to authenticate gRPC calls to the remote cache / remote execution API. Takes precedence over credential_helper for those calls. Uses $IMG_CREDENTIAL_HELPER_REMOTE_CACHE env var if not set. See docs/credential-helpers.md.",
     cross_mount = "Cross-mount configuration. Either 'same_registry', 'cross_registry' or 'disabled'.",
-    blob_repository = "When non-empty, the staging repository that layer blobs are pushed to and cross-mounted from when pushing manifests. Empty means blobs go to the image's own repository.",
+    blob_repository = "When non-empty, the staging repository that image blobs are pushed to and cross-mounted from when pushing manifests. At build time every blob (layers and config) is staged here; layers are cross-mounted into the image's real repository. Empty means blobs go to the image's own repository.",
     forbid_layer_push = "Bool: when True, `img deploy` refuses to upload layer blob bytes (layers must be cross-mounted or already present).",
 )
 

--- a/img/private/push.bzl
+++ b/img/private/push.bzl
@@ -204,6 +204,7 @@ def _image_push_impl(ctx):
             mode = push_at_build_time.mode,
             content = push_at_build_time.content,
             blob_repository = ctx.attr._push_settings[PushSettingsInfo].blob_repository,
+            manifest_repository = push_at_build_time.manifest_repository,
             gateway = push_at_build_time.gateway,
             push_gateway = push_at_build_time.push_gateway,
             pull_gateway = push_at_build_time.pull_gateway,

--- a/img/private/push_metadata.bzl
+++ b/img/private/push_metadata.bzl
@@ -460,18 +460,22 @@ def build_time_push_actions(
         mode,
         content,
         blob_repository,
+        manifest_repository,
         gateway,
         push_gateway,
         pull_gateway,
         pull_info):
     """Create the PushImage validation actions for one push operation.
 
-    Emits one action per layer (mnemonic PushImage) that pushes a single blob to
+    Emits one action per blob (mnemonic PushImage) that pushes a single blob to
     the blob target repository (the staging repository if blob_repository is set,
     else the operation's own repository) and records where it landed in a JSON
-    result. When content == "blobs_and_manifests", also emits one action that
-    pushes the config + manifest(s), depending on all per-layer results so it runs
-    after them and mounts the layers from where they were pushed.
+    result: one action per layer, plus one per manifest for the config blob. The
+    config actions run in both content modes, so after a build every blob of the
+    image (layers and config) is present in the blob target repository. When
+    content == "blobs_and_manifests", also emits one action that pushes the
+    config + manifest(s), depending on all per-layer results so it runs after them
+    and mounts the layers from where they were pushed.
 
     Shared by the push_specs path (`process_deploy_specs`) and the standalone
     `image_push` rule so both push at build time identically.
@@ -489,19 +493,24 @@ def build_time_push_actions(
       sparse_layout: sparse OCI layout File required when content is
         "blobs_and_manifests"; None is accepted only for content == "blobs".
       mode: push mode string passed to the img tool (e.g. "push").
-      content: either "blobs" (push layer blobs only) or "blobs_and_manifests"
-        (push blobs then config+manifest(s)).
-      blob_repository: optional staging repository to push blobs to before
-        mounting them into the final repository; None means push directly.
+      content: either "blobs" (push layer + config blobs only) or
+        "blobs_and_manifests" (push blobs then config+manifest(s)).
+      blob_repository: optional staging repository to push blobs (layers and
+        config) to before mounting them into the final repository; None means push
+        directly.
+      manifest_repository: optional repository to upload the manifest(s)/index and
+        config to instead of the operation's own repository, used only when
+        content == "blobs_and_manifests". Layer blobs are still cross-mounted from
+        blob_repository, so this does not change blob mounting.
       gateway: default registry gateway for both push and pull, or None.
       push_gateway: push-specific registry gateway override, or None.
       pull_gateway: pull-specific registry gateway override, or None.
       pull_info: PullInfo used when computing the manifest push metadata.
 
     Returns:
-      List of Files to place in the `_validation` output group: the per-layer
-      result JSONs when content == "blobs", or the single manifest marker file
-      when content == "blobs_and_manifests".
+      List of Files to place in the `_validation` output group: the per-layer and
+      per-config result JSONs, plus (when content == "blobs_and_manifests") the
+      single manifest marker file.
     """
     img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
     tool = img_toolchain_info.tool_exe
@@ -558,8 +567,41 @@ def build_time_push_actions(
             ctx.actions.run(**blob_run_kwargs)
             layer_results.append(result)
 
+    # Push each manifest's config blob to the same blob target as the layers (one
+    # action per config). This runs in both content modes, so a "blobs"-mode build
+    # leaves every blob of the image -- layers and config -- in the blob target
+    # repository, and a later manifest push (here or via `bazel run`) only has to
+    # write manifests. The config blob has no standalone descriptor file, so `push
+    # blob` derives the descriptor by hashing the config file (which is exactly the
+    # content the manifest's config descriptor addresses).
+    config_results = []
+    for (mi, manifest) in manifests:
+        config_result = ctx.actions.declare_file("{}.config.{}.json".format(prefix, mi))
+        config_args = ctx.actions.args()
+        config_args.add("push")
+        config_args.add("blob")
+        config_args.add("--configuration-file", configuration_json.path)
+        config_args.add("--blob", manifest.config.path)
+        if blob_repository:
+            config_args.add("--blob-repository", blob_repository)
+        config_args.add("--mode", mode)
+        config_args.add("--output", config_result.path)
+        config_run_kwargs = dict(
+            inputs = [configuration_json, manifest.config],
+            outputs = [config_result],
+            executable = tool,
+            arguments = [config_args],
+            mnemonic = "PushImage",
+            execution_requirements = exec_requirements,
+            progress_message = "Pushing config blob %s (manifest %d)" % (ctx.label, mi),
+        )
+        if gateway_env:
+            config_run_kwargs["env"] = gateway_env
+        ctx.actions.run(**config_run_kwargs)
+        config_results.append(config_result)
+
     if content != "blobs_and_manifests":
-        return layer_results
+        return layer_results + config_results
 
     if sparse_layout == None:
         fail(("push_at_build_time with content='blobs_and_manifests' needs the image's " +
@@ -591,6 +633,8 @@ def build_time_push_actions(
     args.add("manifest")
     args.add("--request-file", deploy_metadata.path)
     args.add("--oci-layout", sparse_layout.path)
+    if manifest_repository:
+        args.add("--manifest-repository", manifest_repository)
     args.add("--mode", mode)
     args.add("--marker", marker.path)
     args.add_all(layer_results, before_each = "--layer-result")
@@ -606,7 +650,7 @@ def build_time_push_actions(
     if gateway_env:
         manifest_run_kwargs["env"] = gateway_env
     ctx.actions.run(**manifest_run_kwargs)
-    return [marker]
+    return [marker] + config_results
 
 def process_deploy_specs(
         ctx,
@@ -620,6 +664,7 @@ def process_deploy_specs(
         allow_manifest_tags,
         push_at_build_time_mode = "disabled",
         push_at_build_time_content = "blobs_and_manifests",
+        push_at_build_time_manifest_repository = "",
         push_at_build_time_gateway = "",
         push_at_build_time_push_gateway = "",
         push_at_build_time_pull_gateway = "",
@@ -639,6 +684,7 @@ def process_deploy_specs(
             not 'disabled' and push_specs are present, PushImage validation actions
             are emitted for each push spec.
         push_at_build_time_content: One of 'blobs', 'blobs_and_manifests'.
+        push_at_build_time_manifest_repository: Repository the build-time manifest push (content='blobs_and_manifests') uploads manifest(s)/index and config to instead of the operation's own repository, or ''. Does not affect blob cross-mounting.
         push_at_build_time_gateway: Shared registry gateway endpoint (IMG_REGISTRY_GATEWAY) for the build-time push actions, or ''.
         push_at_build_time_push_gateway: Push registry gateway endpoint (IMG_REGISTRY_PUSH_GATEWAY) for the build-time push actions, or ''.
         push_at_build_time_pull_gateway: Pull registry gateway endpoint (IMG_REGISTRY_PULL_GATEWAY) for the build-time push actions, or ''.
@@ -746,6 +792,7 @@ def process_deploy_specs(
                 mode = push_at_build_time_mode,
                 content = push_at_build_time_content,
                 blob_repository = push_config.blob_repository,
+                manifest_repository = push_at_build_time_manifest_repository,
                 gateway = push_at_build_time_gateway,
                 push_gateway = push_at_build_time_push_gateway,
                 pull_gateway = push_at_build_time_pull_gateway,

--- a/img/private/settings/push_at_build_time.bzl
+++ b/img/private/settings/push_at_build_time.bzl
@@ -7,6 +7,7 @@ def _push_at_build_time_settings_impl(ctx):
     return [PushAtBuildTimeSettingsInfo(
         mode = ctx.attr._mode[BuildSettingInfo].value,
         content = ctx.attr._content[BuildSettingInfo].value,
+        manifest_repository = ctx.attr._manifest_repository[BuildSettingInfo].value,
         gateway = ctx.attr._gateway[BuildSettingInfo].value,
         push_gateway = ctx.attr._push_gateway[BuildSettingInfo].value,
         pull_gateway = ctx.attr._pull_gateway[BuildSettingInfo].value,
@@ -21,6 +22,10 @@ push_at_build_time_settings = rule(
         ),
         "_content": attr.label(
             default = Label("//img/settings:push_at_build_time_content"),
+            providers = [BuildSettingInfo],
+        ),
+        "_manifest_repository": attr.label(
+            default = Label("//img/settings:push_at_build_time_manifest_repository"),
             providers = [BuildSettingInfo],
         ),
         "_gateway": attr.label(

--- a/img/private/settings/settings.bzl
+++ b/img/private/settings/settings.bzl
@@ -58,7 +58,7 @@ push_settings = rule(
             providers = [BuildSettingInfo],
         ),
         "_blob_repository": attr.label(
-            default = Label("//img/settings:push_at_build_time_repository"),
+            default = Label("//img/settings:push_at_build_time_blob_repository"),
             providers = [BuildSettingInfo],
         ),
         "_forbid_layer_push": attr.label(

--- a/img/settings/BUILD.bazel
+++ b/img/settings/BUILD.bazel
@@ -275,12 +275,23 @@ string_flag(
     visibility = ["//visibility:public"],
 )
 
-# When non-empty, layer blobs are pushed to this repository (a "staging"
-# repository within the destination registry) and cross-mounted from there when
-# the manifest is pushed to its real repository. Applies to both push-at-build-time
-# and `bazel run` pushes.
+# When non-empty, every image blob (all layers and the config) is pushed to this
+# repository (a "staging" repository within the destination registry) and
+# cross-mounted from there when the manifest is pushed to its real repository.
+# Applies to both push-at-build-time and `bazel run` pushes.
 string_flag(
-    name = "push_at_build_time_repository",
+    name = "push_at_build_time_blob_repository",
+    build_setting_default = "",
+    visibility = ["//visibility:public"],
+)
+
+# When non-empty, the push-at-build-time manifest push (content=blobs_and_manifests)
+# uploads the manifest(s)/index (and, directly, the config) to this repository
+# instead of the image's real repository. This only redirects where manifests are
+# written at build time; it does NOT change where layer blobs are mounted from
+# (that is push_at_build_time_blob_repository), since manifests are not cross-mounted.
+string_flag(
+    name = "push_at_build_time_manifest_repository",
     build_setting_default = "",
     visibility = ["//visibility:public"],
 )

--- a/img_tool/cmd/deploymetadata/merge.go
+++ b/img_tool/cmd/deploymetadata/merge.go
@@ -176,7 +176,7 @@ func MergeDeployManifests(ctx context.Context, inputPaths []string, outputPath s
 		settings := deployManifest.Settings
 		if settings.BlobRepository != "" {
 			if blobRepository != "" && blobRepository != settings.BlobRepository {
-				return fmt.Errorf("conflicting blob_repository across merged deploy manifests: %q vs %q (all merged operations must share one push_at_build_time_repository)", blobRepository, settings.BlobRepository)
+				return fmt.Errorf("conflicting blob_repository across merged deploy manifests: %q vs %q (all merged operations must share one push_at_build_time_blob_repository)", blobRepository, settings.BlobRepository)
 			}
 			blobRepository = settings.BlobRepository
 		}

--- a/img_tool/cmd/push/blob.go
+++ b/img_tool/cmd/push/blob.go
@@ -2,6 +2,7 @@ package pushcmd
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"flag"
@@ -52,30 +53,32 @@ func blobProcess(ctx context.Context, args []string) {
 		casDir            string
 		sources           stringSliceFlag
 		blobRepository    string
+		mediaType         string
 		mode              string
 		outputPath        string
 	)
 
 	flagSet := flag.NewFlagSet("push blob", flag.ContinueOnError)
 	flagSet.StringVar(&configurationPath, "configuration-file", "", "Path to the configuration file ({registry, repository}). Required.")
-	flagSet.StringVar(&metadataPath, "metadata", "", "Path to the layer metadata JSON (digest/mediaType/size). Required.")
-	flagSet.StringVar(&blobPath, "blob", "", "Path to the materialized layer blob to push.")
+	flagSet.StringVar(&metadataPath, "metadata", "", "Path to the blob metadata JSON (digest/mediaType/size). Optional: when omitted, the descriptor is derived by hashing --blob (used for the config blob, whose descriptor has no standalone file).")
+	flagSet.StringVar(&blobPath, "blob", "", "Path to the materialized blob (layer or config) to push.")
 	flagSet.StringVar(&compactStreamPath, "compact-stream", "", "Path to the layer's compact stream (.cstream) to reconstruct and push.")
 	flagSet.StringVar(&casDir, "cas-dir", "", "Content-addressed input directory (.inputfilecas) for compact-stream reconstruction.")
 	flagSet.Var(&sources, "source", "Upstream source as registry/repository to stream a shallow layer from (can be repeated).")
 	flagSet.StringVar(&blobRepository, "blob-repository", "", "Repository to push the blob to instead of the configuration repository.")
+	flagSet.StringVar(&mediaType, "media-type", "", "Media type recorded in the result when the descriptor is derived from --blob (no --metadata). Informational; unused for the content-addressed upload.")
 	flagSet.StringVar(&mode, "mode", "enabled", "Failure mode: 'best_effort' (log, don't fail build) or 'enabled' (fail build).")
 	flagSet.StringVar(&outputPath, "output", "", "Path to write the JSON result describing where the blob landed. Required.")
 
 	if err := flagSet.Parse(args); err != nil {
 		os.Exit(1)
 	}
-	if configurationPath == "" || metadataPath == "" || outputPath == "" {
-		fmt.Fprintln(os.Stderr, "Error: --configuration-file, --metadata and --output are required")
+	if configurationPath == "" || outputPath == "" {
+		fmt.Fprintln(os.Stderr, "Error: --configuration-file and --output are required")
 		os.Exit(1)
 	}
 
-	desc, err := readDescriptor(metadataPath)
+	desc, err := resolveDescriptor(metadataPath, blobPath, mediaType)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -185,6 +188,36 @@ func layerForBlob(ctx context.Context, desc api.Descriptor, blobPath, compactStr
 	default:
 		return nil, fmt.Errorf("no blob source provided for %s (need --blob, --compact-stream, or --source)", desc.Digest)
 	}
+}
+
+// resolveDescriptor returns the blob's descriptor. When metadataPath is set it is
+// read from that file (the layer path, where a standalone descriptor exists).
+// Otherwise the descriptor is derived by hashing blobPath: this is used for the
+// config blob, which has no standalone metadata file. The blob is content-addressed,
+// so sha256(blobPath) is exactly the digest the manifest references; mediaType is
+// recorded verbatim (informational — it is not used for the upload itself).
+func resolveDescriptor(metadataPath, blobPath, mediaType string) (api.Descriptor, error) {
+	if metadataPath != "" {
+		return readDescriptor(metadataPath)
+	}
+	if blobPath == "" {
+		return api.Descriptor{}, fmt.Errorf("either --metadata or --blob is required to determine the blob descriptor")
+	}
+	f, err := os.Open(blobPath)
+	if err != nil {
+		return api.Descriptor{}, fmt.Errorf("opening blob %s: %w", blobPath, err)
+	}
+	defer f.Close()
+	hasher := sha256.New()
+	size, err := io.Copy(hasher, f)
+	if err != nil {
+		return api.Descriptor{}, fmt.Errorf("hashing blob %s: %w", blobPath, err)
+	}
+	return api.Descriptor{
+		MediaType: mediaType,
+		Digest:    fmt.Sprintf("sha256:%x", hasher.Sum(nil)),
+		Size:      size,
+	}, nil
 }
 
 func readDescriptor(path string) (api.Descriptor, error) {

--- a/img_tool/cmd/push/blob_test.go
+++ b/img_tool/cmd/push/blob_test.go
@@ -143,6 +143,38 @@ func TestPushBlobUploadsToStagingRepository(t *testing.T) {
 	}
 }
 
+// TestResolveDescriptorFromBlob verifies that, when no metadata file is provided,
+// resolveDescriptor derives the descriptor by hashing the blob file. This is how
+// the config blob (which has no standalone descriptor file) is pushed at build
+// time: sha256(config file) is exactly the digest the manifest's config descriptor
+// references.
+func TestResolveDescriptorFromBlob(t *testing.T) {
+	dir := t.TempDir()
+	blobPath, want := writeBlobFile(t, dir)
+
+	got, err := resolveDescriptor("", blobPath, "application/vnd.oci.image.config.v1+json")
+	if err != nil {
+		t.Fatalf("resolveDescriptor: %v", err)
+	}
+	if got.Digest != want.Digest {
+		t.Errorf("Digest = %q, want %q", got.Digest, want.Digest)
+	}
+	if got.Size != want.Size {
+		t.Errorf("Size = %d, want %d", got.Size, want.Size)
+	}
+	if got.MediaType != "application/vnd.oci.image.config.v1+json" {
+		t.Errorf("MediaType = %q, want the value passed in", got.MediaType)
+	}
+}
+
+// TestResolveDescriptorRequiresSource verifies resolveDescriptor errors when it has
+// neither a metadata file nor a blob to hash.
+func TestResolveDescriptorRequiresSource(t *testing.T) {
+	if _, err := resolveDescriptor("", "", ""); err == nil {
+		t.Error("expected an error when neither --metadata nor --blob is provided")
+	}
+}
+
 func anyHasPrefix(items []string, prefix string) bool {
 	for _, item := range items {
 		if strings.HasPrefix(item, prefix) {

--- a/img_tool/cmd/push/manifest.go
+++ b/img_tool/cmd/push/manifest.go
@@ -18,18 +18,20 @@ import (
 
 func manifestProcess(ctx context.Context, args []string) {
 	var (
-		requestFile  string
-		ociLayouts   stringSliceFlag
-		layerResults stringSliceFlag
-		mode         string
-		markerPath   string
-		jobs         int
+		requestFile        string
+		ociLayouts         stringSliceFlag
+		layerResults       stringSliceFlag
+		manifestRepository string
+		mode               string
+		markerPath         string
+		jobs               int
 	)
 
 	flagSet := flag.NewFlagSet("push manifest", flag.ContinueOnError)
 	flagSet.StringVar(&requestFile, "request-file", "", "Push-only deploy manifest JSON. Required.")
 	flagSet.Var(&ociLayouts, "oci-layout", "Path to a (sparse) OCI layout with the manifest(s) + config (can be repeated). Required.")
 	flagSet.Var(&layerResults, "layer-result", "Path to a JSON result from `push blob` recording a layer's location for cross-mounting (can be repeated).")
+	flagSet.StringVar(&manifestRepository, "manifest-repository", "", "Repository to upload the manifest(s)/index and config to instead of the operation's own repository. Layer blobs are still cross-mounted from where `push blob` put them (this does not change blob mounting).")
 	flagSet.StringVar(&mode, "mode", "enabled", "Failure mode: 'best_effort' (log, don't fail build) or 'enabled' (fail build).")
 	flagSet.StringVar(&markerPath, "marker", "", "Path to the marker file to write on success. Required.")
 	flagSet.IntVar(&jobs, "jobs", 16, "Maximum number of parallel push operations.")
@@ -42,10 +44,10 @@ func manifestProcess(ctx context.Context, args []string) {
 		os.Exit(1)
 	}
 
-	finish(mode, markerPath, nil, pushManifest(ctx, requestFile, []string(ociLayouts), []string(layerResults), jobs))
+	finish(mode, markerPath, nil, pushManifest(ctx, requestFile, []string(ociLayouts), []string(layerResults), manifestRepository, jobs))
 }
 
-func pushManifest(ctx context.Context, requestFile string, ociLayouts, layerResults []string, jobs int) error {
+func pushManifest(ctx context.Context, requestFile string, ociLayouts, layerResults []string, manifestRepository string, jobs int) error {
 	raw, err := os.ReadFile(requestFile)
 	if err != nil {
 		return fmt.Errorf("reading request file %s: %w", requestFile, err)
@@ -96,10 +98,17 @@ func pushManifest(ctx context.Context, requestFile string, ociLayouts, layerResu
 		return fmt.Errorf("no push operations found in request file")
 	}
 
-	uploader := push.NewBuilder(vfs).
+	uploaderBuilder := push.NewBuilder(vfs).
 		WithJobs(jobs).
-		WithRemoteOptions(registry.WithAuthFromMultiKeychain(), remote.WithTransport(pushTransport)).
-		Build()
+		WithRemoteOptions(registry.WithAuthFromMultiKeychain(), remote.WithTransport(pushTransport))
+	// Redirect the manifest/index (and the config uploaded alongside it) to the
+	// manifest-staging repository when configured. Layer blobs are unaffected: they
+	// are cross-mounted from wherever `push blob` put them (recorded via the
+	// per-layer cross-mount sources above), not re-uploaded into this repository.
+	if manifestRepository != "" {
+		uploaderBuilder = uploaderBuilder.WithOverrideRepository(manifestRepository)
+	}
+	uploader := uploaderBuilder.Build()
 	if _, err := uploader.PushAll(ctx, pushOps, req.Settings.PushStrategy); err != nil {
 		return fmt.Errorf("pushing manifests: %w", err)
 	}


### PR DESCRIPTION
Builds on #649 (push at build time).

## What

- **Rename** `--@rules_img//img/settings:push_at_build_time_repository` → `push_at_build_time_blob_repository`. It configures the staging repository for image blobs (unchanged behavior, clearer name).
- **Add** `--@rules_img//img/settings:push_at_build_time_manifest_repository`. When set, the build-time manifest push (`push_at_build_time_content=blobs_and_manifests`) uploads the manifest(s)/index and config to this repository instead of the image's real repository. It does **not** change where layer blobs are cross-mounted from (that stays `push_at_build_time_blob_repository`), since manifests aren't mounted. It is build-time-only and is not recorded in the deploy manifest, so `bazel run` deploys are unaffected.
- **Push every image blob at build time, including the config.** `build_time_push_actions` now emits one extra `PushImage` (`push blob`) action per manifest for the config blob, next to the per-layer actions. It runs in **both** content modes (`blobs` and `blobs_and_manifests`), so after a build every blob of the image (layers + config) is present in the blob target repository.

## Implementation notes

- The config blob has no standalone descriptor file, so `img push blob` now derives the descriptor by hashing `--blob` when `--metadata` is omitted (`sha256(config)` is exactly the digest the manifest's config descriptor references). `--metadata` remains used for layers.
- `img push manifest` gains `--manifest-repository`, wired to the uploader's `WithOverrideRepository` so only the manifest/config PUT target changes; layers still cross-mount from the blob repository via `--layer-result`.
- The renamed flag, the two new flags, and the config-in-both-modes behavior are reflected in the docs (README, push-strategies, authenticating-build-actions) and the internal provider/rule docstrings.

## Testing

- `go build` / `go vet` / `gofmt` / `go test ./cmd/push/... ./cmd/deploymetadata/... ./pkg/deployvfs/...` pass; added unit tests for the new descriptor-derivation path.
- `bazel build --nobuild` analyzes both `image_push` and `image_manifest`/`image_index` with all push-at-build-time settings enabled — the new config + manifest actions declare cleanly.

> Note: the `visuals/push-at-build-time-*.svg` diagrams still show the config being pushed after the build in `blobs` mode; the surrounding prose was updated, but the Excalidraw sources were not regenerated.
