### PR TITLE
fix(deploy): annotate untagged images with <registry>/<repository>

### DIFF
--- a/img_tool/cmd/deploy/sink.go
+++ b/img_tool/cmd/deploy/sink.go
@@ -110,6 +110,28 @@ type sinkImage struct {
 	Registry   string
 	Repository string
 	Root       resolvedRoot
+	// RepoRefFallback, when set, allows the annotated sinks to fall back to the
+	// bare "<registry>/<repository>" reference for this image's index.json
+	// annotations when it has no tags. Set for the primary image being
+	// deployed; left unset for referrer manifests (e.g. signatures), which must
+	// not be surfaced under the subject's repository name.
+	RepoRefFallback bool
+}
+
+// indexAnnotationRefs returns the reference names used to annotate an image's
+// index.json descriptors (io.containerd.image.name, org.opencontainers.image.ref.name,
+// ...). It is normally the full tagged references. When an image opts into
+// RepoRefFallback and has no tags but its destination registry/repository is
+// known (a digest-only push), it falls back to the bare "<registry>/<repository>"
+// reference so tooling can still recover the image name instead of only its digest.
+func indexAnnotationRefs(img sinkImage) []string {
+	if len(img.Refs) > 0 {
+		return img.Refs
+	}
+	if img.RepoRefFallback && img.Registry != "" && img.Repository != "" {
+		return []string{img.Registry + "/" + img.Repository}
+	}
+	return img.Refs
 }
 
 // sinkRouteOptions carries the deploy-time overrides and extra tags applied
