### PR TITLE
fix(release): release signer plugins via the shared release workflow

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,15 +1,85 @@
 #!/usr/bin/env bash
 
-# This script is invoked by release.yaml
+# This script is invoked by release.yaml (the main, co-versioned rules_img +
+# img_tool release) and by release_signer_plugins.yaml (one independently
+# versioned signer plugin), both through the same reusable release workflow. The
+# tag decides which release to prepare.
 
 set -euo pipefail
 
 # Argument provided by reusable workflow caller, see
 # https://github.com/bazel-contrib/.github/blob/d197a6427c5435ac22e56e33340dff912bc9334e/.github/workflows/release_ruleset.yaml#L72
 TAG=$1
-ARCHIVE="rules_img-$TAG.tar.gz"
+
+# Prepare a signer plugin release from tag `rules_img_signer_<basename>-v<version>`:
+# the prebuilt per-platform plugin binaries and the versioned BCR source archive
+# (with the populated prebuilt_lockfile.json), all produced hermetically by
+# Bazel. We only extract the resulting tarball into dist/ with plain `tar -xf`
+# (portable across platforms; no awk/sed/tar --transform). Building from the repo
+# root is what lets the cosign plugin compile without rewriting its MODULE.bazel.
+release_prep_signer_plugin() {
+  local basename="$1"
+  local target="//img/private/release:signer_${basename}_dist_tar"
+  local tarball
+
+  echo "Building signer plugin release bundle ${target}..." 1>&2
+  bazel build "${target}" 1>&2
+  tarball="$(bazel cquery --output=files "${target}")"
+
+  echo "Extracting tarball to dist directory..." 1>&2
+  mkdir -p dist
+  tar -xf "${tarball}" -C dist
+
+  # Both the BCR entry (.bcr/modules/*/source.template.json) and the provenance
+  # attestation the registry verifies refer to the archive as <tag>.tar.gz.
+  local archive="${TAG}.tar.gz"
+  if [[ ! -f "dist/${archive}" ]]; then
+    echo "expected release archive dist/${archive} not found;" 1>&2
+    echo "does version() in //img/private/release match the released tag?" 1>&2
+    exit 1
+  fi
+
+  # The per-platform binaries the packaged prebuilt_lockfile.json points at.
+  local binaries=(dist/"${basename}"_*)
+  if [[ ! -e "${binaries[0]}" ]]; then
+    echo "expected prebuilt ${basename} binaries in dist/, found:" 1>&2
+    ls dist 1>&2
+    exit 1
+  fi
+
+  # Release notes, on stdout.
+  cat <<EOF
+## Using Bzlmod
+
+Add the following to your \`MODULE.bazel\` file:
+
+\`\`\`starlark
+bazel_dep(name = "rules_img_signer_${basename}", version = "${TAG##*-v}")
+\`\`\`
+
+\`@rules_img_signer_${basename}\` resolves to the prebuilt plugin binary published
+with this release. See the
+[\`rules_img_signer_${basename}\` README](https://github.com/bazel-contrib/rules_img/blob/${TAG}/modules/rules_img_signer_${basename}/README.md)
+for \`signing_config\` recipes, and
+[image signing](https://github.com/bazel-contrib/rules_img/blob/${TAG}/docs/image-signing.md)
+for the full signing guide.
+EOF
+}
 
 rm -rf dist
+
+case "${TAG}" in
+  rules_img_signer_cosign-v*)
+    release_prep_signer_plugin cosign
+    exit 0
+    ;;
+  rules_img_signer_notation-v*)
+    release_prep_signer_plugin notation
+    exit 0
+    ;;
+esac
+
+ARCHIVE="rules_img-$TAG.tar.gz"
 
 # Build the distribution tarball
 echo "Building distribution tarball..." 1>&2

--- a/.github/workflows/release_signer_plugins.yaml
+++ b/.github/workflows/release_signer_plugins.yaml
@@ -6,6 +6,14 @@
 # `rules_img_signer_<basename>-v` prefix from the tag to derive the module version
 # and passes module_roots so publish-to-bcr publishes only this plugin, leaving
 # the other modules (and their already-published versions) untouched.
+#
+# Building and releasing goes through the same reusable release workflow as the
+# main release (which dispatches on the tag in release_prep.sh). That is not just
+# for consistency: the BCR presubmit verifies the release archive's provenance
+# against a *hard-coded* builder id, namely the reusable workflow that produced
+# the attestation (see `_GH_RELEASE_BUILDER_ID` in tools/slsa.py of
+# bazelbuild/bazel-central-registry). Attesting the archive from a workflow of
+# our own makes slsa-verifier reject it as an "untrusted reusable workflow".
 name: Release signer plugin
 on:
   push:
@@ -17,12 +25,11 @@ permissions:
   attestations: write
   contents: write
 jobs:
-  build:
+  meta:
     runs-on: ubuntu-latest
     outputs:
       basename: ${{ steps.meta.outputs.basename }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Resolve module from tag
         id: meta
         env:
@@ -34,105 +41,28 @@ jobs:
             *) echo "unrecognized tag ${TAG_NAME}"; exit 1 ;;
           esac
           echo "basename=${basename}" >> "$GITHUB_OUTPUT"
-      - name: Build binaries + source archive
-        env:
-          BASENAME: ${{ steps.meta.outputs.basename }}
-        run: |
-          # Everything is produced hermetically by Bazel: the prebuilt
-          # per-platform binaries and the versioned BCR source archive (with the
-          # populated prebuilt_lockfile.json). We only extract the resulting
-          # tarball into dist/ with plain `tar -xf` (portable across platforms;
-          # no awk/sed/tar --transform). Building from the repo root is what lets
-          # the cosign plugin compile without rewriting its MODULE.bazel.
-          target="//img/private/release:signer_${BASENAME}_dist_tar"
-          bazel build "${target}"
-          tarball="$(bazel cquery --output=files "${target}")"
-          mkdir -p dist
-          tar -xf "${tarball}" -C dist
-      # The artifact name is a contract with the publish job: publish-to-bcr's
-      # reusable workflow downloads the run artifact named `release_files` to
-      # compute integrity hashes from local files instead of re-downloading the
-      # release assets. Same name as bazel-contrib/.github's release_ruleset.
-      - name: Upload release files
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: release_files
-          path: dist/
-  # The BCR entry references a provenance attestation for the source archive
-  # (`<archive>.intoto.jsonl`), so produce one just like the main release does
-  # via bazel-contrib/.github's release_ruleset workflow. Without it, publish's
-  # "Create final entry" step fails downloading the missing attestation.
-  attest:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: release_files
-          path: release_files
-      - name: Attest release files
-        id: attest
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
-        with:
-          subject-path: release_files/**/*
-      - name: Write release archive attestation
-        id: archive_attestations
-        env:
-          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
-          TAG_NAME: ${{ github.ref_name }}
-        run: |
-          # attest-build-provenance emits a single bundle covering all subjects,
-          # while the registry wants one attestation file per release archive.
-          # Copy the bundle under the name the BCR entry refers to, which is
-          # derived from the `url` in .bcr/modules/*/source.template.json
-          # (`{TAG}.tar.gz`) plus an `.intoto.jsonl` suffix.
-          archive="${TAG_NAME}.tar.gz"
-          if [ ! -f "release_files/${archive}" ]; then
-            echo "expected release archive release_files/${archive} not found;" >&2
-            echo "does version() in //img/private/release match the released tag?" >&2
-            exit 1
-          fi
-          attestations_dir="$(mktemp -d)"
-          jq --compact-output . "${BUNDLE_PATH}" \
-            >"${attestations_dir}/${archive}.intoto.jsonl"
-          echo "dir=${attestations_dir}" >> "$GITHUB_OUTPUT"
-      # Also a contract with the publish job, which downloads the run artifact
-      # named `attestations`.
-      - name: Upload attestations
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: attestations
-          path: ${{ steps.archive_attestations.outputs.dir }}/*
   release:
-    needs: [build, attest]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: release_files
-          path: dist
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: attestations
-          path: attestations
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          fail_on_unmatched_files: true
-          files: |
-            dist/rules_img_signer_${{ needs.build.outputs.basename }}-*.tar.gz
-            dist/${{ needs.build.outputs.basename }}_*
-            attestations/*
+    needs: meta
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.4.0
+    with:
+      # release_prep.sh builds the plugin's dist bundle: the versioned BCR source
+      # archive plus the prebuilt per-platform plugin binaries.
+      release_files: |
+        dist/rules_img_signer_${{ needs.meta.outputs.basename }}-*.tar.gz
+        dist/${{ needs.meta.outputs.basename }}_*
+      prerelease: false
+      tag_name: ${{ github.ref_name }}
+    secrets:
+      inherit
   publish:
-    needs: [build, attest, release]
+    needs: [meta, release]
     uses: ./.github/workflows/publish.yaml
     with:
       tag_name: ${{ github.ref_name }}
       # The tag is rules_img_signer_<basename>-v<version>; strip that prefix so
       # publish-to-bcr derives the module version (e.g. 0.0.1), and publish only
       # this plugin's module root (not the co-versioned rules_img/img_tool set).
-      tag_prefix: rules_img_signer_${{ needs.build.outputs.basename }}-v
-      module_roots: modules/rules_img_signer_${{ needs.build.outputs.basename }}
+      tag_prefix: rules_img_signer_${{ needs.meta.outputs.basename }}-v
+      module_roots: modules/rules_img_signer_${{ needs.meta.outputs.basename }}
     secrets:
       publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
Follow-up to #660. The BCR PR for `rules_img_signer_notation@0.0.1` now finds the archive attestation, but rejects it:

```
untrusted reusable workflow: builderID does not match provenance:
expected name 'https://github.com/bazel-contrib/rules_img/.github/workflows/release_signer_plugins.yaml',
got 'https://github.com/bazel-contrib/.github/.github/workflows/release_ruleset.yaml'
```

`tools/slsa.py` in bazelbuild/bazel-central-registry hard-codes the builder id it accepts for a release archive attestation (`_GH_RELEASE_BUILDER_ID = https://github.com/bazel-contrib/.github/.github/workflows/release_ruleset.yaml`; `MODULE.bazel`/`source.json` use the publish-to-bcr id). GitHub records the **reusable workflow** that ran `actions/attest-build-provenance` as the provenance builder — compare the two releases:

| attestation | `predicate.runDetails.builder.id` |
| --- | --- |
| `rules_img-v0.3.17.tar.gz.intoto.jsonl` | `bazel-contrib/.github/.github/workflows/release_ruleset.yaml@refs/tags/v7.4.0` ✅ |
| `rules_img_signer_notation-v0.0.1.tar.gz.intoto.jsonl` | `bazel-contrib/rules_img/.github/workflows/release_signer_plugins.yaml@…` ❌ |

So an attestation produced by our own workflow can never validate, whatever it is named. The fix is to release the plugins through the same reusable workflow as the main release:

* `release_signer_plugins.yaml`: the `build`/`attest`/`release` jobs are replaced by `bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.4.0`; a small `meta` job still derives the plugin basename from the tag for the `release_files` globs and the publish inputs. This also removes the hand-rolled attestation and artifact-naming code added in #660 — `release_ruleset` already uploads the `release_files`/`attestations` run artifacts publish-to-bcr consumes.
* `release_prep.sh` (the hard-coded entry point of `release_ruleset`) dispatches on the tag: `rules_img_signer_<basename>-v<version>` builds `//img/private/release:signer_<basename>_dist_tar`, extracts it into `dist/`, asserts the archive is `<tag>.tar.gz` (i.e. `version()` in `//img/private/release` matches the tag) and that the prebuilt binaries are present, then writes plugin-specific release notes to stdout. The main release path is unchanged.

Verified: decoded both existing attestations to confirm the builder-id semantics above; read BCR's `tools/slsa.py` to confirm there is no per-module override; dry-ran `release_prep.sh` with a stubbed `bazel` for the happy path, an archive/tag mismatch, missing binaries, and a main-release tag; `actionlint` is clean.

Re-releasing `v0.0.1` again needs the two releases and tags deleted and the tags re-pushed onto a commit containing this change.