### PR TITLE
feat(auth): support inline docker config via IMG_DOCKER_CONFIG_INLINE

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,9 +415,10 @@ For more details on working with platforms, architecture variants, and building 
 | Priority | Keychain | Registries | Credential Source |
 |----------|----------|------------|-------------------|
 | 1 | **Bazel credential helper** | Any | `--@rules_img//img/settings:credential_helper_oci_registry` or `credential_helper`; `IMG_CREDENTIAL_HELPER_OCI_REGISTRY` or `IMG_CREDENTIAL_HELPER` env var |
-| 2 | **Docker / Podman config** | Any | `~/.docker/config.json`, `$DOCKER_CONFIG/config.json`, `${XDG_RUNTIME_DIR}/containers/auth.json` |
-| 3 | **Google** | `gcr.io`, `*.pkg.dev` | [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) (workload identity, `gcloud auth login`, service account keys) |
-| 4 | **Amazon ECR** | `*.dkr.ecr.*.amazonaws.com` | Ambient AWS credentials (env vars, `~/.aws/`, EC2/ECS instance roles). See [ECR credential helper docs](https://github.com/awslabs/amazon-ecr-credential-helper#usage). |
+| 2 | **Inline Docker config** | Any | `IMG_DOCKER_CONFIG_INLINE` env var (the JSON contents of a `config.json`). For injected secrets only — see [Authenticating Build Actions](docs/authenticating-build-actions.md#4-inline-docker-config-from-an-injected-environment-variable). |
+| 3 | **Docker / Podman config** | Any | `~/.docker/config.json`, `$DOCKER_CONFIG/config.json`, `${XDG_RUNTIME_DIR}/containers/auth.json` |
+| 4 | **Google** | `gcr.io`, `*.pkg.dev` | [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) (workload identity, `gcloud auth login`, service account keys) |
+| 5 | **Amazon ECR** | `*.dkr.ecr.*.amazonaws.com` | Ambient AWS credentials (env vars, `~/.aws/`, EC2/ECS instance roles). See [ECR credential helper docs](https://github.com/awslabs/amazon-ecr-credential-helper#usage). |
 
 The first keychain that returns credentials wins — subsequent keychains are not consulted.
 

--- a/docs/authenticating-build-actions.md
+++ b/docs/authenticating-build-actions.md
@@ -43,10 +43,15 @@ credentials with one keychain, tried in order:
 
 1. A **Bazel credential helper**, when `IMG_CREDENTIAL_HELPER` is set (see
    [Credential Helpers](credential-helpers.md)).
-2. The **Docker config** (honors `DOCKER_CONFIG`; `REGISTRY_AUTH_FILE` is used
+2. An **inline Docker config**, when `IMG_DOCKER_CONFIG_INLINE` holds the JSON
+   contents of a `config.json`. Resolved just like the Docker config below, but
+   from memory. Intended for secret-injection mechanisms only — see
+   [Option 4](#4-inline-docker-config-from-an-injected-environment-variable) and
+   the warning there.
+3. The **Docker config** (honors `DOCKER_CONFIG`; `REGISTRY_AUTH_FILE` is used
    inside build actions).
-3. **Google** — `google.Keychain` (Application Default Credentials / workload identity).
-4. **Amazon ECR** — the ambient AWS configuration.
+4. **Google** — `google.Keychain` (Application Default Credentials / workload identity).
+5. **Amazon ECR** — the ambient AWS configuration.
 
 Whatever option you pick below, the credentials it provides are consumed through
 this keychain.
@@ -205,6 +210,47 @@ a file in CI without starting the gateway with `--validate-policy --policy-file
 **Reloading.** Send the gateway process a `SIGHUP` to re-read the policy file
 without restarting or dropping connections. A reload that fails to parse or
 validate is logged and the previous policy is kept.
+
+### 4. Inline Docker config from an injected environment variable
+
+Set `IMG_DOCKER_CONFIG_INLINE` to the **JSON contents** of a Docker
+`config.json` (the same format as `~/.docker/config.json` — *not* a path to a
+file). rules_img resolves it exactly like the Docker config file, but entirely
+in memory, so it works on an executor that has no config file on disk. It is
+tried just before the on-disk Docker config, so an explicitly injected
+credential wins over whatever config file happens to exist.
+
+> **Not recommended for general use.** The value *is* the credential, so
+> anything that records your Bazel command line or an action's declared
+> environment will capture it. Never set it inline on the command line
+> (`IMG_DOCKER_CONFIG_INLINE=… bazel build …`), through `--action_env`, or via a
+> Bazel setting — it would leak into the build event stream (BES), action
+> metadata, logs, and the remote cache. Use it **only** with a mechanism that
+> injects the variable straight into the (remote) action's process, where the
+> value never appears in the Bazel invocation itself.
+
+The intended mechanism is a per-action secret store such as **BuildBuddy
+secrets** — encrypted, organization-scoped environment variables (encrypted
+client-side with a libsodium sealed box and decrypted only on demand). Save the
+`config.json` contents once as a secret named `IMG_DOCKER_CONFIG_INLINE`, then
+opt the target whose build actions push or pull in to it with the `env-secrets`
+execution property:
+
+```python
+exec_properties = {"env-secrets": "IMG_DOCKER_CONFIG_INLINE"},
+```
+
+The executor decrypts the secret and sets it in the action's environment at run
+time; the value is never baked into the action by Bazel and — unlike a plain
+environment variable — is not stored unencrypted in the action cache. See
+BuildBuddy's [Secrets documentation](https://www.buildbuddy.io/docs/secrets) for
+defining secrets and for the `env-secrets` / `include-secrets` execution
+properties. Other secret-injection systems that set an action's environment on
+the executor work the same way.
+
+Because the credentials flow through the shared keychain, no rules_img setting
+is involved: both lazy base-image pulls (`DownloadBlob`) and push-at-build-time
+actions pick the variable up automatically wherever the executor sets it.
 
 ## Setting up the gateway on Buildbarn
 

--- a/img_tool/MODULE.bazel
+++ b/img_tool/MODULE.bazel
@@ -35,6 +35,7 @@ use_repo(
     "com_github_containerd_containerd_api",
     "com_github_containerd_platforms",
     "com_github_containerd_stargz_snapshotter_estargz",
+    "com_github_docker_cli",
     "com_github_goccy_go_yaml",
     "com_github_google_go_containerregistry",
     "com_github_google_uuid",

--- a/img_tool/go.mod
+++ b/img_tool/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/containerd/containerd/api v1.11.1
 	github.com/containerd/platforms v1.0.0-rc.4
 	github.com/containerd/stargz-snapshotter/estargz v0.18.2
+	github.com/docker/cli v29.6.2+incompatible
 	github.com/goccy/go-yaml v1.19.2
 	github.com/google/go-containerregistry v0.21.7
 	github.com/google/uuid v1.6.0
@@ -53,7 +54,6 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/ttrpc v1.2.9 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/docker/cli v29.6.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.8 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/img_tool/pkg/auth/registry/BUILD.bazel
+++ b/img_tool/pkg/auth/registry/BUILD.bazel
@@ -2,13 +2,20 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "registry",
-    srcs = ["registry.go"],
+    srcs = [
+        "inline_config.go",
+        "registry.go",
+    ],
     importpath = "github.com/bazel-contrib/rules_img/img_tool/pkg/auth/registry",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/auth/credential",
         "@com_github_awslabs_amazon_ecr_credential_helper_ecr_login//:ecr-login",
+        "@com_github_docker_cli//cli/config",
+        "@com_github_docker_cli//cli/config/configfile",
+        "@com_github_docker_cli//cli/config/types",
         "@com_github_google_go_containerregistry//pkg/authn",
+        "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1/google",
         "@com_github_google_go_containerregistry//pkg/v1/remote",
     ],
@@ -17,7 +24,10 @@ go_library(
 go_test(
     name = "registry_test",
     size = "small",
-    srcs = ["registry_test.go"],
+    srcs = [
+        "inline_config_test.go",
+        "registry_test.go",
+    ],
     embed = [":registry"],
     deps = [
         "@com_github_google_go_containerregistry//pkg/name",

--- a/img_tool/pkg/auth/registry/inline_config.go
+++ b/img_tool/pkg/auth/registry/inline_config.go
@@ -1,0 +1,99 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/config/types"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+// EnvDockerConfigInline holds a Docker configuration document inline: its value
+// is the JSON contents of a `config.json` (the same format as
+// `~/.docker/config.json`), not a path to one.
+//
+// It is resolved exactly like the Docker config file keychain, but entirely in
+// memory, so it works in environments where no config file exists on disk.
+//
+// General use is discouraged. Passing it on a command line or through a Bazel
+// setting would leak the credentials into the build event stream, action
+// metadata, logs, and the remote cache. It is meant only for mechanisms that
+// inject the variable directly into a (potentially remote) action's process
+// environment — for example BuildBuddy secrets under remote execution. See
+// docs/authenticating-build-actions.md.
+const EnvDockerConfigInline = "IMG_DOCKER_CONFIG_INLINE"
+
+// inlineDockerConfigKeychain resolves registry credentials from a Docker config
+// JSON document held in memory rather than read from disk. It mirrors the
+// resolution semantics of [authn.DefaultKeychain] so an inline config behaves
+// like the equivalent file would.
+type inlineDockerConfigKeychain struct {
+	// mu guards resolution: configfile.GetAuthConfig lazily initializes internal
+	// maps, so concurrent resolves (e.g. a multi-arch index push) must serialize,
+	// matching authn.DefaultKeychain.
+	mu  sync.Mutex
+	cf  *configfile.ConfigFile
+	err error
+}
+
+// newInlineDockerConfigKeychain parses raw (the JSON contents of a Docker
+// config.json) once. A parse error is retained and surfaced from every Resolve
+// so a malformed value fails loudly instead of being silently ignored.
+func newInlineDockerConfigKeychain(raw string) *inlineDockerConfigKeychain {
+	cf, err := config.LoadFromReader(strings.NewReader(raw))
+	if err != nil {
+		return &inlineDockerConfigKeychain{err: fmt.Errorf("parsing %s: %w", EnvDockerConfigInline, err)}
+	}
+	return &inlineDockerConfigKeychain{cf: cf}
+}
+
+func (k *inlineDockerConfigKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	return k.ResolveContext(context.Background(), target)
+}
+
+func (k *inlineDockerConfigKeychain) ResolveContext(_ context.Context, target authn.Resource) (authn.Authenticator, error) {
+	if k.err != nil {
+		return nil, k.err
+	}
+
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	// Mirror authn.DefaultKeychain: try the full reference and then the bare
+	// registry, mapping Docker Hub to its historical config key.
+	var cfg, empty types.AuthConfig
+	for _, key := range []string{target.String(), target.RegistryStr()} {
+		if key == name.DefaultRegistry {
+			key = authn.DefaultAuthKey
+		}
+		var err error
+		cfg, err = k.cf.GetAuthConfig(key)
+		if err != nil {
+			return nil, err
+		}
+		// GetAuthConfig sets ServerAddress; clear it so the "is empty" test below
+		// works (see go-containerregistry#1510).
+		cfg.ServerAddress = ""
+		if cfg != empty {
+			break
+		}
+	}
+	if cfg == empty {
+		return authn.Anonymous, nil
+	}
+
+	return authn.FromConfig(authn.AuthConfig{
+		Username:      cfg.Username,
+		Password:      cfg.Password,
+		Auth:          cfg.Auth,
+		IdentityToken: cfg.IdentityToken,
+		RegistryToken: cfg.RegistryToken,
+	}), nil
+}
+
+var _ authn.Keychain = (*inlineDockerConfigKeychain)(nil)

--- a/img_tool/pkg/auth/registry/inline_config_test.go
+++ b/img_tool/pkg/auth/registry/inline_config_test.go
@@ -1,0 +1,133 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+// clearCredentialHelperEnv unsets the credential-helper variables so the tests
+// exercise the inline-config keychain without an ambient helper shadowing it.
+func clearCredentialHelperEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("IMG_CREDENTIAL_HELPER", "")
+	t.Setenv("IMG_CREDENTIAL_HELPER_OCI_REGISTRY", "")
+}
+
+func resolveAuth(t *testing.T, ref string) (username, password string) {
+	t.Helper()
+	parsed, err := name.ParseReference(ref)
+	if err != nil {
+		t.Fatalf("failed to parse registry reference: %v", err)
+	}
+	authenticator, err := keychainFromEnvironment().Resolve(parsed.Context().Registry)
+	if err != nil {
+		t.Fatalf("failed to resolve credentials: %v", err)
+	}
+	authConfig, err := authenticator.Authorization()
+	if err != nil {
+		t.Fatalf("failed to resolve auth config: %v", err)
+	}
+	return authConfig.Username, authConfig.Password
+}
+
+func TestKeychainFromEnvironmentUsesInlineDockerConfig(t *testing.T) {
+	clearCredentialHelperEnv(t)
+	// Ensure no on-disk Docker config can satisfy the lookup instead.
+	t.Setenv("DOCKER_CONFIG", t.TempDir())
+	t.Setenv(EnvDockerConfigInline, `{"auths":{"registry.example.com":{"auth":"dXNlcjpwYXNz"}}}`)
+
+	if user, pass := resolveAuth(t, "registry.example.com/project/image:tag"); user != "user" || pass != "pass" {
+		t.Fatalf("expected user/pass from inline docker config, got %q/%q", user, pass)
+	}
+}
+
+func TestInlineDockerConfigTakesPrecedenceOverDockerConfigFile(t *testing.T) {
+	clearCredentialHelperEnv(t)
+
+	dockerConfigDir := t.TempDir()
+	fileConfig := []byte(`{"auths":{"registry.example.com":{"auth":"ZmlsZS11c2VyOmZpbGUtcGFzcw=="}}}`)
+	if err := os.WriteFile(filepath.Join(dockerConfigDir, "config.json"), fileConfig, 0o600); err != nil {
+		t.Fatalf("failed to write Docker config: %v", err)
+	}
+	t.Setenv("DOCKER_CONFIG", dockerConfigDir)
+	t.Setenv(EnvDockerConfigInline, `{"auths":{"registry.example.com":{"auth":"aW5saW5lLXVzZXI6aW5saW5lLXBhc3M="}}}`)
+
+	if user, pass := resolveAuth(t, "registry.example.com/project/image:tag"); user != "inline-user" || pass != "inline-pass" {
+		t.Fatalf("expected inline config to win over Docker config file, got %q/%q", user, pass)
+	}
+}
+
+func TestInlineDockerConfigResolvesUsernamePassword(t *testing.T) {
+	clearCredentialHelperEnv(t)
+	t.Setenv("DOCKER_CONFIG", t.TempDir())
+	// GHA and `docker login` may store username/password directly rather than a
+	// combined base64 `auth`; both must resolve.
+	t.Setenv(EnvDockerConfigInline, `{"auths":{"registry.example.com":{"username":"u2","password":"p2"}}}`)
+
+	if user, pass := resolveAuth(t, "registry.example.com/project/image:tag"); user != "u2" || pass != "p2" {
+		t.Fatalf("expected user/pass from inline docker config, got %q/%q", user, pass)
+	}
+}
+
+func TestInlineDockerConfigUsesDockerHubKey(t *testing.T) {
+	clearCredentialHelperEnv(t)
+	t.Setenv("DOCKER_CONFIG", t.TempDir())
+	// Docker Hub is stored under the historical key; a bare Docker Hub reference
+	// must still resolve against it.
+	t.Setenv(EnvDockerConfigInline, `{"auths":{"https://index.docker.io/v1/":{"auth":"aHViLXVzZXI6aHViLXBhc3M="}}}`)
+
+	if user, pass := resolveAuth(t, "ubuntu:latest"); user != "hub-user" || pass != "hub-pass" {
+		t.Fatalf("expected user/pass from Docker Hub inline entry, got %q/%q", user, pass)
+	}
+}
+
+func TestInlineDockerConfigFallsThroughForOtherRegistry(t *testing.T) {
+	clearCredentialHelperEnv(t)
+
+	dockerConfigDir := t.TempDir()
+	fileConfig := []byte(`{"auths":{"registry.example.com":{"auth":"ZmlsZS11c2VyOmZpbGUtcGFzcw=="}}}`)
+	if err := os.WriteFile(filepath.Join(dockerConfigDir, "config.json"), fileConfig, 0o600); err != nil {
+		t.Fatalf("failed to write Docker config: %v", err)
+	}
+	t.Setenv("DOCKER_CONFIG", dockerConfigDir)
+	// The inline config only has credentials for another registry, so the lookup
+	// falls through to the Docker config file.
+	t.Setenv(EnvDockerConfigInline, `{"auths":{"other.example.com":{"auth":"aW5saW5lLXVzZXI6aW5saW5lLXBhc3M="}}}`)
+
+	if user, pass := resolveAuth(t, "registry.example.com/project/image:tag"); user != "file-user" || pass != "file-pass" {
+		t.Fatalf("expected fall-through to Docker config file, got %q/%q", user, pass)
+	}
+}
+
+func TestInlineDockerConfigEmptyIsIgnored(t *testing.T) {
+	clearCredentialHelperEnv(t)
+
+	dockerConfigDir := t.TempDir()
+	fileConfig := []byte(`{"auths":{"registry.example.com":{"auth":"ZmlsZS11c2VyOmZpbGUtcGFzcw=="}}}`)
+	if err := os.WriteFile(filepath.Join(dockerConfigDir, "config.json"), fileConfig, 0o600); err != nil {
+		t.Fatalf("failed to write Docker config: %v", err)
+	}
+	t.Setenv("DOCKER_CONFIG", dockerConfigDir)
+	t.Setenv(EnvDockerConfigInline, "")
+
+	if user, pass := resolveAuth(t, "registry.example.com/project/image:tag"); user != "file-user" || pass != "file-pass" {
+		t.Fatalf("expected Docker config file to be used when inline is empty, got %q/%q", user, pass)
+	}
+}
+
+func TestInlineDockerConfigInvalidJSONErrors(t *testing.T) {
+	clearCredentialHelperEnv(t)
+	t.Setenv("DOCKER_CONFIG", t.TempDir())
+	t.Setenv(EnvDockerConfigInline, "this is not json")
+
+	ref, err := name.ParseReference("registry.example.com/project/image:tag")
+	if err != nil {
+		t.Fatalf("failed to parse registry reference: %v", err)
+	}
+	if _, err := keychainFromEnvironment().Resolve(ref.Context().Registry); err == nil {
+		t.Fatal("expected a malformed inline docker config to fail loudly, got nil error")
+	}
+}

--- a/img_tool/pkg/auth/registry/registry.go
+++ b/img_tool/pkg/auth/registry/registry.go
@@ -62,6 +62,7 @@ func firstNonEmptyEnv(names ...string) string {
 // WithAuthFromMultiKeychain returns a remote.Option that uses a MultiKeychain.
 // If a credential helper is configured (IMG_CREDENTIAL_HELPER_OCI_REGISTRY, or
 // the generic IMG_CREDENTIAL_HELPER), the Bazel credential helper is checked
+// first. An inline Docker config (IMG_DOCKER_CONFIG_INLINE) is checked next,
 // before the default Docker, Google, and Amazon ECR keychains.
 // If `IMG_AUTH_DEBUG` is set, each keychain resolution is logged to stderr.
 func WithAuthFromMultiKeychain() remote.Option {
@@ -70,9 +71,9 @@ func WithAuthFromMultiKeychain() remote.Option {
 
 // Keychain returns the [authn.Keychain] used to resolve registry credentials.
 // It honors the same environment (IMG_CREDENTIAL_HELPER_OCI_REGISTRY,
-// IMG_CREDENTIAL_HELPER, IMG_AUTH_DEBUG) as WithAuthFromMultiKeychain and is
-// intended for callers that need the raw keychain (for example to run the token
-// exchange flow themselves).
+// IMG_CREDENTIAL_HELPER, IMG_DOCKER_CONFIG_INLINE, IMG_AUTH_DEBUG) as
+// WithAuthFromMultiKeychain and is intended for callers that need the raw
+// keychain (for example to run the token exchange flow themselves).
 func Keychain() authn.Keychain {
 	return keychainFromEnvironment()
 }
@@ -86,6 +87,13 @@ func keychainFromEnvironment() authn.Keychain {
 		bazel := credential.New(value, &credential.Options{CaptureStderr: true})
 		keychain := credential.ContainerRegistryKeychain(bazel)
 		keychains = append(keychains, namedKeychain("bazel credential helper", keychain, debug))
+	}
+
+	// An inline Docker config injected into the (potentially remote) action's
+	// environment. Tried before the on-disk Docker config so an explicitly
+	// injected credential wins over whatever config file happens to exist.
+	if value := os.Getenv(EnvDockerConfigInline); value != "" {
+		keychains = append(keychains, namedKeychain("inline docker config", newInlineDockerConfigKeychain(value), debug))
 	}
 
 	keychains = append(


### PR DESCRIPTION
Add a credential source that reads a Docker config.json document from the
`IMG_DOCKER_CONFIG_INLINE` environment variable (its JSON contents, not a
path). It resolves exactly like the on-disk Docker config keychain by
reusing go-containerregistry's parser, but entirely in memory, and is
tried just before the on-disk config so an explicitly injected credential
wins over a stray config file. A malformed value fails loudly.

This is meant only for secret-injection mechanisms (e.g. BuildBuddy
secrets via the env-secrets execution property) that set the variable
directly in a remote action's environment; general use is discouraged
because passing it on the command line or via a Bazel setting would leak
the credential into the build event stream, action metadata, logs, and
the remote cache.