@@ -130,7 +152,7 @@ func routeToSink(ctx context.Context, s sink, vfs *deployvfs.VFS, pushOps []api.
 		if err != nil {
 			return err
 		}
-		if err := s.AddImage(ctx, sinkImage{Refs: refs, Registry: registry, Repository: repository, Root: root}); err != nil {
+		if err := s.AddImage(ctx, sinkImage{Refs: refs, Registry: registry, Repository: repository, Root: root, RepoRefFallback: true}); err != nil {
 			return err
 		}
 		written = append(written, refs...)
@@ -319,7 +341,7 @@ func (s *tarSink) AddImage(ctx context.Context, img sinkImage) error {
 		MediaType:    root.MediaType,
 		ArtifactType: root.ArtifactType,
 		IsIndex:      root.IsIndex,
-		OCITags:      img.Refs,
+		OCITags:      indexAnnotationRefs(img),
 		Children:     root.Children,
 		Platform:     root.Platform,
 	})
@@ -375,11 +397,12 @@ func newOCIDirSink(dir string) (*ociDirSink, error) {
 
 func (s *ociDirSink) AddImage(ctx context.Context, img sinkImage) error {
 	root := img.Root
+	refs := indexAnnotationRefs(img)
 	if !root.IsIndex {
 		if len(root.Children) == 0 {
 			return fmt.Errorf("manifest root has no image manifest")
 		}
-		return s.e.AddManifest(ctx, root.Children[0], img.Refs...)
+		return s.e.AddManifest(ctx, root.Children[0], refs...)
 	}
 	for i := range root.Children {
 		if err := s.e.AddManifestBlobs(ctx, root.Children[i]); err != nil {
@@ -393,7 +416,7 @@ func (s *ociDirSink) AddImage(ctx context.Context, img sinkImage) error {
 	if err := s.e.AddBlob(ctx, indexHash, ocilayout.BlobFromBytes(root.RootData)); err != nil {
 		return err
 	}
-	for _, d := range ocilayout.DescriptorsForTags(img.Refs, root.MediaType, root.RootData, indexHash, "", false) {
+	for _, d := range ocilayout.DescriptorsForTags(refs, root.MediaType, root.RootData, indexHash, "", false) {
 		if err := s.e.AddIndexEntry(d); err != nil {
 			return err
 		}

--- a/img_tool/cmd/deploy/sink_test.go
+++ b/img_tool/cmd/deploy/sink_test.go
@@ -129,6 +129,30 @@ func tarNames(t *testing.T, data []byte) map[string]bool {
 	return names
 }
 
+// tarFile returns the contents of a single named entry in a tar.
+func tarFile(t *testing.T, data []byte, name string) []byte {
+	t.Helper()
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Name == name {
+			b, err := io.ReadAll(tr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return b
+		}
+	}
+	t.Fatalf("tar entry %q not found", name)
+	return nil
+}
+
 func TestOCITarSink(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "out.tar")
 	s, err := newSink(sinkOCITar, path)
@@ -178,6 +202,114 @@ func TestDockerSaveSink(t *testing.T) {
 	names := tarNames(t, data)
 	if !names["manifest.json"] {
 		t.Errorf("docker-save missing manifest.json")
+	}
+}
+
+// When an image has no tags but its destination registry/repository is known
+// (a digest-only push), the annotated sinks must still record the bare
+// "<registry>/<repository>" reference in the index descriptor annotations
+// rather than emitting a bare, annotation-free descriptor.
+func TestSinksAnnotateRepositoryWithoutTag(t *testing.T) {
+	const (
+		registry = "reg.example"
+		repo     = "team/foo"
+		wantRef  = registry + "/" + repo
+	)
+	assertRefName := func(t *testing.T, idxData []byte) {
+		t.Helper()
+		var idx registryv1.IndexManifest
+		if err := json.Unmarshal(idxData, &idx); err != nil {
+			t.Fatal(err)
+		}
+		if len(idx.Manifests) != 1 {
+			t.Fatalf("index.json manifests: got %d want 1", len(idx.Manifests))
+		}
+		ann := idx.Manifests[0].Annotations
+		for _, key := range []string{
+			"org.opencontainers.image.ref.name",
+			"io.containerd.image.name",
+			"com.apple.containerization.image.name",
+		} {
+			if ann[key] != wantRef {
+				t.Errorf("annotation %q = %q, want %q", key, ann[key], wantRef)
+			}
+		}
+	}
+	newImage := func() sinkImage {
+		return sinkImage{Registry: registry, Repository: repo, Root: testRoot("a"), RepoRefFallback: true}
+	}
+
+	for _, kind := range []sinkKind{sinkOCITar, sinkDockerSave} {
+		t.Run(map[sinkKind]string{sinkOCITar: "oci-tar", sinkDockerSave: "docker-save"}[kind], func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "out.tar")
+			s, err := newSink(kind, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := s.AddImage(context.Background(), newImage()); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.Close(); err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertRefName(t, tarFile(t, data, "index.json"))
+		})
+	}
+
+	t.Run("oci", func(t *testing.T) {
+		dir := t.TempDir()
+		s, err := newSink(sinkOCIDir, dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.AddImage(context.Background(), newImage()); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Close(); err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(filepath.Join(dir, "index.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertRefName(t, data)
+	})
+}
+
+// A referrer-style image (registry/repository set for placement but Refs empty
+// and RepoRefFallback unset, e.g. a signature manifest) must NOT be annotated
+// with the subject's repository name, or it would shadow the real image when a
+// tool selects by org.opencontainers.image.ref.name.
+func TestSinkReferrerWithoutTagStaysUnannotated(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.tar")
+	s, err := newSink(sinkDockerSave, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No Refs, no RepoRefFallback: exactly how signatureSinkImage is built.
+	if err := s.AddImage(context.Background(), sinkImage{Registry: "reg.example", Repository: "team/foo", Root: testRoot("a")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var idx registryv1.IndexManifest
+	if err := json.Unmarshal(tarFile(t, data, "index.json"), &idx); err != nil {
+		t.Fatal(err)
+	}
+	if len(idx.Manifests) != 1 {
+		t.Fatalf("index.json manifests: got %d want 1", len(idx.Manifests))
+	}
+	if ref := idx.Manifests[0].Annotations["org.opencontainers.image.ref.name"]; ref != "" {
+		t.Errorf("referrer descriptor got ref.name %q, want none", ref)
 	}
 }
 


### PR DESCRIPTION
The docker-save (and oci-tar/oci) sinks dropped the destination registry/repository when an image had no tags, so index.json emitted a bare descriptor with no annotations. Fall back to the bare "<registry>/<repository>" reference for the primary image's index annotations when it has no tags, gated behind a RepoRefFallback flag so signature referrer manifests are never surfaced under the subject's repository name.