### PR TITLE
auth: add host-scoped environment credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,10 +415,11 @@ For more details on working with platforms, architecture variants, and building 
 | Priority | Keychain | Registries | Credential Source |
 |----------|----------|------------|-------------------|
 | 1 | **Bazel credential helper** | Any | `--@rules_img//img/settings:credential_helper_oci_registry` or `credential_helper`; `IMG_CREDENTIAL_HELPER_OCI_REGISTRY` or `IMG_CREDENTIAL_HELPER` env var |
-| 2 | **Inline Docker config** | Any | `IMG_DOCKER_CONFIG_INLINE` env var (the JSON contents of a `config.json`). For injected secrets only — see [Authenticating Build Actions](docs/authenticating-build-actions.md#4-inline-docker-config-from-an-injected-environment-variable). |
-| 3 | **Docker / Podman config** | Any | `~/.docker/config.json`, `$DOCKER_CONFIG/config.json`, `${XDG_RUNTIME_DIR}/containers/auth.json` |
-| 4 | **Google** | `gcr.io`, `*.pkg.dev` | [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) (workload identity, `gcloud auth login`, service account keys) |
-| 5 | **Amazon ECR** | `*.dkr.ecr.*.amazonaws.com` | Ambient AWS credentials (env vars, `~/.aws/`, EC2/ECS instance roles). See [ECR credential helper docs](https://github.com/awslabs/amazon-ecr-credential-helper#usage). |
+| 2 | **Host-scoped environment credentials** | One normalized registry host | `IMG_REGISTRY_AUTH_HOST` with username/password or a bearer token. For injected secrets only — see [Authenticating Build Actions](docs/authenticating-build-actions.md#buildbuddy-inject-short-lived-credentials). |
+| 3 | **Inline Docker config** | Any | `IMG_DOCKER_CONFIG_INLINE` env var (the JSON contents of a `config.json`). For injected secrets only — see [Authenticating Build Actions](docs/authenticating-build-actions.md#4-inline-docker-config-from-an-injected-environment-variable). |
+| 4 | **Docker / Podman config** | Any | `~/.docker/config.json`, `$DOCKER_CONFIG/config.json`, `${XDG_RUNTIME_DIR}/containers/auth.json` |
+| 5 | **Google** | `gcr.io`, `*.pkg.dev` | [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) (workload identity, `gcloud auth login`, service account keys) |
+| 6 | **Amazon ECR** | `*.dkr.ecr.*.amazonaws.com` | Ambient AWS credentials (env vars, `~/.aws/`, EC2/ECS instance roles). See [ECR credential helper docs](https://github.com/awslabs/amazon-ecr-credential-helper#usage). |
 
 The first keychain that returns credentials wins — subsequent keychains are not consulted.
 
@@ -495,6 +496,7 @@ bazel run //:push_image
 Set `IMG_AUTH_DEBUG=1` to see which keychains are tried and which one provides credentials:
 
 ```
+IMG_AUTH_DEBUG: keychain "registry environment" for ghcr.io: no credentials, trying next
 IMG_AUTH_DEBUG: keychain "docker config" for ghcr.io: no credentials, trying next
 IMG_AUTH_DEBUG: keychain "google" for ghcr.io: no credentials, trying next
 IMG_AUTH_DEBUG: keychain "amazon ecr" for ghcr.io: no credentials, trying next

--- a/docs/authenticating-build-actions.md
+++ b/docs/authenticating-build-actions.md
@@ -41,17 +41,21 @@ The registry permissions differ per operation:
 rules_img (the `img` tool, its build actions, and the gateway) resolves registry
 credentials with one keychain, tried in order:
 
-1. A **Bazel credential helper**, when `IMG_CREDENTIAL_HELPER` is set (see
-   [Credential Helpers](credential-helpers.md)).
-2. An **inline Docker config**, when `IMG_DOCKER_CONFIG_INLINE` holds the JSON
+1. A **Bazel credential helper**, when
+   `IMG_CREDENTIAL_HELPER_OCI_REGISTRY` or its `IMG_CREDENTIAL_HELPER` fallback
+   is set (see [Credential Helpers](credential-helpers.md)).
+2. **Host-scoped environment credentials**, when `IMG_REGISTRY_AUTH_HOST` and
+   either `IMG_REGISTRY_AUTH_USERNAME` plus `IMG_REGISTRY_AUTH_PASSWORD`, or
+   `IMG_REGISTRY_AUTH_BEARER_TOKEN`, are set.
+3. An **inline Docker config**, when `IMG_DOCKER_CONFIG_INLINE` holds the JSON
    contents of a `config.json`. Resolved just like the Docker config below, but
    from memory. Intended for secret-injection mechanisms only — see
    [Option 4](#4-inline-docker-config-from-an-injected-environment-variable) and
    the warning there.
-3. The **Docker config** (honors `DOCKER_CONFIG`; `REGISTRY_AUTH_FILE` is used
+4. The **Docker config** (honors `DOCKER_CONFIG`; `REGISTRY_AUTH_FILE` is used
    inside build actions).
-4. **Google** — `google.Keychain` (Application Default Credentials / workload identity).
-5. **Amazon ECR** — the ambient AWS configuration.
+5. **Google** — `google.Keychain` (Application Default Credentials / workload identity).
+6. **Amazon ECR** — the ambient AWS configuration.
 
 Whatever option you pick below, the credentials it provides are consumed through
 this keychain.
@@ -217,8 +221,9 @@ Set `IMG_DOCKER_CONFIG_INLINE` to the **JSON contents** of a Docker
 `config.json` (the same format as `~/.docker/config.json` — *not* a path to a
 file). rules_img resolves it exactly like the Docker config file, but entirely
 in memory, so it works on an executor that has no config file on disk. It is
-tried just before the on-disk Docker config, so an explicitly injected
-credential wins over whatever config file happens to exist.
+tried after the host-scoped environment variables and before the on-disk Docker
+config, so a per-invocation host-scoped credential can override a broader stored
+config.
 
 > **Not recommended for general use.** The value *is* the credential, so
 > anything that records your Bazel command line or an action's declared
@@ -229,12 +234,15 @@ credential wins over whatever config file happens to exist.
 > injects the variable straight into the (remote) action's process, where the
 > value never appears in the Bazel invocation itself.
 
-The intended mechanism is a per-action secret store such as **BuildBuddy
-secrets** — encrypted, organization-scoped environment variables (encrypted
-client-side with a libsodium sealed box and decrypted only on demand). Save the
-`config.json` contents once as a secret named `IMG_DOCKER_CONFIG_INLINE`, then
-opt the target whose build actions push or pull in to it with the `env-secrets`
-execution property:
+Use this format when an executor-side secret store provides a complete Docker
+config or when its additional authentication fields are required. On BuildBuddy
+Cloud-managed executors, prefer the shorter host-scoped variables described
+below when username/password or a bearer token is sufficient.
+
+For example, BuildBuddy organization secrets are encrypted, organization-scoped
+environment variables. Save the `config.json` contents once as a secret named
+`IMG_DOCKER_CONFIG_INLINE`, then opt the target whose build actions push or pull
+in to it with the `env-secrets` execution property:
 
 ```python
 exec_properties = {"env-secrets": "IMG_DOCKER_CONFIG_INLINE"},
@@ -251,6 +259,162 @@ the executor work the same way.
 Because the credentials flow through the shared keychain, no rules_img setting
 is involved: both lazy base-image pulls (`DownloadBlob`) and push-at-build-time
 actions pick the variable up automatically wherever the executor sets it.
+
+## BuildBuddy: inject short-lived credentials
+
+For short-lived registry credentials on BuildBuddy Cloud-managed executors,
+this is the preferred authentication method. Use BuildBuddy's [short-lived
+secrets] to inject registry credentials at execution time instead of operating
+a gateway. The secret values are redacted from BuildBuddy's action-cache entries
+and workflow logs, and because they are supplied in a remote execution header
+rather than the Bazel-declared action environment, they do not affect the action
+key.
+
+Set the registry host and exactly one authentication mode:
+
+| Authentication | Environment variables |
+|---|---|
+| Username and password | `IMG_REGISTRY_AUTH_HOST`, `IMG_REGISTRY_AUTH_USERNAME`, `IMG_REGISTRY_AUTH_PASSWORD` |
+| Ready-to-send bearer token | `IMG_REGISTRY_AUTH_HOST`, `IMG_REGISTRY_AUTH_BEARER_TOKEN` |
+
+`IMG_REGISTRY_AUTH_BEARER_TOKEN` is only for a registry-issued bearer token that
+can be sent directly in an `Authorization: Bearer` header. Registry access
+tokens or personal access tokens that require a username are passwords in the
+username/password mode. For the configured host, incomplete or mixed
+authentication variables are an error rather than falling through to another
+keychain.
+
+For example, inject a short-lived username and access token:
+
+```bash
+bazel build //path/to:image \
+  --remote_exec_header="x-buildbuddy-platform.secret-env-overrides=\
+IMG_REGISTRY_AUTH_HOST=${REGISTRY_HOST},\
+IMG_REGISTRY_AUTH_USERNAME=${REGISTRY_USER},\
+IMG_REGISTRY_AUTH_PASSWORD=${REGISTRY_TOKEN}"
+```
+
+`IMG_REGISTRY_AUTH_HOST` is a registry host such as `ghcr.io` or
+`registry.example.com:5000`, without a URL scheme or repository path. rules_img
+normalizes the Docker Hub alias `docker.io` to `index.docker.io` and only offers
+the credentials to the matching host.
+
+The plain `secret-env-overrides` format separates entries with commas. If a
+value contains a comma or other characters that make this format unsuitable,
+base64-encode each complete `KEY=VALUE` entry and use BuildBuddy's
+`secret-env-overrides-base64` header instead, as described in [short-lived
+secrets].
+
+> **Scope and caching:** `--remote_exec_header` applies to every remotely
+> executed action in the Bazel invocation, even though rules_img only sends the
+> registry credentials to the configured host. Use a narrowly scoped invocation
+> when possible and do not print secrets or write them to action outputs. A cache
+> hit skips execution, so rotating the credential alone does not rerun
+> `DownloadBlob` or `PushImage`.
+
+The values are redacted by BuildBuddy, but shell expansion can still expose them
+locally through process arguments, shell tracing, or CI command logs. Disable
+shell tracing and use the secret-masking facilities of the environment launching
+Bazel. Base64 encoding makes complex values transport-safe; it does not encrypt
+them.
+
+This mechanism requires BuildBuddy remote execution. BuildBuddy remote caching
+alone and local execution cannot inject these environment variables; other
+remote execution services need an equivalent execution-time environment
+injection mechanism.
+
+## Setting up the gateway on BuildBuddy self-hosted executors
+
+Run one gateway as a **sidecar container in each BuildBuddy executor Pod**. The
+gateway is not a separate Pod or DaemonSet in this setup: the
+`extraContainers` value adds it to the executor Pod template, so each executor
+replica gets its own gateway.
+
+```text
+BuildBuddy executor Pod
+├── oci-distribution-gateway sidecar
+└── buildbuddy-executor
+    └── child OCI action container
+```
+
+The sidecar listens on a UNIX socket in a private `emptyDir`. The
+[BuildBuddy executor Helm chart] shares that socket with the executor and, with
+the chart's default OCI isolation, the executor bind-mounts it into child action
+containers. This requires configuration at three layers:
+
+1. An `emptyDir` shared by the gateway sidecar and executor Pod containers.
+2. An `extraVolumeMount` that makes the directory visible to the executor.
+3. An `executor.oci.mounts` entry that bind-mounts the directory into every
+   action container.
+
+First create a `ConfigMap` containing the gateway policy in the executor's
+Kubernetes namespace:
+
+```bash
+kubectl --namespace=buildbuddy create configmap rules-img-gateway-policy \
+  --from-file=policy.yaml=/path/to/gateway-policy.yaml
+```
+
+Then add these values to the `buildbuddy-executor` chart:
+
+```yaml
+extraVolumes:
+  - name: rules-img-gateway-socket
+    emptyDir: {}
+  - name: rules-img-gateway-policy
+    configMap:
+      name: rules-img-gateway-policy
+extraVolumeMounts:
+  - name: rules-img-gateway-socket
+    mountPath: /run/rules-img-gateway
+extraContainers:
+  - name: oci-distribution-gateway
+    image: <your oci-distribution-gateway image>
+    args:
+      - --unix-socket=/run/rules-img-gateway/gateway.sock
+      - --policy-file=/etc/rules-img-gateway/policy.yaml
+    volumeMounts:
+      - name: rules-img-gateway-socket
+        mountPath: /run/rules-img-gateway
+      - name: rules-img-gateway-policy
+        mountPath: /etc/rules-img-gateway
+        readOnly: true
+config:
+  executor:
+    oci:
+      mounts:
+        - type: bind
+          source: /run/rules-img-gateway
+          destination: /run/rules-img-gateway
+          options:
+            - bind
+            - ro
+```
+
+rules_img does not currently publish a gateway container image. Build and
+publish an image containing `oci-distribution-gateway`, then replace the image
+placeholder above, preferably with an immutable digest.
+
+Point Bazel at the same socket path:
+
+```bash
+common --@rules_img//img/settings:registry_gateway=unix:/run/rules-img-gateway/gateway.sock
+```
+
+Give only the gateway sidecar the upstream credentials it needs, using its
+environment or additional secret volume mounts. The actions connect to the
+gateway anonymously and do not need registry credentials.
+
+This example assumes the chart's default OCI isolation. Other isolation types
+need their own mechanism for exposing the socket inside action containers.
+`executor.oci.mounts` applies to every OCI action on the executor, so use a
+restrictive gateway policy and consider a dedicated executor pool. Also ensure
+the socket permissions allow the action user to connect. `extraContainers`
+start concurrently with the executor; if startup ordering is important, use a
+Kubernetes restartable init sidecar with a startup probe through the chart's
+`extraInitContainers` value. A separate Deployment or DaemonSet would require
+different network or volume plumbing and would expose the unauthenticated
+gateway beyond this private per-Pod socket.
 
 ## Setting up the gateway on Buildbarn
 
@@ -320,3 +484,5 @@ listening on another socket on the shared volume.
 
 [buildbarn/bb-deployments]: https://github.com/buildbarn/bb-deployments
 [bb-deployments]: https://github.com/buildbarn/bb-deployments
+[BuildBuddy executor Helm chart]: https://github.com/buildbuddy-io/buildbuddy-helm/tree/master/charts/buildbuddy-executor
+[short-lived secrets]: https://www.buildbuddy.io/docs/secrets#short-lived-secrets

--- a/img_tool/pkg/auth/registry/inline_config_test.go
+++ b/img_tool/pkg/auth/registry/inline_config_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
-// clearCredentialHelperEnv unsets the credential-helper variables so the tests
-// exercise the inline-config keychain without an ambient helper shadowing it.
-func clearCredentialHelperEnv(t *testing.T) {
+// clearHigherPriorityCredentialEnv unsets higher-priority credential sources so the
+// tests exercise the inline-config keychain without an ambient value shadowing
+// it.
+func clearHigherPriorityCredentialEnv(t *testing.T) {
 	t.Helper()
-	t.Setenv("IMG_CREDENTIAL_HELPER", "")
-	t.Setenv("IMG_CREDENTIAL_HELPER_OCI_REGISTRY", "")
+	clearRegistryAuthEnvironment(t)
 }
 
 func resolveAuth(t *testing.T, ref string) (username, password string) {
@@ -34,7 +34,7 @@ func resolveAuth(t *testing.T, ref string) (username, password string) {
 }
 
 func TestKeychainFromEnvironmentUsesInlineDockerConfig(t *testing.T) {
-	clearCredentialHelperEnv(t)
+	clearHigherPriorityCredentialEnv(t)
 	// Ensure no on-disk Docker config can satisfy the lookup instead.
 	t.Setenv("DOCKER_CONFIG", t.TempDir())
 	t.Setenv(EnvDockerConfigInline, `{"auths":{"registry.example.com":{"auth":"dXNlcjpwYXNz"}}}`)
@@ -45,7 +45,7 @@ func TestKeychainFromEnvironmentUsesInlineDockerConfig(t *testing.T) {
 }
 
 func TestInlineDockerConfigTakesPrecedenceOverDockerConfigFile(t *testing.T) {
-	clearCredentialHelperEnv(t)
+	clearHigherPriorityCredentialEnv(t)
 
 	dockerConfigDir := t.TempDir()
 	fileConfig := []byte(`{"auths":{"registry.example.com":{"auth":"ZmlsZS11c2VyOmZpbGUtcGFzcw=="}}}`)
@@ -61,7 +61,7 @@ func TestInlineDockerConfigTakesPrecedenceOverDockerConfigFile(t *testing.T) {
 }
 
 func TestInlineDockerConfigResolvesUsernamePassword(t *testing.T) {
-	clearCredentialHelperEnv(t)
+	clearHigherPriorityCredentialEnv(t)
 	t.Setenv("DOCKER_CONFIG", t.TempDir())
 	// GHA and `docker login` may store username/password directly rather than a
 	// combined base64 `auth`; both must resolve.
@@ -73,7 +73,7 @@ func TestInlineDockerConfigResolvesUsernamePassword(t *testing.T) {
 }
 
 func TestInlineDockerConfigUsesDockerHubKey(t *testing.T) {
-	clearCredentialHelperEnv(t)
+	clearHigherPriorityCredentialEnv(t)
 	t.Setenv("DOCKER_CONFIG", t.TempDir())
 	// Docker Hub is stored under the historical key; a bare Docker Hub reference
 	// must still resolve against it.
@@ -85,7 +85,7 @@ func TestInlineDockerConfigUsesDockerHubKey(t *testing.T) {
 }
 
 func TestInlineDockerConfigFallsThroughForOtherRegistry(t *testing.T) {
-	clearCredentialHelperEnv(t)
+	clearHigherPriorityCredentialEnv(t)
 
 	dockerConfigDir := t.TempDir()
 	fileConfig := []byte(`{"auths":{"registry.example.com":{"auth":"ZmlsZS11c2VyOmZpbGUtcGFzcw=="}}}`)
@@ -103,7 +103,7 @@ func TestInlineDockerConfigFallsThroughForOtherRegistry(t *testing.T) {
 }
 
 func TestInlineDockerConfigEmptyIsIgnored(t *testing.T) {
-	clearCredentialHelperEnv(t)
+	clearHigherPriorityCredentialEnv(t)
 
 	dockerConfigDir := t.TempDir()
 	fileConfig := []byte(`{"auths":{"registry.example.com":{"auth":"ZmlsZS11c2VyOmZpbGUtcGFzcw=="}}}`)
@@ -119,7 +119,7 @@ func TestInlineDockerConfigEmptyIsIgnored(t *testing.T) {
 }
 
 func TestInlineDockerConfigInvalidJSONErrors(t *testing.T) {
-	clearCredentialHelperEnv(t)
+	clearHigherPriorityCredentialEnv(t)
 	t.Setenv("DOCKER_CONFIG", t.TempDir())
 	t.Setenv(EnvDockerConfigInline, "this is not json")
 

--- a/img_tool/pkg/auth/registry/registry.go
+++ b/img_tool/pkg/auth/registry/registry.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	ecr "github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/credential"
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
@@ -33,6 +35,16 @@ const (
 	// authenticate gRPC calls to the remote cache / remote execution API.
 	// Takes precedence over EnvCredentialHelper for those calls.
 	EnvCredentialHelperRemoteCache = "IMG_CREDENTIAL_HELPER_REMOTE_CACHE"
+
+	// EnvRegistryAuthHost is the registry host for credentials supplied directly
+	// through the environment.
+	EnvRegistryAuthHost = "IMG_REGISTRY_AUTH_HOST"
+	// EnvRegistryAuthUsername is the username for registry basic authentication.
+	EnvRegistryAuthUsername = "IMG_REGISTRY_AUTH_USERNAME"
+	// EnvRegistryAuthPassword is the password for registry basic authentication.
+	EnvRegistryAuthPassword = "IMG_REGISTRY_AUTH_PASSWORD"
+	// EnvRegistryAuthBearerToken is a ready-to-send registry bearer token.
+	EnvRegistryAuthBearerToken = "IMG_REGISTRY_AUTH_BEARER_TOKEN"
 )
 
 // OCIRegistryCredentialHelper returns the credential helper configured for OCI
@@ -62,8 +74,9 @@ func firstNonEmptyEnv(names ...string) string {
 // WithAuthFromMultiKeychain returns a remote.Option that uses a MultiKeychain.
 // If a credential helper is configured (IMG_CREDENTIAL_HELPER_OCI_REGISTRY, or
 // the generic IMG_CREDENTIAL_HELPER), the Bazel credential helper is checked
-// first. An inline Docker config (IMG_DOCKER_CONFIG_INLINE) is checked next,
-// before the default Docker, Google, and Amazon ECR keychains.
+// first. Host-scoped IMG_REGISTRY_AUTH_* credentials are checked next, followed
+// by an inline Docker config (IMG_DOCKER_CONFIG_INLINE), before the default
+// Docker, Google, and Amazon ECR keychains.
 // If `IMG_AUTH_DEBUG` is set, each keychain resolution is logged to stderr.
 func WithAuthFromMultiKeychain() remote.Option {
 	return remote.WithAuthFromKeychain(keychainFromEnvironment())
@@ -71,9 +84,9 @@ func WithAuthFromMultiKeychain() remote.Option {
 
 // Keychain returns the [authn.Keychain] used to resolve registry credentials.
 // It honors the same environment (IMG_CREDENTIAL_HELPER_OCI_REGISTRY,
-// IMG_CREDENTIAL_HELPER, IMG_DOCKER_CONFIG_INLINE, IMG_AUTH_DEBUG) as
-// WithAuthFromMultiKeychain and is intended for callers that need the raw
-// keychain (for example to run the token exchange flow themselves).
+// IMG_CREDENTIAL_HELPER, IMG_DOCKER_CONFIG_INLINE, IMG_REGISTRY_AUTH_*,
+// IMG_AUTH_DEBUG) as WithAuthFromMultiKeychain and is intended for callers that
+// need the raw keychain (for example to run the token exchange flow themselves).
 func Keychain() authn.Keychain {
 	return keychainFromEnvironment()
 }
@@ -88,6 +101,11 @@ func keychainFromEnvironment() authn.Keychain {
 		keychain := credential.ContainerRegistryKeychain(bazel)
 		keychains = append(keychains, namedKeychain("bazel credential helper", keychain, debug))
 	}
+
+	// Short-lived credentials scoped to one registry host. Tried before an
+	// inline Docker config so a per-invocation override wins over a broader
+	// stored config.
+	keychains = append(keychains, namedKeychain("registry environment", environmentKeychain{}, debug))
 
 	// An inline Docker config injected into the (potentially remote) action's
 	// environment. Tried before the on-disk Docker config so an explicitly
@@ -104,6 +122,46 @@ func keychainFromEnvironment() authn.Keychain {
 	)
 
 	return authn.NewMultiKeychain(keychains...)
+}
+
+type environmentKeychain struct{}
+
+func (environmentKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	host := os.Getenv(EnvRegistryAuthHost)
+	username := os.Getenv(EnvRegistryAuthUsername)
+	password := os.Getenv(EnvRegistryAuthPassword)
+	bearerToken := os.Getenv(EnvRegistryAuthBearerToken)
+
+	if host == "" && username == "" && password == "" && bearerToken == "" {
+		return authn.Anonymous, nil
+	}
+	if host == "" {
+		return nil, fmt.Errorf("%s is required when registry environment credentials are set", EnvRegistryAuthHost)
+	}
+
+	registry, err := name.NewRegistry(host, name.StrictValidation)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", EnvRegistryAuthHost, err)
+	}
+
+	if !strings.EqualFold(registry.RegistryStr(), target.RegistryStr()) {
+		return authn.Anonymous, nil
+	}
+
+	if bearerToken != "" && (username != "" || password != "") {
+		return nil, fmt.Errorf("%s is mutually exclusive with %s and %s", EnvRegistryAuthBearerToken, EnvRegistryAuthUsername, EnvRegistryAuthPassword)
+	}
+	if bearerToken == "" && (username == "" || password == "") {
+		return nil, fmt.Errorf("set either %s or both %s and %s", EnvRegistryAuthBearerToken, EnvRegistryAuthUsername, EnvRegistryAuthPassword)
+	}
+
+	if bearerToken != "" {
+		return authn.FromConfig(authn.AuthConfig{RegistryToken: bearerToken}), nil
+	}
+	return authn.FromConfig(authn.AuthConfig{
+		Username: username,
+		Password: password,
+	}), nil
 }
 
 func namedKeychain(name string, kc authn.Keychain, debug bool) authn.Keychain {

--- a/img_tool/pkg/auth/registry/registry_test.go
+++ b/img_tool/pkg/auth/registry/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
@@ -18,7 +19,24 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func clearRegistryAuthEnvironment(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"IMG_CREDENTIAL_HELPER",
+		"IMG_CREDENTIAL_HELPER_OCI_REGISTRY",
+		EnvDockerConfigInline,
+		EnvRegistryAuthHost,
+		EnvRegistryAuthUsername,
+		EnvRegistryAuthPassword,
+		EnvRegistryAuthBearerToken,
+	} {
+		t.Setenv(name, "")
+	}
+}
+
 func TestKeychainFromEnvironmentPrefersConfiguredCredentialHelper(t *testing.T) {
+	clearRegistryAuthEnvironment(t)
+
 	helperPath, err := os.Executable()
 	if err != nil {
 		t.Fatalf("failed to locate test executable: %v", err)
@@ -26,6 +44,10 @@ func TestKeychainFromEnvironmentPrefersConfiguredCredentialHelper(t *testing.T) 
 
 	t.Setenv("RULES_IMG_TEST_CREDENTIAL_HELPER", "1")
 	t.Setenv("IMG_CREDENTIAL_HELPER", helperPath)
+	t.Setenv(EnvRegistryAuthHost, "registry.example.com")
+	t.Setenv(EnvRegistryAuthUsername, "environment-user")
+	t.Setenv(EnvRegistryAuthPassword, "environment-pass")
+	t.Setenv(EnvDockerConfigInline, `{"auths":{"registry.example.com":{"auth":"aW5saW5lLXVzZXI6aW5saW5lLXBhc3M="}}}`)
 
 	dockerConfigDir := t.TempDir()
 	dockerConfig := []byte(`{"credsStore":"rules-img-missing-helper"}`)
@@ -54,6 +76,8 @@ func TestKeychainFromEnvironmentPrefersConfiguredCredentialHelper(t *testing.T) 
 }
 
 func TestKeychainFromEnvironmentIgnoresEmptyCredentialHelper(t *testing.T) {
+	clearRegistryAuthEnvironment(t)
+
 	t.Setenv("IMG_CREDENTIAL_HELPER", "")
 
 	dockerConfigDir := t.TempDir()
@@ -83,6 +107,8 @@ func TestKeychainFromEnvironmentIgnoresEmptyCredentialHelper(t *testing.T) {
 }
 
 func TestKeychainFromEnvironmentPrefersOCIRegistryHelper(t *testing.T) {
+	clearRegistryAuthEnvironment(t)
+
 	helperPath, err := os.Executable()
 	if err != nil {
 		t.Fatalf("failed to locate test executable: %v", err)
@@ -117,6 +143,155 @@ func TestKeychainFromEnvironmentPrefersOCIRegistryHelper(t *testing.T) {
 	}
 	if authConfig.Username != "user" || authConfig.Password != "pass" {
 		t.Fatalf("expected user/pass from credential helper, got %q/%q", authConfig.Username, authConfig.Password)
+	}
+}
+
+func TestKeychainFromEnvironmentPrefersRegistryEnvironment(t *testing.T) {
+	clearRegistryAuthEnvironment(t)
+	t.Setenv("IMG_CREDENTIAL_HELPER", "")
+	t.Setenv(EnvRegistryAuthHost, "registry.example.com")
+	t.Setenv(EnvRegistryAuthUsername, "environment-user")
+	t.Setenv(EnvRegistryAuthPassword, "environment-pass")
+	t.Setenv(EnvDockerConfigInline, `{"auths":{"registry.example.com":{"auth":"aW5saW5lLXVzZXI6aW5saW5lLXBhc3M="}}}`)
+
+	dockerConfigDir := t.TempDir()
+	dockerConfig := []byte(`{"auths":{"registry.example.com":{"auth":"ZG9ja2VyOnBhc3M="}}}`)
+	if err := os.WriteFile(filepath.Join(dockerConfigDir, "config.json"), dockerConfig, 0o600); err != nil {
+		t.Fatalf("failed to write Docker config: %v", err)
+	}
+	t.Setenv("DOCKER_CONFIG", dockerConfigDir)
+
+	ref, err := name.ParseReference("registry.example.com/project/image:tag")
+	if err != nil {
+		t.Fatalf("failed to parse registry reference: %v", err)
+	}
+
+	authenticator, err := keychainFromEnvironment().Resolve(ref.Context().Registry)
+	if err != nil {
+		t.Fatalf("registry environment should be used before injected and on-disk Docker configs: %v", err)
+	}
+
+	authConfig, err := authenticator.Authorization()
+	if err != nil {
+		t.Fatalf("failed to resolve auth config: %v", err)
+	}
+	if authConfig.Username != "environment-user" || authConfig.Password != "environment-pass" {
+		t.Fatalf("expected user/pass from registry environment, got %q/%q", authConfig.Username, authConfig.Password)
+	}
+}
+
+func TestEnvironmentKeychainBearerToken(t *testing.T) {
+	clearRegistryAuthEnvironment(t)
+	t.Setenv(EnvRegistryAuthHost, "registry.example.com")
+	t.Setenv(EnvRegistryAuthBearerToken, "registry-token")
+
+	ref, err := name.ParseReference("registry.example.com/project/image:tag")
+	if err != nil {
+		t.Fatalf("failed to parse registry reference: %v", err)
+	}
+
+	authenticator, err := (environmentKeychain{}).Resolve(ref.Context().Registry)
+	if err != nil {
+		t.Fatalf("failed to resolve registry environment: %v", err)
+	}
+	authConfig, err := authenticator.Authorization()
+	if err != nil {
+		t.Fatalf("failed to resolve auth config: %v", err)
+	}
+	if authConfig.RegistryToken != "registry-token" {
+		t.Fatalf("expected bearer token from registry environment, got %q", authConfig.RegistryToken)
+	}
+}
+
+func TestEnvironmentKeychainNormalizesDockerHub(t *testing.T) {
+	clearRegistryAuthEnvironment(t)
+	t.Setenv(EnvRegistryAuthHost, "docker.io")
+	t.Setenv(EnvRegistryAuthUsername, "user")
+	t.Setenv(EnvRegistryAuthPassword, "pass")
+
+	ref, err := name.ParseReference("ubuntu:latest")
+	if err != nil {
+		t.Fatalf("failed to parse registry reference: %v", err)
+	}
+
+	authenticator, err := (environmentKeychain{}).Resolve(ref.Context().Registry)
+	if err != nil {
+		t.Fatalf("failed to resolve registry environment: %v", err)
+	}
+	if authenticator == authn.Anonymous {
+		t.Fatal("expected docker.io credentials to match index.docker.io")
+	}
+}
+
+func TestEnvironmentKeychainIgnoresOtherRegistries(t *testing.T) {
+	clearRegistryAuthEnvironment(t)
+	t.Setenv(EnvRegistryAuthHost, "registry.example.com")
+	t.Setenv(EnvRegistryAuthUsername, "incomplete-credentials")
+
+	ref, err := name.ParseReference("other.example.com/project/image:tag")
+	if err != nil {
+		t.Fatalf("failed to parse registry reference: %v", err)
+	}
+
+	authenticator, err := (environmentKeychain{}).Resolve(ref.Context().Registry)
+	if err != nil {
+		t.Fatalf("failed to resolve registry environment: %v", err)
+	}
+	if authenticator != authn.Anonymous {
+		t.Fatal("expected credentials to be ignored for another registry")
+	}
+}
+
+func TestEnvironmentKeychainRejectsInvalidConfiguration(t *testing.T) {
+	tests := []struct {
+		name        string
+		host        string
+		username    string
+		password    string
+		bearerToken string
+	}{
+		{
+			name:     "missing host",
+			username: "user",
+			password: "pass",
+		},
+		{
+			name:     "missing password",
+			host:     "registry.example.com",
+			username: "user",
+		},
+		{
+			name:        "mixed authentication",
+			host:        "registry.example.com",
+			username:    "user",
+			password:    "pass",
+			bearerToken: "registry-token",
+		},
+		{
+			name:     "invalid host",
+			host:     "https://registry.example.com",
+			username: "user",
+			password: "pass",
+		},
+	}
+
+	ref, err := name.ParseReference("registry.example.com/project/image:tag")
+	if err != nil {
+		t.Fatalf("failed to parse registry reference: %v", err)
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearRegistryAuthEnvironment(t)
+			t.Setenv(EnvRegistryAuthHost, test.host)
+			t.Setenv(EnvRegistryAuthUsername, test.username)
+			t.Setenv(EnvRegistryAuthPassword, test.password)
+			t.Setenv(EnvRegistryAuthBearerToken, test.bearerToken)
+
+			if _, err := (environmentKeychain{}).Resolve(ref.Context().Registry); err == nil {
+				t.Fatal("expected invalid registry environment to fail")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
PR #656 added `IMG_DOCKER_CONFIG_INLINE` for injecting a complete
Docker config without materializing a file, but constructing and
transporting JSON is cumbersome for a single short-lived registry
credential. This is needed because those credentials should remain
readable without losing host scoping.

This PR builds on that support in two reviewable commits:

- `auth: add host-scoped environment credentials` adds readable
  username/password and bearer-token variables scoped to one registry.
  Per-invocation values override inline and on-disk Docker configs while
  preserving credential-helper precedence.
- `docs: explain BuildBuddy action credentials` distinguishes stored
  inline configs from short-lived BuildBuddy Cloud credentials and shows
  how self-hosted executors can run the OCI distribution gateway as a
  Helm-managed sidecar.

Requests for other registries continue through the inline Docker,
on-disk Docker, Google, and Amazon ECR keychains.
