### PR TITLE
fix(bcr): fix signer plugin BCR presubmit.yml

### DIFF
--- a/.bcr/modules/rules_img_signer_cosign/presubmit.yml
+++ b/.bcr/modules/rules_img_signer_cosign/presubmit.yml
@@ -2,11 +2,11 @@ bcr_test_module:
   module_path: "."
   matrix:
     platform: ["debian10", "ubuntu2004", "macos", "macos_arm64", "windows", "windows_arm64"]
-    bazel: [8.x]
+    bazel: [8.x, 9.*]
   tasks:
     run_test_module:
       name: "build plugin"
       platform: ${{ platform }}
       bazel: ${{ bazel }}
-      build_targets:
-        - "@rules_img_signer_$m"
+      test_targets:
+        - "//..."

--- a/.bcr/modules/rules_img_signer_notation/presubmit.yml
+++ b/.bcr/modules/rules_img_signer_notation/presubmit.yml
@@ -2,11 +2,11 @@ bcr_test_module:
   module_path: "."
   matrix:
     platform: ["debian10", "ubuntu2004", "macos", "macos_arm64", "windows", "windows_arm64"]
-    bazel: [8.x]
+    bazel: [8.x, 9.*]
   tasks:
     run_test_module:
       name: "build plugin"
       platform: ${{ platform }}
       bazel: ${{ bazel }}
-      build_targets:
-        - "@rules_img_signer_$m"
+      test_targets:
+        - "//..."


### PR DESCRIPTION
## Summary

- Replace dangling `@rules_img_signer_$m` build target (`$m` is not a BCR template variable — it was never substituted, so BCR was trying to build a literally-named external repo)
- Switch from `build_targets` to `test_targets` so the `build_test` rules actually run and verify the plugin binaries build
- Add Bazel `9.*` to the test matrix (was missing, all other modules include it)

Fixes the presubmit in the pending BCR PRs for both signer plugin modules.