### PR TITLE
feat(gateway): memoize blob existence checks in serving mode

### DIFF
--- a/img_tool/cmd/oci-distribution-gateway/README.md
+++ b/img_tool/cmd/oci-distribution-gateway/README.md
@@ -45,6 +45,8 @@ is deliberately unauthenticated and reveals nothing else.
 | `--default-registry <host>` | — | Upstream to use when the request omits the host header (still policy-checked) |
 | `--credential-helper <path>` | — | Bazel credential helper for upstream auth |
 | `--deny-private-upstreams` | `false` | Refuse upstreams that resolve to a loopback, link-local, or private address (see [Restricting which upstreams are reachable](#restricting-which-upstreams-are-reachable)) |
+| `--blob-existence-cache-ttl <dur>` | `6h` | How long a blob the registry confirmed is assumed to still be there (see [Blob existence cache](#blob-existence-cache)). `0` disables the cache |
+| `--blob-existence-cache-max-memory <size>` | `64MiB` | Memory that cache may use, preallocated at startup, e.g. `256MiB`. `0` disables the cache |
 | `--tls-cert-file`, `--tls-key-file` | — | Serve TLS, which also enables HTTP/2 via ALPN. Hot-reloaded |
 | `--client-ca-file <path>` | — | CAs whose client certificates are accepted (enables mTLS). Requires `--tls-cert-file`. Hot-reloaded |
 | `--allowed-client-id <id>` | any cert from the CA | Permitted client identity: a SPIFFE ID or a DNS name (a single leading `*.` wildcard allowed). Repeatable |
@@ -193,6 +195,95 @@ same check. It is off by default because a legitimate in-cluster registry behind
 ClusterIP *is* a private address. For a gateway shared between workloads, turn it
 on and add an egress NetworkPolicy naming your registries.
 
+## Blob existence cache
+
+A serving gateway memoizes one thing: the answer `200` to
+`HEAD /v2/<name>/blobs/<digest>`, the "is this layer already pushed?" probe every
+push begins with. On a build farm that request dominates registry traffic — a fleet
+re-pushing the same base image asks the same question thousands of times, and each
+answer is a round trip a client waits on.
+
+It is on by default, remembering a blob for six hours within 64 MiB of memory:
+
+```bash
+oci-distribution-gateway serve --policy-file /etc/img/policy.json \
+  --blob-existence-cache-ttl 6h \
+  --blob-existence-cache-max-memory 64MiB
+```
+
+Setting either flag to `0` turns the cache off, and every probe goes to the
+registry as before.
+
+**The key is the resolved upstream registry, the resolved repository, and the
+digest** — all three. A blob is present *in a repository of a registry*, not in
+general: the same digest in another repository of the same registry is a different
+question, and gets asked. Resolution happens first, so a request naming `docker.io`
+and one naming `index.docker.io` share entries (they are the same upstream) while
+`registry.example.com` and `registry.example.com:5000` do not.
+
+Only a plain `200` is remembered:
+
+- **A `404` is not cached.** A blob that is absent now can be pushed a second
+  later, so remembering "not there" would tell clients to re-upload content that
+  exists — and, worse, would not expire fast enough to be corrected.
+- **Errors are not cached**, so a `429` or a `503` cannot outlive the outage.
+- **Manifests and tags are never cached**, whatever the reference. Both are
+  mutable, and a `HEAD` on one is exactly how a client discovers that it changed.
+- **Conditional requests** (`Range`, `If-Match`, `If-None-Match`,
+  `If-Modified-Since`, `If-Unmodified-Since`, `If-Range`) go to the registry
+  untouched and their answers are not stored, since those depend on more than
+  whether the blob is there.
+
+A cached answer carries `Content-Length` (which is how a client sizes a layer
+without downloading it) and `Docker-Content-Digest` (the digest the client asked
+about, by definition of a content-addressed blob). Nothing else the registry
+happened to send is replayed to another client hours later, and every cached hit is
+logged with `(cached)` so the decision log still accounts for every request.
+
+**Authorization is not cached.** The policy is consulted on every request, before
+the cache is; a reload that revokes access takes effect on the next probe even
+though its answer is sitting in memory.
+
+### Sizing the TTL
+
+The TTL is the one thing between a client and a wrong answer. A blob cannot
+change, but a registry can **garbage-collect** one — and a push client that
+believes a collected layer is still there will skip re-uploading it and commit a
+manifest referring to a blob that is gone.
+
+Set the TTL well inside the window in which your registry could collect a blob:
+the grace period of its GC, the untagged-blob retention of your Artifactory or ECR
+lifecycle rule, whichever applies. The six-hour default suits a registry that
+collects daily at the earliest. If your registry collects aggressively, lower it;
+if blobs are never collected, raising it costs nothing but memory.
+
+### Sizing the memory
+
+The bound is allocated **in full at startup and never grows**, so the cache is a
+fixed addition to the pod's memory request rather than a number that moves under
+load. Nothing in a lookup or a store allocates, so it adds no garbage collection
+pressure either.
+
+An entry costs 376 bytes, so the default 64 MiB holds about 178,000 blob digests —
+several times a large farm's working set. When the cache is full the least recently
+used entry makes room for the new one, so a burst of one-off digests cannot push
+out blobs that are still being probed.
+
+Watch `oci_gateway_blob_existence_cache_entries / ..._capacity` for how full it is
+and `..._evictions_total{oci_gateway_cache_eviction_reason="capacity"}` for whether the
+memory bound, rather than the TTL, is deciding how long blobs are remembered — a
+capacity eviction rate above zero is the signal to raise
+`--blob-existence-cache-max-memory`. See [Metrics](#metrics).
+
+### In a two-hop deployment
+
+The cache lives in the **serving** tier, where the registry knowledge is: a
+forwarder has no policy, no credentials and no view of which upstream a request
+resolves to, and caching in every worker pod would multiply the memory by the fleet
+while sharing nothing. One shared serving deployment means one shared cache — and
+the more workers behind it, the better it works. Note that each replica keeps its
+own cache, so N replicas mean up to N upstream probes for the same first-seen blob.
+
 ## Client authentication
 
 Needed whenever the gateway listens on an address other processes can reach — most
@@ -309,6 +400,10 @@ worst-case receive buffers as
 `MaxConcurrentStreams (64) × per-stream window (2 MiB) × connections`, i.e. about
 128 MiB per fully-loaded peer connection. Set the pod's memory request and limit
 with that in mind.
+
+Add `--blob-existence-cache-max-memory` (64 MiB by default) on top: unlike the flow
+control windows, that one is allocated up front and held for the life of the
+process, so it is a flat addition to the request rather than a worst case.
 
 ### A serving deployment
 
@@ -704,7 +799,11 @@ so it is the one that counts registry traffic:
 | `oci.gateway.blob.download.size` | `oci_gateway_blob_download_size_bytes` | histogram (By) | Size distribution of those blobs |
 | `oci.gateway.blob.uploads` | `oci_gateway_blob_uploads_total` | counter | Blobs stored upstream, by `oci.blob.upload.kind` |
 | `oci.gateway.blob.upload.size` | `oci_gateway_blob_upload_size_bytes` | histogram (By) | Size distribution of uploaded blobs |
-| `oci.gateway.existence_checks` | `oci_gateway_existence_checks_total` | counter | `HEAD` probes by `oci.result` (`hit`/`miss`/`error`) |
+| `oci.gateway.existence_checks` | `oci_gateway_existence_checks_total` | counter | `HEAD` probes by `oci.result` (`hit`/`miss`/`error`). A probe answered from the [blob existence cache](#blob-existence-cache) counts as a `hit` here too, so this number means "how often was the content already there" whatever the cache is doing |
+| `oci.gateway.blob_existence_cache.lookups` | `oci_gateway_blob_existence_cache_lookups_total` | counter | Cacheable blob probes by whether the cache answered them (`oci.result`) |
+| `oci.gateway.blob_existence_cache.entries` | `oci_gateway_blob_existence_cache_entries` | gauge | Blobs the cache holds. Over `..._capacity`, how full it is |
+| `oci.gateway.blob_existence_cache.capacity` | `oci_gateway_blob_existence_cache_capacity` | gauge | Blobs it has room for. Fixed: the memory is preallocated |
+| `oci.gateway.blob_existence_cache.evictions` | `oci_gateway_blob_existence_cache_evictions_total` | counter | Entries dropped, by `oci.gateway.cache.eviction.reason` (`capacity`/`expired`) |
 | `oci.gateway.errors` | `oci_gateway_errors_total` | counter | Failures by `error.type` and registry |
 | `oci.gateway.upstream.duration` | `oci_gateway_upstream_duration_seconds` | histogram (s) | Time until the registry returned response headers |
 | `oci.gateway.upstream.auth_handshakes` | `oci_gateway_upstream_auth_handshakes_total` | counter | Ping + token exchanges (cached per repository and scope) |
@@ -738,6 +837,10 @@ semantic-convention `http.request.method`, `url.scheme`,
 A forwarder's hop instruments additionally carry `oci.gateway.peer` (the peer's
 host, constant for the process, so it costs no cardinality) and
 `network.protocol.version` (`1.1`, `2`, or `unknown`).
+
+The blob existence cache's occupancy instruments carry no registry at all — the
+memory is one pool shared by every upstream — and its evictions carry only
+`oci.gateway.cache.eviction.reason`.
 
 `error.type` is a fixed set, grouped by who is at fault:
 
@@ -791,6 +894,16 @@ histogram_quantile(0.5, sum by (le) (rate(oci_gateway_blob_download_size_bytes_b
 # HEAD hit rate: how often a push found the content already upstream.
   sum(rate(oci_gateway_existence_checks_total{oci_result="hit"}[5m]))
 / sum(rate(oci_gateway_existence_checks_total[5m]))
+
+# How much of that the gateway answered itself, without asking a registry — the
+# round trips the blob existence cache saved your build farm.
+  sum(rate(oci_gateway_blob_existence_cache_lookups_total{oci_result="hit"}[5m]))
+/ sum(rate(oci_gateway_blob_existence_cache_lookups_total[5m]))
+
+# Is that cache big enough? A capacity eviction rate above zero means the memory
+# bound, not the TTL, is deciding how long blobs are remembered.
+sum(rate(oci_gateway_blob_existence_cache_evictions_total{oci_gateway_cache_eviction_reason="capacity"}[5m]))
+sum(oci_gateway_blob_existence_cache_entries) / sum(oci_gateway_blob_existence_cache_capacity)
 
 # Errors per second by type and registry.
 sum by (error_type, oci_registry) (rate(oci_gateway_errors_total[5m]))
@@ -889,6 +1002,11 @@ counted once, by the replica that handles the committing request, but its size i
 reported as `oci.blob.upload.kind="unknown"` because no single instance saw all of
 the bytes; the `oci_gateway_io_bytes_total` bandwidth is exact either way.
 
+The blob existence cache is per replica, and its two occupancy gauges are written
+to be summed: `sum(..._entries) / sum(..._capacity)` is how full the fleet's caches
+are. A first-seen blob therefore costs up to one upstream probe per replica, which
+is the one place where adding replicas slightly lowers the hit rate.
+
 ### What is deliberately *not* measured
 
 Repository paths are never used as attributes: on a build farm they are
@@ -901,6 +1019,11 @@ A `404` is not an error — clients probe for content that does not exist as a
 matter of course, and those show up as existence-check misses. A partial (`206`)
 blob response counts toward bandwidth but not as a completed download, and a
 cross-repository mount counts as an upload with no size (it transfers no bytes).
+
+A probe the [blob existence cache](#blob-existence-cache) answered records no
+`oci.gateway.upstream.duration`, because there was no upstream leg to time. That is
+also how you tell the two apart on a dashboard: `existence_checks` counts the
+question, `upstream.duration` counts the ones that reached a registry.
 
 [buildbarn/bb-deployments]: https://github.com/buildbarn/bb-deployments
 [bb-deployments]: https://github.com/buildbarn/bb-deployments

--- a/img_tool/cmd/oci-distribution-gateway/main.go
+++ b/img_tool/cmd/oci-distribution-gateway/main.go
@@ -22,6 +22,11 @@
 // in every worker pod. See the "Two-hop deployment" section of this command's
 // README.
 //
+// A serving gateway also memoizes the blob existence checks a push begins with, so
+// that a fleet asking whether the same layer is already upstream pays for one round
+// trip rather than thousands. See --blob-existence-cache-ttl and the "Blob
+// existence cache" section of the README.
+//
 // A bare invocation with no subcommand means serving mode, so existing
 // deployments keep working unchanged.
 //
@@ -36,6 +41,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"net"
 	"net/http"
 	"os"
@@ -75,6 +81,62 @@ func (f *repeatedFlag) String() string { return strings.Join(*f, ",") }
 
 func (f *repeatedFlag) Set(value string) error {
 	*f = append(*f, value)
+	return nil
+}
+
+// byteSizeFlag is a flag value for an amount of memory: a plain byte count, or a
+// number with a unit suffix. Binary units (KiB, MiB, GiB, and the Ki/Mi/Gi
+// spellings a Kubernetes resource quantity uses) and decimal ones (KB, MB, GB)
+// are both accepted.
+//
+// A bare K, M or G is deliberately rejected: Kubernetes reads them as powers of
+// ten and Docker as powers of two, so a flag in a manifest that accepted both
+// spellings would mean different things to whoever read it next.
+type byteSizeFlag int64
+
+var byteSizeUnits = []struct {
+	suffix string
+	scale  int64
+}{
+	// Longest suffix first: "MiB" has to be tried before "B".
+	{"KiB", 1 << 10}, {"MiB", 1 << 20}, {"GiB", 1 << 30},
+	{"Ki", 1 << 10}, {"Mi", 1 << 20}, {"Gi", 1 << 30},
+	{"KB", 1e3}, {"MB", 1e6}, {"GB", 1e9},
+	{"B", 1},
+}
+
+func (f byteSizeFlag) String() string {
+	if f == 0 {
+		return "0"
+	}
+	for _, unit := range []struct {
+		suffix string
+		scale  int64
+	}{{"GiB", 1 << 30}, {"MiB", 1 << 20}, {"KiB", 1 << 10}} {
+		if int64(f)%unit.scale == 0 {
+			return strconv.FormatInt(int64(f)/unit.scale, 10) + unit.suffix
+		}
+	}
+	return strconv.FormatInt(int64(f), 10)
+}
+
+func (f *byteSizeFlag) Set(value string) error {
+	digits := strings.TrimSpace(value)
+	scale := int64(1)
+	for _, unit := range byteSizeUnits {
+		if trimmed, ok := strings.CutSuffix(digits, unit.suffix); ok {
+			digits, scale = strings.TrimSpace(trimmed), unit.scale
+			break
+		}
+	}
+	n, err := strconv.ParseInt(digits, 10, 64)
+	if err != nil || n < 0 {
+		return fmt.Errorf("%q is not a size: want a byte count, or a number with a KiB/MiB/GiB (or KB/MB/GB) suffix", value)
+	}
+	if n > math.MaxInt64/scale {
+		return fmt.Errorf("%q is out of range", value)
+	}
+	*f = byteSizeFlag(n * scale)
 	return nil
 }
 

--- a/img_tool/cmd/oci-distribution-gateway/main_test.go
+++ b/img_tool/cmd/oci-distribution-gateway/main_test.go
@@ -240,6 +240,87 @@ func TestParseSocketMode(t *testing.T) {
 	}
 }
 
+func TestByteSizeFlag(t *testing.T) {
+	for _, tc := range []struct {
+		in      string
+		want    byteSizeFlag
+		wantErr bool
+	}{
+		{in: "0", want: 0},
+		{in: "67108864", want: 64 << 20},
+		{in: "64MiB", want: 64 << 20},
+		{in: "64Mi", want: 64 << 20},
+		{in: "512KiB", want: 512 << 10},
+		{in: "2GiB", want: 2 << 30},
+		{in: "1024B", want: 1024},
+		{in: "64MB", want: 64_000_000},
+		{in: "2GB", want: 2_000_000_000},
+		{in: " 64MiB ", want: 64 << 20},
+		{in: "64 MiB", want: 64 << 20},
+		// A bare K/M/G is binary to Docker and decimal to Kubernetes, so it is
+		// refused rather than guessed at.
+		{in: "64M", wantErr: true},
+		{in: "64G", wantErr: true},
+		{in: "64mib", wantErr: true},
+		{in: "-1", wantErr: true},
+		{in: "1.5MiB", wantErr: true},
+		{in: "", wantErr: true},
+		{in: "MiB", wantErr: true},
+		{in: "9223372036854775807GiB", wantErr: true},
+	} {
+		var got byteSizeFlag
+		err := got.Set(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("byteSizeFlag.Set(%q) = %d, want an error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("byteSizeFlag.Set(%q): %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("byteSizeFlag.Set(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestByteSizeFlagString covers the flag defaults the usage message prints, which
+// is what an operator copies into a manifest.
+func TestByteSizeFlagString(t *testing.T) {
+	for _, tc := range []struct {
+		in   byteSizeFlag
+		want string
+	}{
+		{in: 0, want: "0"},
+		{in: 64 << 20, want: "64MiB"},
+		{in: 512 << 10, want: "512KiB"},
+		{in: 3 << 30, want: "3GiB"},
+		{in: 1000, want: "1000"},
+		{in: defaultBlobCacheMemory, want: "64MiB"},
+	} {
+		if got := tc.in.String(); got != tc.want {
+			t.Errorf("byteSizeFlag(%d).String() = %q, want %q", int64(tc.in), got, tc.want)
+		}
+	}
+}
+
+// TestByteSizeFlagRoundTrips checks that what the usage message prints parses
+// back to the same number, so a default copied out of --help means what it said.
+func TestByteSizeFlagRoundTrips(t *testing.T) {
+	for _, size := range []byteSizeFlag{0, 1, 1000, 1 << 10, defaultBlobCacheMemory, 3 << 30} {
+		var back byteSizeFlag
+		if err := back.Set(size.String()); err != nil {
+			t.Errorf("byteSizeFlag(%d).String() = %q, which does not parse: %v", int64(size), size, err)
+			continue
+		}
+		if back != size {
+			t.Errorf("byteSizeFlag(%d) printed as %q, which parses back as %d", int64(size), size, int64(back))
+		}
+	}
+}
+
 func TestServeProtocols(t *testing.T) {
 	// A UNIX socket stays HTTP/1.1 only: the registry protocol is request/response
 	// and the img tool's unix transport does not attempt h2 anyway.

--- a/img_tool/cmd/oci-distribution-gateway/serve.go
+++ b/img_tool/cmd/oci-distribution-gateway/serve.go
@@ -31,6 +31,10 @@ type serveFlags struct {
 	shutdownTimeout      time.Duration
 	denyPrivateUpstreams bool
 
+	// Blob existence cache.
+	blobCacheTTL       time.Duration
+	blobCacheMaxMemory byteSizeFlag
+
 	// TLS and client authentication.
 	tlsCertFile              string
 	tlsKeyFile               string
@@ -45,6 +49,13 @@ type serveFlags struct {
 	metrics metricsFlags
 }
 
+// defaultBlobCacheMemory is how much memory the blob existence cache is allowed
+// by default. It holds on the order of a hundred thousand blob digests, which
+// covers a build farm's working set several times over, and it is preallocated,
+// so it is a fixed addition to the pod's memory request rather than a number that
+// grows under load.
+const defaultBlobCacheMemory = 64 << 20
+
 func (f *serveFlags) register(flagSet *flag.FlagSet) {
 	flagSet.StringVar(&f.address, "address", "localhost", "Address to bind the gateway to (ignored when --unix-socket is set)")
 	flagSet.IntVar(&f.port, "port", 0, "Port to bind the gateway to (0 picks a free port; ignored when --unix-socket is set)")
@@ -57,6 +68,10 @@ func (f *serveFlags) register(flagSet *flag.FlagSet) {
 	flagSet.BoolVar(&f.dangerouslyAllowAll, "dangerously-allow-all", false, "Allow every request to every upstream, ignoring the policy file. DANGEROUS: only for trusted, isolated environments.")
 	flagSet.DurationVar(&f.shutdownTimeout, "shutdown-timeout", 30*time.Second, "How long in-flight requests may take to finish after a shutdown signal. Set this above your longest blob transfer, and give the pod a terminationGracePeriodSeconds larger still, or a rolling update cuts transfers short.")
 	flagSet.BoolVar(&f.denyPrivateUpstreams, "deny-private-upstreams", false, "Refuse upstream registries that resolve to a loopback, link-local, or private address. Recommended for a gateway shared between workloads; leave off when your registry is reachable only through an in-cluster (private) address.")
+
+	f.blobCacheMaxMemory = defaultBlobCacheMemory
+	flagSet.DurationVar(&f.blobCacheTTL, "blob-existence-cache-ttl", 6*time.Hour, "How long the gateway may assume a blob it has already seen is still in its repository, answering repeat HEAD probes for it without a round trip. 0 disables the cache. Keep it well inside the window in which your registry could garbage-collect a blob: a client that trusts a stale hit skips re-uploading a layer that is gone.")
+	flagSet.Var(&f.blobCacheMaxMemory, "blob-existence-cache-max-memory", "Memory the blob existence cache may use, e.g. 64MiB. It is allocated in full at startup and never grows; when it is full the least recently used blob makes room. 0 disables the cache.")
 
 	flagSet.StringVar(&f.tlsCertFile, "tls-cert-file", "", "PEM certificate (leaf plus any intermediates) to serve TLS with. Enables HTTP/2 via ALPN. Re-read when the file changes and on SIGHUP.")
 	flagSet.StringVar(&f.tlsKeyFile, "tls-key-file", "", "PEM private key matching --tls-cert-file. Both or neither.")
@@ -122,6 +137,13 @@ func serveProcess(ctx context.Context, args []string) {
 	}
 	if flags.clientCAFile != "" && flags.tlsCertFile == "" {
 		fmt.Fprintln(os.Stderr, "Error: --client-ca-file requires --tls-cert-file (a client certificate can only be presented over TLS)")
+		os.Exit(1)
+	}
+	// A bound too small to hold one blob would leave a cache that stores nothing
+	// while looking configured, so say so instead of starting up like that.
+	if flags.blobCacheTTL > 0 && flags.blobCacheMaxMemory > 0 && int64(flags.blobCacheMaxMemory) < gateway.MinBlobExistenceCacheBytes {
+		fmt.Fprintf(os.Stderr, "Error: --blob-existence-cache-max-memory %s is below the %d bytes one cached blob costs (pass 0 to disable the cache)\n",
+			flags.blobCacheMaxMemory, gateway.MinBlobExistenceCacheBytes)
 		os.Exit(1)
 	}
 
@@ -223,6 +245,7 @@ func serveProcess(ctx context.Context, args []string) {
 		gateway.WithDefaultRegistry(flags.defaultRegistry),
 		gateway.WithKeychain(reg.Keychain()),
 		gateway.WithMeterProvider(metrics.MeterProvider),
+		gateway.WithBlobExistenceCache(flags.blobCacheTTL, int64(flags.blobCacheMaxMemory)),
 	}
 	if peerAuth != nil {
 		handlerOpts = append(handlerOpts, gateway.WithPeerAuth(peerAuth))

--- a/img_tool/pkg/serve/gateway/BUILD.bazel
+++ b/img_tool/pkg/serve/gateway/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "classify.go",
         "errclass.go",
+        "existencecache.go",
         "forward.go",
         "gateway.go",
         "metrics.go",
@@ -34,6 +35,8 @@ go_test(
     srcs = [
         "classify_test.go",
         "errclass_test.go",
+        "existencecache_serve_test.go",
+        "existencecache_test.go",
         "forward_test.go",
         "gateway_test.go",
         "h2_test.go",

--- a/img_tool/pkg/serve/gateway/classify.go
+++ b/img_tool/pkg/serve/gateway/classify.go
@@ -29,15 +29,23 @@ var (
 	nameGrammar = `[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*`
 
 	blobUploadRe = regexp.MustCompile(`^/v2/(` + nameGrammar + `)/blobs/uploads/?(?P<reference>.*)$`)
-	blobRe       = regexp.MustCompile(`^/v2/(` + nameGrammar + `)/blobs/([^/]+)$`)
+	blobRe       = regexp.MustCompile(`^/v2/(` + nameGrammar + `)/blobs/(?P<reference>[^/]+)$`)
 	manifestRe   = regexp.MustCompile(`^/v2/(` + nameGrammar + `)/manifests/(.+)$`)
 	tagsRe       = regexp.MustCompile(`^/v2/(` + nameGrammar + `)/tags/list$`)
 	referrersRe  = regexp.MustCompile(`^/v2/(` + nameGrammar + `)/referrers/(.+)$`)
 
-	// uploadRefGroup is the submatch index of the upload session reference. The
-	// repository grammar contains groups of its own, so it is looked up by name
-	// rather than assumed to be a fixed index.
+	// digestRe matches a content descriptor digest per the distribution spec's
+	// grammar (algorithm ":" encoded). It gates what the blob existence cache
+	// keys on: a reference that is not a digest names nothing immutable, and
+	// matching bounds the key length as a side effect.
+	digestRe = regexp.MustCompile(`^[a-z0-9]+(?:[+._-][a-z0-9]+)*:[a-zA-Z0-9=_-]{32,128}$`)
+
+	// uploadRefGroup and blobRefGroup are the submatch indices of the upload
+	// session reference and of the blob reference. The repository grammar contains
+	// groups of its own, so they are looked up by name rather than assumed to be a
+	// fixed index.
 	uploadRefGroup = blobUploadRe.SubexpIndex("reference")
+	blobRefGroup   = blobRe.SubexpIndex("reference")
 )
 
 // Values of the oci.operation metric attribute: a stable, low-cardinality token
@@ -93,6 +101,11 @@ type request struct {
 	// forwarded: the gateway could otherwise authorize a different mount source
 	// than the one the upstream acts on.
 	malformedQuery bool
+	// digest is the blob digest a blob existence check asked about, and is set
+	// only for that operation and only when the reference really is a digest. It
+	// is the part of the blob existence cache's key that identifies the content;
+	// leaving it empty is how every other request opts out of the cache.
+	digest string
 }
 
 // existenceCheck reports whether this is a HEAD probe for a blob or manifest,
@@ -152,7 +165,14 @@ func classify(r *http.Request) (request, bool) {
 		case http.MethodGet:
 			return request{repo: m[1], req: reqBlobRead, kind: "blob read", op: opNameBlobRead, route: routeBlob}, true
 		case http.MethodHead:
-			return request{repo: m[1], req: reqBlobReadOrWrite, kind: "blob existence check", op: opNameBlobHead, route: routeBlob}, true
+			req := request{repo: m[1], req: reqBlobReadOrWrite, kind: "blob existence check", op: opNameBlobHead, route: routeBlob}
+			// Carry the digest only when the reference is one, so that the blob
+			// existence cache is never keyed on a reference no registry could
+			// answer for.
+			if digestRe.MatchString(m[blobRefGroup]) {
+				req.digest = m[blobRefGroup]
+			}
+			return req, true
 		default: // DELETE and anything else that mutates.
 			return request{repo: m[1], req: reqBlobWrite, kind: "blob write", op: opNameBlobWrite, route: routeBlob, write: true}, true
 		}

--- a/img_tool/pkg/serve/gateway/classify_test.go
+++ b/img_tool/pkg/serve/gateway/classify_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -86,6 +87,46 @@ func TestClassifyMount(t *testing.T) {
 			}
 			if got.malformedQuery != tc.wantBadReq {
 				t.Errorf("malformedQuery = %v, want %v", got.malformedQuery, tc.wantBadReq)
+			}
+		})
+	}
+}
+
+// TestClassifyBlobDigest covers the field the blob existence cache keys on. It is
+// set only for a blob existence check, and only when the reference really is a
+// digest — the repository grammar has capture groups of its own, so reading the
+// reference out of the wrong submatch is the mistake to guard against.
+func TestClassifyBlobDigest(t *testing.T) {
+	const sha256Digest = "sha256:6b0f2e1a4c3d5e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f7"
+	for _, tc := range []struct {
+		name       string
+		method     string
+		path       string
+		wantDigest string
+	}{
+		{"blob head", http.MethodHead, "/v2/app/blobs/" + sha256Digest, sha256Digest},
+		{"nested repository", http.MethodHead, "/v2/team/service/app/blobs/" + sha256Digest, sha256Digest},
+		{"repository with separators", http.MethodHead, "/v2/a.b__c-d/blobs/" + sha256Digest, sha256Digest},
+		{"sha512", http.MethodHead, "/v2/app/blobs/sha512:" + strings.Repeat("ab", 64), "sha512:" + strings.Repeat("ab", 64)},
+		{"multipart algorithm", http.MethodHead, "/v2/app/blobs/multihash+base58:" + strings.Repeat("c", 46), "multihash+base58:" + strings.Repeat("c", 46)},
+		// Not a digest, so nothing immutable is named.
+		{"tag", http.MethodHead, "/v2/app/blobs/latest", ""},
+		{"too short to be a digest", http.MethodHead, "/v2/app/blobs/sha256:abc", ""},
+		{"too long to be a digest", http.MethodHead, "/v2/app/blobs/sha256:" + strings.Repeat("a", 129), ""},
+		{"no algorithm", http.MethodHead, "/v2/app/blobs/" + strings.Repeat("a", 64), ""},
+		{"uppercase algorithm", http.MethodHead, "/v2/app/blobs/SHA256:" + strings.Repeat("a", 64), ""},
+		// Only the existence check is cacheable; a read or a delete is not.
+		{"blob get", http.MethodGet, "/v2/app/blobs/" + sha256Digest, ""},
+		{"blob delete", http.MethodDelete, "/v2/app/blobs/" + sha256Digest, ""},
+		{"manifest head", http.MethodHead, "/v2/app/manifests/" + sha256Digest, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := classify(req(tc.method, tc.path))
+			if !ok {
+				t.Fatalf("classify ok = false, want true")
+			}
+			if got.digest != tc.wantDigest {
+				t.Errorf("digest = %q, want %q", got.digest, tc.wantDigest)
 			}
 		})
 	}

--- a/img_tool/pkg/serve/gateway/existencecache.go
+++ b/img_tool/pkg/serve/gateway/existencecache.go
@@ -1,0 +1,499 @@
+package gateway
+
+import (
+	"hash/maphash"
+	"math/bits"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+// This file implements the blob existence cache: a memo of the successful
+// answers to HEAD /v2/<name>/blobs/<digest>.
+//
+// That one request dominates a build farm's registry traffic. Every push begins
+// by probing whether each layer is already upstream, so a fleet re-pushing the
+// same base image asks the same question thousands of times, and each answer
+// costs a round trip the client waits on. The answer is also the most cacheable
+// one in the protocol: a blob is immutable and content-addressed, so "this
+// digest is present in this repository" cannot become true-then-false-then-true
+// — it can only stop being true, when the registry garbage-collects the blob.
+// That single failure mode is what the TTL bounds.
+//
+// Manifests and tags are deliberately *not* cached. A tag is mutable by
+// definition, and a manifest HEAD is how a client discovers that a tag now
+// points somewhere else, so memoizing either would hand out stale answers about
+// data that is meant to change.
+//
+// The implementation is one preallocated block of memory, sharded for
+// concurrency:
+//
+//   - Capacity is fixed at startup from the configured memory bound. The slot
+//     table, the hash buckets and the key arena are three allocations made once;
+//     nothing in a lookup or a store allocates, and the cache's contribution to
+//     RSS cannot grow past the bound no matter what traffic arrives.
+//   - Each entry owns a fixed slice of the arena for its key, so the arena never
+//     fragments and evicting an entry is an overwrite rather than a free.
+//   - Every link is an index into the slot table rather than a pointer, so the
+//     whole structure holds no pointers and the garbage collector never scans
+//     it.
+//   - Keys are spread over independently locked shards, which is what lets the
+//     cache scale with cores: a lookup takes one shard's mutex and holds it for a
+//     hash-bucket walk and an LRU splice, both O(1) (see BenchmarkBlobCache).
+//
+// The one thing this deliberately does not do is collapse concurrent misses for
+// the same blob into a single upstream request. A registry answers a blob HEAD
+// in milliseconds, so the duplicate probes a burst can produce are cheap, while
+// sharing one in-flight request would tie one client's answer to another
+// client's context and cancellation.
+
+const (
+	// entryBytes is the arena slice one entry gets for its key: the upstream
+	// registry, the repository, and the digest, concatenated. It leaves room for a
+	// key far longer than a registry serves — a sha256 digest is 71 bytes of it, so
+	// a 249-byte registry and repository still fit, and even a sha512 digest leaves
+	// 185 — and a key that does not fit is simply not cached.
+	entryBytes = 320
+
+	// slotBytes is the size of the fixed-size part of an entry. unsafe.Sizeof is
+	// a compile-time constant — this file does no pointer arithmetic — and using
+	// it keeps the memory accounting exact rather than a number to maintain by
+	// hand.
+	slotBytes = int64(unsafe.Sizeof(slot{}))
+
+	// bucketBytes is an entry's share of the hash bucket table, which is sized to
+	// the next power of two at or above a shard's slot count and therefore holds
+	// fewer than two int32 per slot.
+	bucketBytes = 2 * 4
+
+	// entryCost is what one entry takes out of the configured memory bound. The
+	// three tables are the cache's only allocations, so capacity x entryCost is
+	// its total footprint.
+	entryCost = entryBytes + slotBytes + bucketBytes
+
+	// maxShards caps the shard count, and shardsPerProc is how many shards each
+	// runnable goroutine gets. Both come from measurement (BenchmarkBlobCache):
+	// the cost under load is dominated by cores contending for the same shard, so
+	// spreading keys widely is what makes the cache scale, and past this cap the
+	// curve is flat and shards only cost LRU quality — each shard evicts its own
+	// least recently used entry, not the cache's.
+	maxShards     = 256
+	shardsPerProc = 16
+
+	// minSlotsPerShard keeps sharding from turning a small cache into a set of
+	// tiny LRU lists that evict entries a single list would have kept.
+	minSlotsPerShard = 64
+
+	// maxCapacity bounds the slot table, so that a slot index always fits in the
+	// int32 links and the table sizes cannot overflow an int on a 32-bit platform.
+	// A larger memory bound is honoured up to this many entries and no further,
+	// which is not a limit any real deployment reaches: it is about 1.5 GiB worth
+	// of blob digests.
+	maxCapacity = 1 << 22
+)
+
+// MinBlobExistenceCacheBytes is the smallest memory bound that holds one entry.
+// A smaller one disables the cache, so a command validates against it rather
+// than starting up with a cache that silently never stores anything.
+const MinBlobExistenceCacheBytes = entryCost
+
+// slot is the fixed-size part of a cache entry.
+//
+// Every link is an int32 index into the owning shard's slot table, with -1 for
+// "none", which is what keeps the whole structure free of pointers for the
+// garbage collector to trace.
+type slot struct {
+	// hash is the full 64-bit hash of the key, so walking a bucket only compares
+	// key bytes for a slot whose hash already matches.
+	hash uint64
+	// expires is the deadline, in nanoseconds since the cache's base time. It is
+	// zero in a slot that holds no entry.
+	expires int64
+	// contentLength is the Content-Length the registry reported for the blob, or
+	// -1 when it reported none.
+	contentLength int64
+	// prev and next chain the LRU list, most recently used first. next doubles as
+	// the free-list link in a slot that holds no entry.
+	prev, next int32
+	// hprev and hnext chain the slots that share a hash bucket. The head of a
+	// bucket has hprev == -1; its bucket index is recomputed from hash, so it
+	// does not have to be stored.
+	hprev, hnext int32
+	// The lengths of the three key parts in the slot's arena slice, which is laid
+	// out as registry, then repository, then digest.
+	regLen, repoLen, digestLen uint16
+}
+
+// blobExistenceCache memoizes successful blob existence checks.
+//
+// A nil *blobExistenceCache is a disabled cache: every method tolerates it, so
+// the gateway needs no second code path for the cache being turned off.
+type blobExistenceCache struct {
+	shards []cacheShard
+	// shardShift takes a shard index from the top bits of a key's hash. The
+	// bucket index comes from the bottom bits, so the two are independent.
+	shardShift uint
+	// seed is this process's hash seed. maphash randomizes it per process, which
+	// is what stops a client from choosing digests that collide into one bucket.
+	seed maphash.Seed
+	ttl  time.Duration
+	// base is the reference point deadlines are measured from. Storing an offset
+	// from it rather than a wall-clock instant means both readings carry the
+	// monotonic clock, so a clock step (NTP, a suspended VM) cannot stretch or
+	// cut short a TTL.
+	base time.Time
+	// now is the clock, replaced in tests.
+	now func() time.Time
+	// capacity is the number of slots, summed over the shards.
+	capacity int64
+}
+
+// cacheShard is one independently locked partition of the cache. Everything it
+// owns is a slice of the cache's three preallocated tables.
+type cacheShard struct {
+	mu sync.Mutex
+	// slots, buckets and arena are this shard's slices of the three tables. Slot
+	// i owns arena[i*entryBytes:(i+1)*entryBytes].
+	slots   []slot
+	buckets []int32
+	arena   []byte
+	// mask turns a hash into a bucket index; buckets is a power of two long.
+	mask uint64
+	// head and tail are the ends of the LRU list, -1 when it is empty.
+	head, tail int32
+	// free heads the list of slots whose entry was dropped, chained through
+	// slot.next. used counts the slots that have ever held an entry, so the table
+	// is filled without an initialization pass over every slot.
+	free int32
+	used int32
+
+	// The counters below are read without the lock, by the metric callbacks.
+	live            atomic.Int64
+	evictedCapacity atomic.Int64
+	evictedExpired  atomic.Int64
+}
+
+// newBlobExistenceCache builds a cache that treats a blob it has seen as present
+// for ttl, within maxBytes of memory allocated up front.
+//
+// It returns nil — a disabled cache — when ttl is not positive or when maxBytes
+// is too small to hold a single entry.
+func newBlobExistenceCache(ttl time.Duration, maxBytes int64) *blobExistenceCache {
+	if ttl <= 0 || maxBytes < entryCost {
+		return nil
+	}
+	capacity := maxBytes / entryCost
+	if capacity > maxCapacity {
+		capacity = maxCapacity
+	}
+	shards := shardCount(capacity)
+	perShard := int(capacity) / shards
+	// One power-of-two bucket table per shard, at a load factor of at most 1: an
+	// average bucket then holds about one entry, so a lookup that misses walks a
+	// single link and one that hits walks one or two.
+	perShardBuckets := 1 << bits.Len(uint(perShard-1))
+	total := perShard * shards
+
+	c := &blobExistenceCache{
+		shards:     make([]cacheShard, shards),
+		shardShift: uint(64 - bits.TrailingZeros(uint(shards))),
+		seed:       maphash.MakeSeed(),
+		ttl:        ttl,
+		base:       time.Now(),
+		now:        time.Now,
+		capacity:   int64(total),
+	}
+	// The three tables, allocated once. None of them holds a pointer, so the
+	// runtime hands them out as fresh (already zeroed) pages: the arena and the slot
+	// table cost nothing in RSS until entries are stored in them, and only the
+	// bucket table — the smallest of the three — is touched here, to write its empty
+	// sentinel.
+	slots := make([]slot, total)
+	buckets := make([]int32, perShardBuckets*shards)
+	arena := make([]byte, total*entryBytes)
+	for i := range buckets {
+		buckets[i] = -1
+	}
+	for i := range c.shards {
+		s := &c.shards[i]
+		s.slots = slots[i*perShard : (i+1)*perShard]
+		s.buckets = buckets[i*perShardBuckets : (i+1)*perShardBuckets]
+		s.arena = arena[i*perShard*entryBytes : (i+1)*perShard*entryBytes]
+		s.mask = uint64(perShardBuckets - 1)
+		s.head, s.tail, s.free = -1, -1, -1
+	}
+	return c
+}
+
+// shardCount picks a power-of-two shard count: enough that concurrent lookups of
+// different blobs rarely queue behind each other, but not so many that each
+// shard's LRU list is too short to be a useful one.
+func shardCount(capacity int64) int {
+	n := 1
+	for n < maxShards && n < shardsPerProc*runtime.GOMAXPROCS(0) && int64(n*2*minSlotsPerShard) <= capacity {
+		n *= 2
+	}
+	return n
+}
+
+// lookup reports whether the blob is known to exist in the repository, and the
+// Content-Length the registry gave for it (-1 if it gave none).
+//
+// A hit moves the entry to the head of its shard's LRU list. An entry past its
+// deadline is dropped and reported as a miss, so the caller asks the registry
+// again.
+func (c *blobExistenceCache) lookup(registry, repository, digest string) (contentLength int64, ok bool) {
+	if c == nil {
+		return 0, false
+	}
+	hash := c.hash(registry, repository, digest)
+	s := &c.shards[hash>>c.shardShift]
+	now := c.elapsed()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	idx := s.find(hash, registry, repository, digest)
+	if idx < 0 {
+		return 0, false
+	}
+	if s.slots[idx].expires <= now {
+		s.drop(idx)
+		s.evictedExpired.Add(1)
+		return 0, false
+	}
+	s.touch(idx)
+	return s.slots[idx].contentLength, true
+}
+
+// store records that the blob exists in the repository, for the cache's TTL,
+// evicting the least recently used entry of its shard if that shard is full.
+// Storing a key that is already present refreshes its deadline in place.
+//
+// A key too long for an entry's arena slice is not stored. It is the one case
+// that is skipped silently: no registry serves a name that long, and the
+// alternative — a variable-length arena — would fragment and could not offer a
+// hard memory bound.
+func (c *blobExistenceCache) store(registry, repository, digest string, contentLength int64) {
+	if c == nil || len(registry)+len(repository)+len(digest) > entryBytes {
+		return
+	}
+	hash := c.hash(registry, repository, digest)
+	s := &c.shards[hash>>c.shardShift]
+	expires := c.elapsed() + c.ttl.Nanoseconds()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if idx := s.find(hash, registry, repository, digest); idx >= 0 {
+		s.slots[idx].expires = expires
+		s.slots[idx].contentLength = contentLength
+		s.touch(idx)
+		return
+	}
+
+	idx := s.claim()
+	region := s.arena[int(idx)*entryBytes:][:entryBytes]
+	n := copy(region, registry)
+	n += copy(region[n:], repository)
+	copy(region[n:], digest)
+
+	e := &s.slots[idx]
+	e.hash = hash
+	e.expires = expires
+	e.contentLength = contentLength
+	e.regLen = uint16(len(registry))
+	e.repoLen = uint16(len(repository))
+	e.digestLen = uint16(len(digest))
+
+	s.link(idx)
+	s.pushFront(idx)
+	s.live.Add(1)
+}
+
+// hash mixes the three parts of a key without concatenating them, so a lookup
+// allocates nothing.
+func (c *blobExistenceCache) hash(registry, repository, digest string) uint64 {
+	h := maphash.String(c.seed, registry)
+	h = mixHash(h, maphash.String(c.seed, repository))
+	return mixHash(h, maphash.String(c.seed, digest))
+}
+
+// mixHash combines two 64-bit hashes so that every input bit reaches every
+// output bit — splitmix64's finalizer over the two. That matters here because
+// the shard index comes from the top of the result and the bucket index from the
+// bottom: a weaker combiner would correlate the two and pile keys into a corner
+// of one shard.
+func mixHash(a, b uint64) uint64 {
+	x := a ^ (b * 0x9e3779b97f4a7c15)
+	x ^= x >> 30
+	x *= 0xbf58476d1ce4e5b9
+	x ^= x >> 27
+	x *= 0x94d049bb133111eb
+	return x ^ (x >> 31)
+}
+
+// elapsed is the current time as a nanosecond offset from the cache's base.
+func (c *blobExistenceCache) elapsed() int64 {
+	return int64(c.now().Sub(c.base))
+}
+
+// cacheStats is a snapshot of the cache's occupancy for the metric callbacks. It
+// is read from atomics rather than under the shard locks, so exporting metrics
+// never blocks a lookup.
+type cacheStats struct {
+	// entries counts the entries held, including any that have expired but have
+	// not been looked up or evicted since.
+	entries int64
+	// capacity is the number of entries the memory bound allows.
+	capacity int64
+	// evictedCapacity counts entries dropped to make room, evictedExpired those
+	// dropped because their TTL had passed.
+	evictedCapacity int64
+	evictedExpired  int64
+}
+
+func (c *blobExistenceCache) stats() cacheStats {
+	if c == nil {
+		return cacheStats{}
+	}
+	st := cacheStats{capacity: c.capacity}
+	for i := range c.shards {
+		s := &c.shards[i]
+		st.entries += s.live.Load()
+		st.evictedCapacity += s.evictedCapacity.Load()
+		st.evictedExpired += s.evictedExpired.Load()
+	}
+	return st
+}
+
+// find returns the slot holding the key, or -1. The stored key bytes are
+// compared even though the hash already matched: a 64-bit collision is
+// improbable, but the cost of one would be telling a client a blob exists in a
+// repository it was never seen in.
+func (s *cacheShard) find(hash uint64, registry, repository, digest string) int32 {
+	for idx := s.buckets[hash&s.mask]; idx >= 0; idx = s.slots[idx].hnext {
+		if s.slots[idx].hash == hash && s.matches(idx, registry, repository, digest) {
+			return idx
+		}
+	}
+	return -1
+}
+
+// matches compares an entry's stored key with the three parts of a lookup key.
+// The comparisons are against the arena bytes directly: the compiler turns
+// string(b) == s into a comparison that materializes no string, so this
+// allocates nothing.
+func (s *cacheShard) matches(idx int32, registry, repository, digest string) bool {
+	e := &s.slots[idx]
+	if int(e.regLen) != len(registry) || int(e.repoLen) != len(repository) || int(e.digestLen) != len(digest) {
+		return false
+	}
+	regEnd := int(e.regLen)
+	repoEnd := regEnd + int(e.repoLen)
+	key := s.arena[int(idx)*entryBytes:][:repoEnd+int(e.digestLen)]
+	return string(key[:regEnd]) == registry &&
+		string(key[regEnd:repoEnd]) == repository &&
+		string(key[repoEnd:]) == digest
+}
+
+// claim returns a slot to write a new entry into: one freed earlier, then one
+// that has never been used, and finally the least recently used entry, which is
+// evicted to make room.
+func (s *cacheShard) claim() int32 {
+	if s.free >= 0 {
+		idx := s.free
+		s.free = s.slots[idx].next
+		return idx
+	}
+	if int(s.used) < len(s.slots) {
+		idx := s.used
+		s.used++
+		return idx
+	}
+	idx := s.tail
+	s.unlinkLRU(idx)
+	s.unlink(idx)
+	s.evictedCapacity.Add(1)
+	s.live.Add(-1)
+	return idx
+}
+
+// drop removes an entry and returns its slot to the free list.
+func (s *cacheShard) drop(idx int32) {
+	s.unlinkLRU(idx)
+	s.unlink(idx)
+	s.slots[idx].expires = 0
+	// The free list is chained through next, so this has to come after unlinkLRU,
+	// which writes that field as part of unlinking.
+	s.slots[idx].next = s.free
+	s.free = idx
+	s.live.Add(-1)
+}
+
+// touch moves an entry to the head of the LRU list. An entry that is already the
+// head needs no work at all, which is the common case for the blob a fleet is
+// currently hammering.
+func (s *cacheShard) touch(idx int32) {
+	if s.head == idx {
+		return
+	}
+	s.unlinkLRU(idx)
+	s.pushFront(idx)
+}
+
+func (s *cacheShard) pushFront(idx int32) {
+	e := &s.slots[idx]
+	e.prev, e.next = -1, s.head
+	if s.head >= 0 {
+		s.slots[s.head].prev = idx
+	}
+	s.head = idx
+	if s.tail < 0 {
+		s.tail = idx
+	}
+}
+
+func (s *cacheShard) unlinkLRU(idx int32) {
+	e := &s.slots[idx]
+	if e.prev >= 0 {
+		s.slots[e.prev].next = e.next
+	} else {
+		s.head = e.next
+	}
+	if e.next >= 0 {
+		s.slots[e.next].prev = e.prev
+	} else {
+		s.tail = e.prev
+	}
+	e.prev, e.next = -1, -1
+}
+
+// link adds an entry to its hash bucket.
+func (s *cacheShard) link(idx int32) {
+	bucket := s.slots[idx].hash & s.mask
+	head := s.buckets[bucket]
+	e := &s.slots[idx]
+	e.hprev, e.hnext = -1, head
+	if head >= 0 {
+		s.slots[head].hprev = idx
+	}
+	s.buckets[bucket] = idx
+}
+
+// unlink removes an entry from its hash bucket. The bucket is recomputed from
+// the entry's hash, which is why a slot does not store its bucket index.
+func (s *cacheShard) unlink(idx int32) {
+	e := &s.slots[idx]
+	if e.hprev >= 0 {
+		s.slots[e.hprev].hnext = e.hnext
+	} else {
+		s.buckets[e.hash&s.mask] = e.hnext
+	}
+	if e.hnext >= 0 {
+		s.slots[e.hnext].hprev = e.hprev
+	}
+	e.hprev, e.hnext = -1, -1
+}

--- a/img_tool/pkg/serve/gateway/existencecache_serve_test.go
+++ b/img_tool/pkg/serve/gateway/existencecache_serve_test.go
@@ -1,0 +1,455 @@
+package gateway
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	clientgateway "github.com/bazel-contrib/rules_img/img_tool/pkg/gateway"
+)
+
+// These tests cover the blob existence cache through the handler: what a client
+// observes, and which requests reach the upstream registry. The data structure
+// itself is tested in existencecache_test.go.
+
+const testBlobPath = "/v2/app/blobs/" + testCacheDigest
+
+// blobUpstream is a scripted upstream registry that counts the requests reaching
+// it, which is how these tests tell a replayed answer from a forwarded one.
+type blobUpstream struct {
+	// status is answered to everything but the /v2/ ping.
+	status int
+	// contentLength is sent as the Content-Length header, when not empty.
+	contentLength string
+	requests      []*http.Request
+}
+
+func (u *blobUpstream) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.URL.Path == "/v2/" || r.URL.Path == "/v2" {
+		return upstreamResponse(http.StatusOK, nil, ""), nil
+	}
+	u.requests = append(u.requests, r)
+	header := http.Header{}
+	if u.contentLength != "" {
+		header.Set("Content-Length", u.contentLength)
+	}
+	// A header of the registry's own, which a cached answer must not replay to
+	// some other client hours later.
+	header.Set("Etag", `"upstream-etag"`)
+	return upstreamResponse(u.status, header, ""), nil
+}
+
+// count reports how many requests for the given path reached the upstream.
+func (u *blobUpstream) count(method, path string) int {
+	n := 0
+	for _, r := range u.requests {
+		if r.Method == method && r.URL.EscapedPath() == path {
+			n++
+		}
+	}
+	return n
+}
+
+// newCachingHandler wires a gateway with the blob existence cache enabled, plus
+// the clock the cache reads, so a test can let entries expire without sleeping.
+func newCachingHandler(t *testing.T, cp *CompiledPolicy, base http.RoundTripper, ttl time.Duration) (*Handler, *fakeClock) {
+	t.Helper()
+	h := New(
+		WithAuthorizer(cp),
+		WithKeychain(authn.NewMultiKeychain()), // always anonymous, hermetic
+		WithLogger(log.New(io.Discard, "", 0)),
+		WithBaseTransport(base),
+		WithBlobExistenceCache(ttl, 256*entryCost),
+	)
+	if h.blobCache == nil {
+		t.Fatalf("WithBlobExistenceCache(%v, room for 256) left the cache disabled", ttl)
+	}
+	clock := &fakeClock{t: h.blobCache.base}
+	h.blobCache.now = clock.now
+	return h, clock
+}
+
+// head sends a blob existence check through the gateway, with any extra request
+// headers applied as key/value pairs.
+func head(h *Handler, host, path string, headers ...string) *http.Response {
+	r, _ := http.NewRequest(http.MethodHead, "http://gateway"+path, nil)
+	if host != "" {
+		r.Header.Set(clientgateway.OriginalHostHeader, host)
+	}
+	for i := 0; i+1 < len(headers); i += 2 {
+		r.Header.Set(headers[i], headers[i+1])
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, r)
+	return rec.Result()
+}
+
+// TestBlobExistenceCacheAnswersRepeatProbes is the point of the feature: the
+// second probe for a blob the registry already confirmed costs no round trip.
+func TestBlobExistenceCacheAnswersRepeatProbes(t *testing.T) {
+	up := &blobUpstream{status: http.StatusOK, contentLength: "12345"}
+	h, _ := newCachingHandler(t, allowHostPolicy(t, testUpstreamHost, "blob:read"), up, time.Hour)
+
+	first := head(h, testUpstreamHost, testBlobPath)
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("first probe status = %d, want 200", first.StatusCode)
+	}
+	if got := up.count(http.MethodHead, testBlobPath); got != 1 {
+		t.Fatalf("upstream saw %d probes, want 1", got)
+	}
+
+	second := head(h, testUpstreamHost, testBlobPath)
+	if second.StatusCode != http.StatusOK {
+		t.Fatalf("cached probe status = %d, want 200", second.StatusCode)
+	}
+	if got := up.count(http.MethodHead, testBlobPath); got != 1 {
+		t.Fatalf("upstream saw %d probes, want the second answered from the cache", got)
+	}
+
+	// The replayed answer carries what a client reads off a blob HEAD: the size,
+	// and the digest it asked about.
+	if got := second.Header.Get("Content-Length"); got != "12345" {
+		t.Errorf("cached Content-Length = %q, want %q", got, "12345")
+	}
+	if got := second.Header.Get("Docker-Content-Digest"); got != testCacheDigest {
+		t.Errorf("cached Docker-Content-Digest = %q, want %q", got, testCacheDigest)
+	}
+	// ...and nothing else the registry happened to send.
+	if got := second.Header.Get("Etag"); got != "" {
+		t.Errorf("cached answer replayed the upstream Etag %q", got)
+	}
+	if got := first.Header.Get("Etag"); got == "" {
+		t.Error("the forwarded answer dropped the upstream Etag, so the test above proves nothing")
+	}
+}
+
+// TestBlobExistenceCacheOmitsUnknownContentLength keeps a registry that sends no
+// Content-Length from being turned into one that claims a zero-byte blob.
+func TestBlobExistenceCacheOmitsUnknownContentLength(t *testing.T) {
+	up := &blobUpstream{status: http.StatusOK}
+	h, _ := newCachingHandler(t, allowHostPolicy(t, testUpstreamHost, "blob:read"), up, time.Hour)
+
+	head(h, testUpstreamHost, testBlobPath)
+	cached := head(h, testUpstreamHost, testBlobPath)
+	if got := cached.Header.Get("Content-Length"); got != "" {
+		t.Errorf("cached Content-Length = %q, want it absent", got)
+	}
+	if cached.StatusCode != http.StatusOK {
+		t.Errorf("cached probe status = %d, want 200", cached.StatusCode)
+	}
+}
+
+// TestBlobExistenceCacheKeyedByRepositoryAndRegistry is the correctness property
+// at the handler level: a blob is present in one repository of one registry, and
+// nothing may be concluded about any other.
+func TestBlobExistenceCacheKeyedByRepositoryAndRegistry(t *testing.T) {
+	up := &blobUpstream{status: http.StatusOK, contentLength: "1"}
+	h, _ := newCachingHandler(t, AllowAll(), up, time.Hour)
+
+	head(h, testUpstreamHost, testBlobPath)
+
+	otherRepo := "/v2/other/blobs/" + testCacheDigest
+	head(h, testUpstreamHost, otherRepo)
+	if got := up.count(http.MethodHead, otherRepo); got != 1 {
+		t.Errorf("another repository was answered from the cache (%d upstream probes)", got)
+	}
+
+	// The same repository path on a different registry, which resolves to a
+	// different upstream.
+	head(h, "other.registry.test", testBlobPath)
+	if got := up.count(http.MethodHead, testBlobPath); got != 2 {
+		t.Errorf("another registry was answered from the cache (%d upstream probes)", got)
+	}
+}
+
+// TestBlobExistenceCacheStoresOnlyPresentBlobs keeps the cache to the one answer
+// that is safe to remember. A blob that is absent now can be pushed a second
+// later, so a remembered 404 would tell a client to download something that is
+// there, and a remembered error would outlive the outage that caused it.
+func TestBlobExistenceCacheStoresOnlyPresentBlobs(t *testing.T) {
+	for _, status := range []int{
+		http.StatusNotFound,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusUnauthorized,
+		// A partial answer is not "the blob is present" either.
+		http.StatusPartialContent,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			up := &blobUpstream{status: status}
+			h, _ := newCachingHandler(t, allowHostPolicy(t, testUpstreamHost, "blob:read"), up, time.Hour)
+
+			head(h, testUpstreamHost, testBlobPath)
+			head(h, testUpstreamHost, testBlobPath)
+			if got := up.count(http.MethodHead, testBlobPath); got != 2 {
+				t.Errorf("a %d answer was cached (%d upstream probes, want 2)", status, got)
+			}
+			if entries := h.blobCache.stats().entries; entries != 0 {
+				t.Errorf("cache holds %d entries after a %d answer, want 0", entries, status)
+			}
+		})
+	}
+}
+
+// TestBlobExistenceCacheIgnoresMutableReferences covers what the cache must not
+// touch. A tag or a manifest can be repointed at any moment, and a HEAD on one is
+// exactly how a client finds that out.
+func TestBlobExistenceCacheIgnoresMutableReferences(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"manifest by tag", "/v2/app/manifests/latest"},
+		{"manifest by digest", "/v2/app/manifests/" + testCacheDigest},
+		{"blob by a reference that is not a digest", "/v2/app/blobs/latest"},
+		{"blob by a truncated digest", "/v2/app/blobs/sha256:abc123"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			up := &blobUpstream{status: http.StatusOK, contentLength: "1"}
+			h, _ := newCachingHandler(t, AllowAll(), up, time.Hour)
+
+			head(h, testUpstreamHost, tc.path)
+			head(h, testUpstreamHost, tc.path)
+			if got := up.count(http.MethodHead, tc.path); got != 2 {
+				t.Errorf("%s was cached (%d upstream probes, want 2)", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestBlobExistenceCacheBypassedByConditionalRequests checks the requests that
+// are handed to the registry untouched, because their answer depends on more than
+// whether the blob is there.
+func TestBlobExistenceCacheBypassedByConditionalRequests(t *testing.T) {
+	for _, header := range []struct{ key, value string }{
+		{"Range", "bytes=0-1023"},
+		{"If-Match", `"etag"`},
+		{"If-None-Match", `"etag"`},
+		{"If-Modified-Since", "Wed, 21 Oct 2015 07:28:00 GMT"},
+		{"If-Unmodified-Since", "Wed, 21 Oct 2015 07:28:00 GMT"},
+		{"If-Range", `"etag"`},
+	} {
+		t.Run(header.key, func(t *testing.T) {
+			up := &blobUpstream{status: http.StatusOK, contentLength: "1"}
+			h, _ := newCachingHandler(t, allowHostPolicy(t, testUpstreamHost, "blob:read"), up, time.Hour)
+
+			// Warm the cache with a plain probe, then send a conditional one: it must
+			// still reach the registry.
+			head(h, testUpstreamHost, testBlobPath)
+			head(h, testUpstreamHost, testBlobPath, header.key, header.value)
+			if got := up.count(http.MethodHead, testBlobPath); got != 2 {
+				t.Errorf("a request with %s was answered from the cache (%d upstream probes, want 2)", header.key, got)
+			}
+		})
+	}
+}
+
+// TestBlobExistenceCacheConditionalAnswerNotStored is the other half: a
+// conditional request's answer must not become the cache's idea of the blob.
+func TestBlobExistenceCacheConditionalAnswerNotStored(t *testing.T) {
+	up := &blobUpstream{status: http.StatusOK, contentLength: "1"}
+	h, _ := newCachingHandler(t, allowHostPolicy(t, testUpstreamHost, "blob:read"), up, time.Hour)
+
+	head(h, testUpstreamHost, testBlobPath, "Range", "bytes=0-1023")
+	if entries := h.blobCache.stats().entries; entries != 0 {
+		t.Fatalf("cache holds %d entries after a ranged probe, want 0", entries)
+	}
+}
+
+// TestBlobExistenceCacheStillAsksThePolicy is the security property: the cache
+// memoizes the registry's answer, never the authorization to ask for it.
+func TestBlobExistenceCacheStillAsksThePolicy(t *testing.T) {
+	up := &blobUpstream{status: http.StatusOK, contentLength: "1"}
+	h, _ := newCachingHandler(t, allowHostPolicy(t, testUpstreamHost, "blob:read"), up, time.Hour)
+
+	if got := head(h, testUpstreamHost, testBlobPath).StatusCode; got != http.StatusOK {
+		t.Fatalf("warming probe status = %d, want 200", got)
+	}
+	// A reload that revokes access must take effect on the very next request, even
+	// though the answer to it is sitting in the cache.
+	h.policy.Store(&CompiledPolicy{})
+	if got := head(h, testUpstreamHost, testBlobPath).StatusCode; got != http.StatusForbidden {
+		t.Errorf("status after the policy stopped allowing the repository = %d, want 403", got)
+	}
+	if got := up.count(http.MethodHead, testBlobPath); got != 1 {
+		t.Errorf("upstream saw %d probes, want the denied one to have gone nowhere", got)
+	}
+}
+
+func TestBlobExistenceCacheExpiresThroughHandler(t *testing.T) {
+	const ttl = 6 * time.Hour
+	up := &blobUpstream{status: http.StatusOK, contentLength: "1"}
+	h, clock := newCachingHandler(t, allowHostPolicy(t, testUpstreamHost, "blob:read"), up, ttl)
+
+	head(h, testUpstreamHost, testBlobPath)
+	clock.advance(ttl - time.Second)
+	head(h, testUpstreamHost, testBlobPath)
+	if got := up.count(http.MethodHead, testBlobPath); got != 1 {
+		t.Fatalf("upstream saw %d probes before the TTL was up, want 1", got)
+	}
+	clock.advance(2 * time.Second)
+	if got := head(h, testUpstreamHost, testBlobPath).StatusCode; got != http.StatusOK {
+		t.Fatalf("status after expiry = %d, want 200", got)
+	}
+	if got := up.count(http.MethodHead, testBlobPath); got != 2 {
+		t.Errorf("upstream saw %d probes after the TTL passed, want 2", got)
+	}
+}
+
+// TestBlobExistenceCacheOffByDefault: the library default is no cache, so a
+// gateway only starts answering from memory when an operator asks it to.
+func TestBlobExistenceCacheOffByDefault(t *testing.T) {
+	up := &blobUpstream{status: http.StatusOK, contentLength: "1"}
+	h := newTestHandler(allowHostPolicy(t, testUpstreamHost, "blob:read"), up)
+	if h.blobCache != nil {
+		t.Fatal("a handler built without WithBlobExistenceCache has a cache")
+	}
+	head(h, testUpstreamHost, testBlobPath)
+	head(h, testUpstreamHost, testBlobPath)
+	if got := up.count(http.MethodHead, testBlobPath); got != 2 {
+		t.Errorf("upstream saw %d probes with the cache off, want 2", got)
+	}
+}
+
+func TestBlobExistenceCacheMetrics(t *testing.T) {
+	up := upstreamFunc(func(r *http.Request) (*http.Response, error) {
+		header := http.Header{}
+		header.Set("Content-Length", "1")
+		return upstreamResponse(http.StatusOK, header, ""), nil
+	})
+	h, collect := newMetricsHandler(t, allowHostPolicy(t, testUpstreamHost, "blob:read"), up,
+		WithBlobExistenceCache(time.Hour, 256*entryCost))
+
+	// One miss that goes upstream, then two answered from the cache.
+	for range 3 {
+		if got := head(h, testUpstreamHost, testBlobPath).StatusCode; got != http.StatusOK {
+			t.Fatalf("probe status = %d, want 200", got)
+		}
+	}
+	rm := collect()
+
+	registry := attrRegistry.String(testUpstreamHost)
+	if got := counterValue(t, rm, "oci.gateway.blob_existence_cache.lookups", registry, attrResult.String(resultHit)); got != 2 {
+		t.Errorf("cache hits = %d, want 2", got)
+	}
+	if got := counterValue(t, rm, "oci.gateway.blob_existence_cache.lookups", registry, attrResult.String(resultMiss)); got != 1 {
+		t.Errorf("cache misses = %d, want 1", got)
+	}
+	// A cached answer still counts as an existence check that found the blob, so
+	// the hit rate an operator reads is not a function of the cache.
+	if got := counterValue(t, rm, "oci.gateway.existence_checks", registry, attrResult.String(resultHit)); got != 3 {
+		t.Errorf("existence checks reported as hits = %d, want 3", got)
+	}
+	// Only the forwarded probe has an upstream leg.
+	if got := histogramCount(t, rm, "oci.gateway.upstream.duration", registry); got != 1 {
+		t.Errorf("upstream durations recorded = %d, want 1 (the cached probes have no upstream leg)", got)
+	}
+	if got := gaugeValue(t, rm, "oci.gateway.blob_existence_cache.entries"); got != 1 {
+		t.Errorf("cache entries = %d, want 1", got)
+	}
+	if got := gaugeValue(t, rm, "oci.gateway.blob_existence_cache.capacity"); got != 256 {
+		t.Errorf("cache capacity = %d, want 256", got)
+	}
+	if got := counterValue(t, rm, "oci.gateway.blob_existence_cache.evictions",
+		attrEvictionReason.String(evictedForCapacity)); got != 0 {
+		t.Errorf("capacity evictions = %d, want 0", got)
+	}
+}
+
+// TestBlobExistenceCacheInstrumentsAbsentWhenDisabled keeps a disabled cache from
+// exporting a flat zero that looks like a cache nobody is hitting.
+func TestBlobExistenceCacheInstrumentsAbsentWhenDisabled(t *testing.T) {
+	h, collect := newMetricsHandler(t, allowHostPolicy(t, testUpstreamHost, "blob:read"),
+		func(r *http.Request) (*http.Response, error) {
+			return upstreamResponse(http.StatusOK, nil, ""), nil
+		})
+	head(h, testUpstreamHost, testBlobPath)
+	rm := collect()
+	for _, name := range []string{
+		"oci.gateway.blob_existence_cache.lookups",
+		"oci.gateway.blob_existence_cache.entries",
+		"oci.gateway.blob_existence_cache.capacity",
+		"oci.gateway.blob_existence_cache.evictions",
+	} {
+		if hasMetric(rm, name) {
+			t.Errorf("%s was reported by a gateway with the cache disabled", name)
+		}
+	}
+}
+
+// TestBlobExistenceCacheReplayIsWellFormedOnTheWire serves both the forwarded and
+// the cached answer through a real net/http server, because a HEAD response is the
+// one place where declaring a Content-Length and writing no body is correct — and
+// getting it wrong would not show up in a ResponseRecorder. If net/http thought
+// the handler had under-written the body it would close the connection after every
+// reply, so the reused connection is the assertion that matters.
+func TestBlobExistenceCacheReplayIsWellFormedOnTheWire(t *testing.T) {
+	up := &blobUpstream{status: http.StatusOK, contentLength: "12345"}
+	h, _ := newCachingHandler(t, allowHostPolicy(t, testUpstreamHost, "blob:read"), up, time.Hour)
+
+	protocols := &http.Protocols{}
+	protocols.SetHTTP1(true)
+	transport, listener := serveInMemory(t, h, protocols, protocols, nil, nil)
+
+	probe := func(t *testing.T) {
+		t.Helper()
+		r, err := http.NewRequest(http.MethodHead, "http://peer.test:8443"+testBlobPath, nil)
+		if err != nil {
+			t.Fatalf("building request: %v", err)
+		}
+		r.Header.Set(clientgateway.OriginalHostHeader, testUpstreamHost)
+		resp, err := transport.RoundTrip(r)
+		if err != nil {
+			t.Fatalf("probing: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		// net/http fills ContentLength on a HEAD response from the header, so this
+		// is what a go-containerregistry client reads to size the layer.
+		if resp.ContentLength != 12345 {
+			t.Errorf("ContentLength = %d, want 12345", resp.ContentLength)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("reading body: %v", err)
+		}
+		if len(body) != 0 {
+			t.Errorf("HEAD response carried %d bytes of body", len(body))
+		}
+	}
+
+	t.Run("forwarded", func(t *testing.T) { probe(t) })
+	t.Run("cached", func(t *testing.T) { probe(t) })
+
+	if got := up.count(http.MethodHead, testBlobPath); got != 1 {
+		t.Errorf("upstream saw %d probes, want the second answered from the cache", got)
+	}
+	if dials := listener.dials(); dials != 1 {
+		t.Errorf("the client opened %d connections, want 1: a response net/http considers short is not kept alive", dials)
+	}
+}
+
+// gaugeValue sums the int64 gauge data points carrying all of want.
+func gaugeValue(t *testing.T, rm *metricdata.ResourceMetrics, name string, want ...attribute.KeyValue) int64 {
+	t.Helper()
+	gauge, ok := findMetric(t, rm, name).(metricdata.Gauge[int64])
+	if !ok {
+		t.Fatalf("metric %q is not an int64 gauge", name)
+	}
+	var total int64
+	for _, dp := range gauge.DataPoints {
+		if matches(dp.Attributes, want) {
+			total += dp.Value
+		}
+	}
+	return total
+}

--- a/img_tool/pkg/serve/gateway/existencecache_test.go
+++ b/img_tool/pkg/serve/gateway/existencecache_test.go
@@ -1,0 +1,526 @@
+package gateway
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The blob existence cache has two kinds of test here: the ones below exercise
+// the data structure directly (keys, expiry, eviction, the memory bound and the
+// promise that none of it allocates), and the handler-level ones in
+// existencecache_serve_test.go check what a client actually observes.
+
+const (
+	testCacheRegistry   = "registry.test"
+	testCacheRepository = "team/service/app"
+	testCacheDigest     = "sha256:6b0f2e1a4c3d5e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f7"
+)
+
+// fakeClock is a manually advanced clock, so the TTL tests neither sleep nor
+// depend on how long the rest of the test took.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+// newTestCache builds a cache sized to exactly entries, with a clock the test
+// drives.
+func newTestCache(t *testing.T, ttl time.Duration, entries int64) (*blobExistenceCache, *fakeClock) {
+	t.Helper()
+	c := newBlobExistenceCache(ttl, entries*entryCost)
+	if c == nil {
+		t.Fatalf("newBlobExistenceCache(%v, room for %d) returned a disabled cache", ttl, entries)
+	}
+	if c.capacity != entries {
+		t.Fatalf("capacity = %d, want %d", c.capacity, entries)
+	}
+	clock := &fakeClock{t: c.base}
+	c.now = clock.now
+	return c, clock
+}
+
+// blobDigest is a distinct, digest-shaped string per index.
+func blobDigest(i int) string {
+	return fmt.Sprintf("sha256:%064x", i)
+}
+
+func TestBlobCacheStoreLookup(t *testing.T) {
+	c, _ := newTestCache(t, time.Hour, 64)
+
+	if _, ok := c.lookup(testCacheRegistry, testCacheRepository, testCacheDigest); ok {
+		t.Fatal("empty cache reported a hit")
+	}
+	c.store(testCacheRegistry, testCacheRepository, testCacheDigest, 4096)
+	length, ok := c.lookup(testCacheRegistry, testCacheRepository, testCacheDigest)
+	if !ok {
+		t.Fatal("stored blob was not found")
+	}
+	if length != 4096 {
+		t.Fatalf("content length = %d, want 4096", length)
+	}
+
+	// A registry that reported no Content-Length is stored as such, so the
+	// replayed response omits the header rather than claiming a zero-byte blob.
+	c.store(testCacheRegistry, testCacheRepository, blobDigest(1), -1)
+	if length, ok := c.lookup(testCacheRegistry, testCacheRepository, blobDigest(1)); !ok || length != -1 {
+		t.Fatalf("lookup of a blob with no content length = (%d, %v), want (-1, true)", length, ok)
+	}
+}
+
+// TestBlobCacheKeyIsAllThreeParts is the correctness property the whole feature
+// rests on: a blob is present in *a repository of a registry*, so a hit must
+// require all three parts of the key to match.
+func TestBlobCacheKeyIsAllThreeParts(t *testing.T) {
+	c, _ := newTestCache(t, time.Hour, 64)
+	c.store(testCacheRegistry, testCacheRepository, testCacheDigest, 1)
+
+	for _, tc := range []struct {
+		name                         string
+		registry, repository, digest string
+	}{
+		{"other registry", "other.test", testCacheRepository, testCacheDigest},
+		{"other repository", testCacheRegistry, "team/service/other", testCacheDigest},
+		{"other digest", testCacheRegistry, testCacheRepository, blobDigest(2)},
+		{"registry with a port", testCacheRegistry + ":5000", testCacheRepository, testCacheDigest},
+		{"repository prefix", testCacheRegistry, "team/service", testCacheDigest},
+		// The three parts are concatenated in the arena, so a naive comparison of
+		// the joined bytes would confuse these two with the stored key.
+		{"shifted boundary", testCacheRegistry + "team", "/service/app", testCacheDigest},
+		{"shifted the other way", "registry", ".testteam/service/app", testCacheDigest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := c.lookup(tc.registry, tc.repository, tc.digest); ok {
+				t.Errorf("lookup(%q, %q, %q) hit the entry stored for (%q, %q, %q)",
+					tc.registry, tc.repository, tc.digest, testCacheRegistry, testCacheRepository, testCacheDigest)
+			}
+		})
+	}
+}
+
+// TestBlobCacheHashCollisionMisses forces two keys to share a hash, which is the
+// case the stored key bytes exist to settle.
+func TestBlobCacheHashCollisionMisses(t *testing.T) {
+	c, _ := newTestCache(t, time.Hour, 64)
+	c.store(testCacheRegistry, testCacheRepository, testCacheDigest, 7)
+
+	// Plant the stored entry's hash on the key we are about to look up.
+	stored := c.hash(testCacheRegistry, testCacheRepository, testCacheDigest)
+	shard := &c.shards[stored>>c.shardShift]
+	idx := shard.find(stored, testCacheRegistry, testCacheRepository, testCacheDigest)
+	if idx < 0 {
+		t.Fatal("stored entry not found in its shard")
+	}
+	if got := shard.find(stored, testCacheRegistry, testCacheRepository, blobDigest(3)); got >= 0 {
+		t.Fatalf("a colliding hash returned slot %d for a different digest", got)
+	}
+	if got := shard.find(stored, testCacheRegistry, testCacheRepository, testCacheDigest); got != idx {
+		t.Fatalf("find = %d, want %d for the key that is really stored", got, idx)
+	}
+}
+
+func TestBlobCacheExpiry(t *testing.T) {
+	const ttl = 6 * time.Hour
+	c, clock := newTestCache(t, ttl, 64)
+	c.store(testCacheRegistry, testCacheRepository, testCacheDigest, 1)
+
+	clock.advance(ttl - time.Nanosecond)
+	if _, ok := c.lookup(testCacheRegistry, testCacheRepository, testCacheDigest); !ok {
+		t.Fatal("entry expired before its TTL was up")
+	}
+	clock.advance(time.Nanosecond)
+	if _, ok := c.lookup(testCacheRegistry, testCacheRepository, testCacheDigest); ok {
+		t.Fatal("entry survived its TTL")
+	}
+	// The expired entry is dropped rather than left to occupy its slot, and is
+	// reported as such.
+	if stats := c.stats(); stats.entries != 0 || stats.evictedExpired != 1 {
+		t.Fatalf("after expiry: entries = %d, expired evictions = %d; want 0 and 1", stats.entries, stats.evictedExpired)
+	}
+
+	// Storing it again starts a fresh TTL, and refreshing an entry that is still
+	// live extends it rather than adding a second one.
+	c.store(testCacheRegistry, testCacheRepository, testCacheDigest, 1)
+	clock.advance(ttl / 2)
+	c.store(testCacheRegistry, testCacheRepository, testCacheDigest, 1)
+	clock.advance(ttl - time.Nanosecond)
+	if _, ok := c.lookup(testCacheRegistry, testCacheRepository, testCacheDigest); !ok {
+		t.Fatal("a refreshed entry expired on the original deadline")
+	}
+	if entries := c.stats().entries; entries != 1 {
+		t.Fatalf("entries = %d after refreshing one blob, want 1", entries)
+	}
+	// The slot the expired entry occupied went back into circulation, rather than
+	// leaking or being counted twice.
+	checkIntegrity(t, c)
+}
+
+// TestBlobCacheEvictsLeastRecentlyUsed uses a single-shard cache so the eviction
+// order is the whole cache's, not one shard's.
+func TestBlobCacheEvictsLeastRecentlyUsed(t *testing.T) {
+	c, _ := newTestCache(t, time.Hour, 4)
+	if len(c.shards) != 1 {
+		t.Fatalf("a 4-entry cache has %d shards, want 1", len(c.shards))
+	}
+	for i := range 4 {
+		c.store(testCacheRegistry, testCacheRepository, blobDigest(i), int64(i))
+	}
+	// Touch the oldest entry, so it is no longer the one to go.
+	if _, ok := c.lookup(testCacheRegistry, testCacheRepository, blobDigest(0)); !ok {
+		t.Fatal("blob 0 was not cached")
+	}
+	c.store(testCacheRegistry, testCacheRepository, blobDigest(4), 4)
+
+	for _, i := range []int{0, 2, 3, 4} {
+		if _, ok := c.lookup(testCacheRegistry, testCacheRepository, blobDigest(i)); !ok {
+			t.Errorf("blob %d was evicted, want it kept", i)
+		}
+	}
+	if _, ok := c.lookup(testCacheRegistry, testCacheRepository, blobDigest(1)); ok {
+		t.Error("blob 1 survived, want the least recently used entry evicted")
+	}
+	if stats := c.stats(); stats.entries != 4 || stats.evictedCapacity != 1 {
+		t.Fatalf("entries = %d, capacity evictions = %d; want 4 and 1", stats.entries, stats.evictedCapacity)
+	}
+	checkIntegrity(t, c)
+}
+
+// TestBlobCacheNeverExceedsCapacity stores far more blobs than fit, over every
+// shard, and checks the structure is still coherent and still bounded.
+func TestBlobCacheNeverExceedsCapacity(t *testing.T) {
+	c, _ := newTestCache(t, time.Hour, 512)
+	for i := range 10_000 {
+		c.store(testCacheRegistry, testCacheRepository, blobDigest(i), int64(i))
+	}
+	stats := c.stats()
+	if stats.entries > stats.capacity {
+		t.Fatalf("entries = %d, above the capacity of %d", stats.entries, stats.capacity)
+	}
+	if stats.evictedCapacity == 0 {
+		t.Fatal("no capacity evictions after storing 10000 blobs in a 512-entry cache")
+	}
+	// The most recently stored blobs are the ones a fleet is working on, so they
+	// are the ones that must have survived. Only the last shard-full is
+	// guaranteed: each shard evicts its own least recently used entry.
+	found := 0
+	for i := 10_000 - int(stats.capacity)/len(c.shards); i < 10_000; i++ {
+		if _, ok := c.lookup(testCacheRegistry, testCacheRepository, blobDigest(i)); ok {
+			found++
+		}
+	}
+	if want := int(stats.capacity) / len(c.shards) / 2; found < want {
+		t.Errorf("only %d of the most recent blobs survived, want at least %d", found, want)
+	}
+	checkIntegrity(t, c)
+}
+
+// TestBlobCacheRespectsMemoryBound checks the promise the flag makes: the cache
+// allocates its whole bound at startup, and not a byte more.
+func TestBlobCacheRespectsMemoryBound(t *testing.T) {
+	for _, maxBytes := range []int64{
+		MinBlobExistenceCacheBytes,
+		64 << 10,
+		1 << 20,
+		64 << 20,
+		//
+
+		// A bound that is not a multiple of the entry cost, so the rounding is
+		// exercised too.
+		12345678,
+	} {
+		t.Run(fmt.Sprint(maxBytes), func(t *testing.T) {
+			c := newBlobExistenceCache(time.Hour, maxBytes)
+			if c == nil {
+				t.Fatalf("newBlobExistenceCache(1h, %d) is disabled", maxBytes)
+			}
+			var buckets int64
+			for i := range c.shards {
+				buckets += int64(len(c.shards[i].buckets))
+			}
+			allocated := c.capacity*entryBytes + c.capacity*slotBytes + buckets*4
+			if allocated > maxBytes {
+				t.Errorf("allocated %d bytes for a bound of %d", allocated, maxBytes)
+			}
+			// Fill it, so anything that would grow at runtime has to.
+			for i := range int(c.capacity) * 2 {
+				c.store(testCacheRegistry, testCacheRepository, blobDigest(i), int64(i))
+			}
+			if entries := c.stats().entries; entries > c.capacity {
+				t.Errorf("entries = %d, above the capacity of %d", entries, c.capacity)
+			}
+			checkIntegrity(t, c)
+		})
+	}
+}
+
+func TestBlobCacheDisabledConfigurations(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		ttl      time.Duration
+		maxBytes int64
+	}{
+		{"zero ttl", 0, 64 << 20},
+		{"negative ttl", -time.Hour, 64 << 20},
+		{"zero memory", time.Hour, 0},
+		{"negative memory", time.Hour, -1},
+		{"too little memory for one entry", time.Hour, MinBlobExistenceCacheBytes - 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newBlobExistenceCache(tc.ttl, tc.maxBytes)
+			if c != nil {
+				t.Fatalf("newBlobExistenceCache(%v, %d) built a cache, want it disabled", tc.ttl, tc.maxBytes)
+			}
+			// A disabled cache is a nil one, and every method has to tolerate it so
+			// the gateway needs no second code path.
+			c.store(testCacheRegistry, testCacheRepository, testCacheDigest, 1)
+			if _, ok := c.lookup(testCacheRegistry, testCacheRepository, testCacheDigest); ok {
+				t.Error("a disabled cache reported a hit")
+			}
+			if stats := c.stats(); stats != (cacheStats{}) {
+				t.Errorf("stats of a disabled cache = %+v, want the zero value", stats)
+			}
+		})
+	}
+}
+
+// TestBlobCacheSkipsOversizeKeys covers the one case a store is dropped: a key
+// too long for the fixed arena slice an entry owns.
+func TestBlobCacheSkipsOversizeKeys(t *testing.T) {
+	c, _ := newTestCache(t, time.Hour, 64)
+	long := strings.Repeat("a", entryBytes)
+
+	c.store(testCacheRegistry, long, testCacheDigest, 1)
+	if _, ok := c.lookup(testCacheRegistry, long, testCacheDigest); ok {
+		t.Error("an oversize key was cached")
+	}
+	if entries := c.stats().entries; entries != 0 {
+		t.Errorf("entries = %d after an oversize store, want 0", entries)
+	}
+
+	// A key of exactly the arena slice length still fits.
+	fits := strings.Repeat("b", entryBytes-len(testCacheRegistry)-len(testCacheDigest))
+	c.store(testCacheRegistry, fits, testCacheDigest, 2)
+	if _, ok := c.lookup(testCacheRegistry, fits, testCacheDigest); !ok {
+		t.Error("a key filling the arena slice exactly was not cached")
+	}
+}
+
+// TestBlobCacheDoesNotAllocate is the load-bearing test for the cache's design:
+// the memory is taken once, at startup, so serving from it must not put anything
+// on the heap however long the process runs.
+func TestBlobCacheDoesNotAllocate(t *testing.T) {
+	c, _ := newTestCache(t, time.Hour, 64)
+	c.store(testCacheRegistry, testCacheRepository, testCacheDigest, 4096)
+
+	if allocs := testing.AllocsPerRun(200, func() {
+		c.lookup(testCacheRegistry, testCacheRepository, testCacheDigest)
+	}); allocs != 0 {
+		t.Errorf("lookup allocated %v objects per call, want 0", allocs)
+	}
+	// Storing past capacity, so every call evicts and reuses a slot. The digests
+	// are built up front: formatting one would be the measured allocation.
+	digests := make([]string, 256)
+	for i := range digests {
+		digests[i] = blobDigest(i)
+	}
+	i := 0
+	if allocs := testing.AllocsPerRun(200, func() {
+		i = (i + 1) % len(digests)
+		c.store(testCacheRegistry, testCacheRepository, digests[i], int64(i))
+	}); allocs != 0 {
+		t.Errorf("store allocated %v objects per call, want 0", allocs)
+	}
+}
+
+// TestBlobCacheConcurrent hammers the cache from every direction at once. Run
+// with -race, it is what says the sharded locking is right; the integrity check
+// afterwards is what says no interleaving corrupted a list.
+func TestBlobCacheConcurrent(t *testing.T) {
+	c, _ := newTestCache(t, time.Hour, 1024)
+	const (
+		goroutines = 16
+		iterations = 2000
+		keyspace   = 4096
+	)
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(g)))
+			for range iterations {
+				digest := blobDigest(rng.Intn(keyspace))
+				repository := fmt.Sprintf("team/service%d", rng.Intn(4))
+				if rng.Intn(2) == 0 {
+					c.store(testCacheRegistry, repository, digest, 1)
+					continue
+				}
+				c.lookup(testCacheRegistry, repository, digest)
+			}
+		}()
+	}
+	wg.Wait()
+
+	stats := c.stats()
+	if stats.entries > stats.capacity {
+		t.Fatalf("entries = %d, above the capacity of %d", stats.entries, stats.capacity)
+	}
+	checkIntegrity(t, c)
+
+	// An entry stored after the storm is still found, so the structure is not
+	// merely uncorrupted but still usable.
+	c.store(testCacheRegistry, testCacheRepository, testCacheDigest, 99)
+	if length, ok := c.lookup(testCacheRegistry, testCacheRepository, testCacheDigest); !ok || length != 99 {
+		t.Fatalf("after concurrent use, lookup = (%d, %v), want (99, true)", length, ok)
+	}
+}
+
+func TestShardCount(t *testing.T) {
+	// Whatever the machine, the shard count is a power of two, at least one, and
+	// never so high that a shard holds fewer than minSlotsPerShard entries.
+	for _, capacity := range []int64{1, 63, 64, 128, 1024, 178_481, 1 << 22} {
+		shards := shardCount(capacity)
+		if shards < 1 || shards&(shards-1) != 0 {
+			t.Errorf("shardCount(%d) = %d, want a power of two of at least 1", capacity, shards)
+		}
+		if shards > 1 && capacity/int64(shards) < minSlotsPerShard {
+			t.Errorf("shardCount(%d) = %d, leaving %d slots per shard (want at least %d)",
+				capacity, shards, capacity/int64(shards), minSlotsPerShard)
+		}
+		if shards > maxShards {
+			t.Errorf("shardCount(%d) = %d, above the cap of %d", capacity, shards, maxShards)
+		}
+	}
+}
+
+// BenchmarkBlobCache measures the cache from every core at once, which is the
+// shape of the load it is built for: a build farm's workers all probing at the
+// same time. The mixed case is the realistic one — a fleet pushing overlapping
+// image sets hits mostly the same blobs, and refreshes them as they expire.
+func BenchmarkBlobCache(b *testing.B) {
+	digests := make([]string, 8192)
+	for i := range digests {
+		digests[i] = blobDigest(i)
+	}
+	for _, bc := range []struct {
+		name string
+		// storeEvery is how many lookups fall between two stores; 0 means never
+		// store, 1 means store every time.
+		storeEvery int
+	}{
+		{"lookup", 0},
+		{"mixed", 16},
+		{"store", 1},
+	} {
+		b.Run(bc.name, func(b *testing.B) {
+			c := newBlobExistenceCache(time.Hour, 64<<20)
+			for _, digest := range digests {
+				c.store(testCacheRegistry, testCacheRepository, digest, 4096)
+			}
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				i := 0
+				for pb.Next() {
+					i++
+					digest := digests[i%len(digests)]
+					if bc.storeEvery > 0 && i%bc.storeEvery == 0 {
+						c.store(testCacheRegistry, testCacheRepository, digest, 4096)
+						continue
+					}
+					c.lookup(testCacheRegistry, testCacheRepository, digest)
+				}
+			})
+		})
+	}
+}
+
+// checkIntegrity verifies every shard's invariants: the LRU list is a consistent
+// doubly-linked list of exactly the live entries, each of those entries is
+// reachable through its hash bucket, and every slot is accounted for exactly
+// once (live, free, or never used).
+func checkIntegrity(t *testing.T, c *blobExistenceCache) {
+	t.Helper()
+	for i := range c.shards {
+		s := &c.shards[i]
+		s.mu.Lock()
+		checkShardIntegrity(t, i, s)
+		s.mu.Unlock()
+	}
+}
+
+func checkShardIntegrity(t *testing.T, shard int, s *cacheShard) {
+	t.Helper()
+	seen := make(map[int32]bool, len(s.slots))
+	var forward []int32
+	prev := int32(-1)
+	for idx := s.head; idx >= 0; idx = s.slots[idx].next {
+		if seen[idx] {
+			t.Fatalf("shard %d: LRU list revisits slot %d", shard, idx)
+		}
+		seen[idx] = true
+		if s.slots[idx].prev != prev {
+			t.Fatalf("shard %d: slot %d has prev = %d, want %d", shard, idx, s.slots[idx].prev, prev)
+		}
+		forward = append(forward, idx)
+		prev = idx
+	}
+	if prev != s.tail {
+		t.Fatalf("shard %d: LRU list ends at slot %d, but tail is %d", shard, prev, s.tail)
+	}
+	if live := s.live.Load(); int64(len(forward)) != live {
+		t.Fatalf("shard %d: LRU list holds %d entries, but live counts %d", shard, len(forward), live)
+	}
+	// Every live entry must be reachable through its bucket, which is what a
+	// lookup walks.
+	for _, idx := range forward {
+		e := &s.slots[idx]
+		found := false
+		for at := s.buckets[e.hash&s.mask]; at >= 0; at = s.slots[at].hnext {
+			if at == idx {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("shard %d: live slot %d is not in bucket %d", shard, idx, e.hash&s.mask)
+		}
+		if e.expires == 0 {
+			t.Fatalf("shard %d: live slot %d has no deadline", shard, idx)
+		}
+	}
+	// ...and every bucket must hold only live entries, in a consistent chain.
+	chained := 0
+	for bucket := range s.buckets {
+		hprev := int32(-1)
+		for idx := s.buckets[bucket]; idx >= 0; idx = s.slots[idx].hnext {
+			if !seen[idx] {
+				t.Fatalf("shard %d: bucket %d holds slot %d, which is not a live entry", shard, bucket, idx)
+			}
+			if s.slots[idx].hprev != hprev {
+				t.Fatalf("shard %d: slot %d has hprev = %d, want %d", shard, idx, s.slots[idx].hprev, hprev)
+			}
+			hprev = idx
+			chained++
+		}
+	}
+	if chained != len(forward) {
+		t.Fatalf("shard %d: buckets hold %d entries, LRU list holds %d", shard, chained, len(forward))
+	}
+	// Free slots plus live slots plus never-used slots account for the table.
+	free := 0
+	for idx := s.free; idx >= 0; idx = s.slots[idx].next {
+		if seen[idx] {
+			t.Fatalf("shard %d: slot %d is both live and free", shard, idx)
+		}
+		free++
+		if free > len(s.slots) {
+			t.Fatalf("shard %d: the free list cycles", shard)
+		}
+	}
+	if got := len(forward) + free; got != int(s.used) {
+		t.Fatalf("shard %d: %d live + %d free = %d, but %d slots have been used", shard, len(forward), free, got, s.used)
+	}
+}

--- a/img_tool/pkg/serve/gateway/gateway.go
+++ b/img_tool/pkg/serve/gateway/gateway.go
@@ -13,6 +13,11 @@
 // Requests, transferred bytes, blob transfers, existence-check hit rates, and
 // errors are reported as OpenTelemetry metrics through the [metric.MeterProvider]
 // installed with [WithMeterProvider] (see metrics.go for the instruments).
+//
+// Successful blob existence checks can be memoized with
+// [WithBlobExistenceCache], which is what keeps a build farm's repeated "is this
+// layer already pushed?" probes from each costing an upstream round trip (see
+// existencecache.go).
 package gateway
 
 import (
@@ -25,6 +30,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -92,6 +98,13 @@ type Handler struct {
 	meterProvider metric.MeterProvider
 	metrics       *metrics
 
+	// blobCacheTTL and blobCacheMaxBytes are set by WithBlobExistenceCache and
+	// consumed by New, which builds blobCache from them. blobCache is nil when
+	// the cache is disabled, which every one of its methods tolerates.
+	blobCacheTTL      time.Duration
+	blobCacheMaxBytes int64
+	blobCache         *blobExistenceCache
+
 	cache authCache
 }
 
@@ -146,6 +159,32 @@ func WithPeerAuth(auth *PeerAuth) Option {
 	return func(h *Handler) { h.peerAuth = auth }
 }
 
+// WithBlobExistenceCache memoizes the successful answers to blob existence
+// checks (HEAD /v2/<name>/blobs/<digest>), so that a fleet asking the same
+// question about the same layer pays for one upstream round trip instead of
+// thousands. Entries are keyed by upstream registry, repository, and digest, and
+// held for ttl.
+//
+// maxBytes bounds the cache's memory, which is allocated in full at startup and
+// never grows; once it is full, the least recently used entry makes room for a
+// new one. A ttl or maxBytes that is not positive disables the cache, as does a
+// maxBytes below [MinBlobExistenceCacheBytes].
+//
+// ttl is the only thing standing between a client and a stale answer: a blob
+// cannot change, but a registry can garbage-collect one, and a push client that
+// believes a collected layer is still there will skip re-uploading it and commit
+// a manifest referring to nothing. Keep ttl well inside the window in which the
+// registry could collect a blob.
+//
+// Manifests and tags are never cached: both are mutable, and a HEAD on one is
+// exactly how a client finds out that it changed.
+func WithBlobExistenceCache(ttl time.Duration, maxBytes int64) Option {
+	return func(h *Handler) {
+		h.blobCacheTTL = ttl
+		h.blobCacheMaxBytes = maxBytes
+	}
+}
+
 // New constructs a gateway [Handler].
 func New(opts ...Option) *Handler {
 	h := &Handler{
@@ -163,12 +202,21 @@ func New(opts ...Option) *Handler {
 	}
 	h.policy.Store(policy)
 	h.cache.inner = make(map[string]*authEntry)
-	m, err := newMetrics(h.meterProvider, func() int64 {
-		if p := h.policy.Load(); p != nil {
-			return int64(p.RuleCount())
-		}
-		return 0
-	})
+	h.blobCache = newBlobExistenceCache(h.blobCacheTTL, h.blobCacheMaxBytes)
+	sources := gaugeSources{
+		policyRules: func() int64 {
+			if p := h.policy.Load(); p != nil {
+				return int64(p.RuleCount())
+			}
+			return 0
+		},
+	}
+	if h.blobCache != nil {
+		sources.blobCache = h.blobCache.stats
+		h.log.Printf("blob existence cache enabled: up to %d blobs over %d shards, each assumed present for %v",
+			h.blobCache.capacity, len(h.blobCache.shards), h.blobCacheTTL)
+	}
+	m, err := newMetrics(h.meterProvider, sources)
 	if err != nil {
 		// Instruments are still usable (no-ops at worst); serving matters more
 		// than measuring it.
@@ -341,7 +389,90 @@ func (h *Handler) serve(obs *observation, w http.ResponseWriter, r *http.Request
 		}
 	}
 
+	// A blob existence check may already be answerable without the upstream. The
+	// cache is deliberately consulted *after* the policy decision above: whether
+	// this client may ask the question is decided every time, and only the answer
+	// is memoized.
+	if h.serveCachedBlobHead(obs, w, r, repo, cls) {
+		return
+	}
+
 	h.forward(obs, w, r, repo, cls)
+}
+
+// serveCachedBlobHead answers a blob existence check from the blob existence
+// cache, and reports whether it did.
+//
+// The replayed response carries the two headers that mean something on a blob
+// HEAD: Content-Length, which is how a client sizes a layer without downloading
+// it, and Docker-Content-Digest, which for a content-addressed blob is the digest
+// the client just asked about and so needs no storing. Everything else a registry
+// might have sent (its Date, ETag, Accept-Ranges, or any header of its own) is
+// dropped rather than replayed to a different client minutes or hours later.
+func (h *Handler) serveCachedBlobHead(obs *observation, w http.ResponseWriter, r *http.Request, repo name.Repository, cls request) bool {
+	if !h.cacheableBlobHead(r, cls) {
+		return false
+	}
+	contentLength, ok := h.blobCache.lookup(repo.RegistryStr(), repo.RepositoryStr(), cls.digest)
+	obs.blobCacheLookup(r.Context(), ok)
+	if !ok {
+		return false
+	}
+	if contentLength >= 0 {
+		w.Header().Set("Content-Length", strconv.FormatInt(contentLength, 10))
+	}
+	w.Header().Set("Docker-Content-Digest", cls.digest)
+	w.WriteHeader(http.StatusOK)
+	h.log.Printf("%s %q (host=%s%s) -> 200 (cached)", r.Method, r.URL.EscapedPath(), repo.RegistryStr(), obs.logContext())
+	return true
+}
+
+// cacheableBlobHead reports whether a request may be answered from, or admitted
+// to, the blob existence cache. Only a plain HEAD of a digest-referenced blob
+// qualifies.
+func (h *Handler) cacheableBlobHead(r *http.Request, cls request) bool {
+	if h.blobCache == nil || cls.op != opNameBlobHead || cls.digest == "" {
+		return false
+	}
+	for _, header := range uncacheableHeaders {
+		if _, ok := r.Header[header]; ok {
+			return false
+		}
+	}
+	return true
+}
+
+// uncacheableHeaders make a response depend on more than whether the blob exists,
+// so a request carrying one is passed through untouched and its answer is not
+// stored: the upstream would answer it with a 206 or a 304, and the cache only
+// ever holds a plain 200. No OCI client sends one of these on a blob HEAD; the
+// check is here so that one which does gets the registry's real answer.
+var uncacheableHeaders = []string{
+	"Range",
+	"If-Match",
+	"If-None-Match",
+	"If-Modified-Since",
+	"If-Unmodified-Since",
+	"If-Range",
+}
+
+// blobLength is the Content-Length a registry reported for a blob, or -1 when it
+// reported none or an unusable value.
+//
+// The header is parsed rather than read from [http.Response.ContentLength] so
+// that a hand-rolled [http.RoundTripper] installed with [WithBaseTransport]
+// behaves like an [http.Transport], which fills that field in from this header
+// specifically for a HEAD response.
+func blobLength(resp *http.Response) int64 {
+	value := resp.Header.Get("Content-Length")
+	if value == "" {
+		return -1
+	}
+	n, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || n < 0 {
+		return -1
+	}
+	return n
 }
 
 // mountSourceReadable reports whether the cross-repo mount source repository is
@@ -409,6 +540,13 @@ func (h *Handler) forward(obs *observation, w http.ResponseWriter, r *http.Reque
 	}
 	defer resp.Body.Close()
 	obs.upstreamResponse(r.Context(), cls, resp.StatusCode, time.Since(started))
+
+	// Remember a blob the registry confirmed, so the next probe for it costs no
+	// round trip. Only a plain 200 is stored: that is the one answer that means
+	// "this blob is present", and it is the only one the cache replays.
+	if resp.StatusCode == http.StatusOK && h.cacheableBlobHead(r, cls) {
+		h.blobCache.store(repo.RegistryStr(), repo.RepositoryStr(), cls.digest, blobLength(resp))
+	}
 
 	copyResponseHeader(w.Header(), resp.Header, repo)
 	w.WriteHeader(resp.StatusCode)

--- a/img_tool/pkg/serve/gateway/metrics.go
+++ b/img_tool/pkg/serve/gateway/metrics.go
@@ -56,6 +56,10 @@ const (
 	// attrMaterial names the on-disk material a reload concerned:
 	// "certificate", "ca", or "token".
 	attrMaterial = attribute.Key("oci.gateway.material")
+	// attrEvictionReason says why a cache entry was dropped: "capacity" (it was
+	// the least recently used entry when room was needed) or "expired" (its TTL
+	// had passed).
+	attrEvictionReason = attribute.Key("oci.gateway.cache.eviction.reason")
 	// attrPeer is the peer gateway a forwarder relays to. It is constant for the
 	// life of the process, so it costs no cardinality; it is attached anyway so a
 	// dashboard panel says which hop it is describing.
@@ -74,6 +78,10 @@ const (
 	uploadChunked    = "chunked"
 	uploadMount      = "mount"
 	uploadUnknown    = "unknown"
+
+	// Values of [attrEvictionReason].
+	evictedForCapacity = "capacity"
+	evictedForExpiry   = "expired"
 )
 
 const (
@@ -152,6 +160,11 @@ type metrics struct {
 	// existenceChecks counts HEAD requests by hit/miss, the signal push clients
 	// depend on to skip uploads that already exist upstream.
 	existenceChecks metric.Int64Counter
+	// blobCacheLookups counts the blob existence checks that could have been
+	// answered from the blob existence cache, by whether they were. It is what
+	// says whether the TTL and the memory bound are sized right; the requests it
+	// counts are the subset of existenceChecks that are cacheable at all.
+	blobCacheLookups metric.Int64Counter
 	// errors counts failures by error.type and upstream registry.
 	errors metric.Int64Counter
 
@@ -194,14 +207,14 @@ func (m *metrics) failures() metric.Int64Counter {
 }
 
 // newMetrics creates a serving gateway's instruments from mp (the global provider
-// when mp is nil). rules reports the number of rules in the active policy for the
-// oci.gateway.policy.rules gauge; nil omits that gauge.
+// when mp is nil), plus the asynchronous instruments backed by the callbacks in
+// sources.
 //
 // Instrument creation only fails for invalid names or units, which are compile
 // time constants here; on failure the returned metrics is still fully usable
 // (the API hands out no-op instruments alongside the error) so callers can log
 // and carry on serving.
-func newMetrics(mp metric.MeterProvider, rules func() int64) (*metrics, error) {
+func newMetrics(mp metric.MeterProvider, sources gaugeSources) (*metrics, error) {
 	b := newInstruments(mp)
 	m := b.shared()
 	m.io = b.counter("oci.gateway.io", "By",
@@ -216,6 +229,8 @@ func newMetrics(mp metric.MeterProvider, rules func() int64) (*metrics, error) {
 		"Size of blobs downloaded through the gateway.")
 	m.existenceChecks = b.counter("oci.gateway.existence_checks", "{check}",
 		"HEAD requests for blobs and manifests, by hit or miss upstream.")
+	m.blobCacheLookups = b.counter("oci.gateway.blob_existence_cache.lookups", "{lookup}",
+		"Cacheable blob existence checks, by whether the blob existence cache could answer them.")
 	m.errors = b.counter("oci.gateway.errors", "{error}",
 		"Failures serving or forwarding registry requests, by error type.")
 	m.upstreamDuration = b.seconds("oci.gateway.upstream.duration",
@@ -228,18 +243,64 @@ func newMetrics(mp metric.MeterProvider, rules func() int64) (*metrics, error) {
 		"Policy file reloads, by outcome. A failure means the previous policy is still in force.")
 	m.uploads = newUploadTracker(maxUploadSessions)
 
-	if rules != nil {
+	b.observe(sources)
+	return m, b.err()
+}
+
+// gaugeSources are the callbacks behind a serving gateway's asynchronous
+// instruments: state the process holds rather than events it counts. A nil field
+// omits its instruments.
+type gaugeSources struct {
+	// policyRules reports how many rules the active policy has.
+	policyRules func() int64
+	// blobCache reports the blob existence cache's occupancy and evictions. It is
+	// nil when the cache is disabled, which is how the cache's instruments stay
+	// absent rather than reporting a flat zero.
+	blobCache func() cacheStats
+}
+
+// observe registers the asynchronous instruments described by sources.
+func (b *instruments) observe(sources gaugeSources) {
+	if sources.policyRules != nil {
 		_, err := b.meter.Int64ObservableGauge("oci.gateway.policy.rules",
 			metric.WithUnit("{rule}"),
 			metric.WithDescription("Number of rules in the policy this instance has loaded."),
 			metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
-				o.Observe(rules())
+				o.Observe(sources.policyRules())
 				return nil
 			}),
 		)
 		b.track(err)
 	}
-	return m, b.err()
+	if sources.blobCache == nil {
+		return
+	}
+	// One callback for the three, so a scrape reads the cache's counters once and
+	// reports a consistent picture of them.
+	entries, err := b.meter.Int64ObservableGauge("oci.gateway.blob_existence_cache.entries",
+		metric.WithUnit("{entry}"),
+		metric.WithDescription("Blobs the existence cache is currently holding, including any whose TTL has passed but which have not been looked up or evicted since."),
+	)
+	b.track(err)
+	capacity, err := b.meter.Int64ObservableGauge("oci.gateway.blob_existence_cache.capacity",
+		metric.WithUnit("{entry}"),
+		metric.WithDescription("Blobs the existence cache has room for. Entries divided by this is how full it is; the memory behind it is allocated up front, so this does not move."),
+	)
+	b.track(err)
+	evictions, err := b.meter.Int64ObservableCounter("oci.gateway.blob_existence_cache.evictions",
+		metric.WithUnit("{entry}"),
+		metric.WithDescription("Entries the existence cache dropped, by reason. A capacity eviction rate above zero means the memory bound, not the TTL, is deciding how long blobs are remembered."),
+	)
+	b.track(err)
+	_, err = b.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		stats := sources.blobCache()
+		o.ObserveInt64(entries, stats.entries)
+		o.ObserveInt64(capacity, stats.capacity)
+		o.ObserveInt64(evictions, stats.evictedCapacity, metric.WithAttributes(attrEvictionReason.String(evictedForCapacity)))
+		o.ObserveInt64(evictions, stats.evictedExpired, metric.WithAttributes(attrEvictionReason.String(evictedForExpiry)))
+		return nil
+	}, entries, capacity, evictions)
+	b.track(err)
 }
 
 // newForwardMetrics creates a forwarding gateway's instruments. It deliberately
@@ -487,6 +548,25 @@ func (o *observation) upstreamResponse(ctx context.Context, cls request, status 
 	}
 	if errType := statusErrorType(status); errType != "" {
 		o.fail(ctx, errType)
+	}
+}
+
+// blobCacheLookup records whether a cacheable blob existence check was answered
+// by the blob existence cache.
+//
+// A hit is *also* counted as an existence check that found the blob, which
+// [observation.upstreamResponse] would have done had the request gone upstream.
+// oci.gateway.existence_checks answers "how often was the content already
+// there", and leaving cached answers out of it would turn it into a function of
+// how the cache is configured.
+func (o *observation) blobCacheLookup(ctx context.Context, hit bool) {
+	result := resultMiss
+	if hit {
+		result = resultHit
+	}
+	o.m.blobCacheLookups.Add(ctx, 1, o.attrs(attrResult.String(result)))
+	if hit {
+		o.m.existenceChecks.Add(ctx, 1, o.attrs(attrResult.String(resultHit)))
 	}
 }
 

--- a/img_tool/pkg/serve/gateway/metrics_test.go
+++ b/img_tool/pkg/serve/gateway/metrics_test.go
@@ -53,8 +53,9 @@ func upstreamResponse(status int, header http.Header, body string) *http.Respons
 }
 
 // newMetricsHandler returns a gateway that records into a manual reader, plus a
-// collect function returning the metrics gathered so far.
-func newMetricsHandler(t *testing.T, cp *CompiledPolicy, upstream upstreamFunc) (*Handler, func() *metricdata.ResourceMetrics) {
+// collect function returning the metrics gathered so far. Any extra options are
+// applied after the fixed ones, so a test can add or override them.
+func newMetricsHandler(t *testing.T, cp *CompiledPolicy, upstream upstreamFunc, opts ...Option) (*Handler, func() *metricdata.ResourceMetrics) {
 	t.Helper()
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
@@ -63,13 +64,13 @@ func newMetricsHandler(t *testing.T, cp *CompiledPolicy, upstream upstreamFunc) 
 			t.Errorf("shutting down meter provider: %v", err)
 		}
 	})
-	h := New(
+	h := New(append([]Option{
 		WithAuthorizer(cp),
 		WithKeychain(authn.NewMultiKeychain()), // always anonymous, hermetic
 		WithLogger(log.New(io.Discard, "", 0)),
 		WithBaseTransport(upstream),
 		WithMeterProvider(provider),
-	)
+	}, opts...)...)
 	collect := func() *metricdata.ResourceMetrics {
 		t.Helper()
 		var rm metricdata.ResourceMetrics


### PR DESCRIPTION
Every push begins by probing whether each layer is already upstream, so a build farm asks the same question about the same blob thousands of times and waits on a round trip for each answer. Memoize it: a serving gateway now remembers that a blob is present, keyed by resolved registry, repository and digest, and answers repeat probes itself.

Manifests, tags, misses and errors are never remembered — only a plain 200 for a digest-referenced blob, which is the one answer immutability makes safe to cache. The policy is still consulted on every request; only the registry's answer is memoized.

The cache's memory is allocated in full at startup and never grows, entries are evicted least-recently-used, and lookups allocate nothing. Both settings are flags on `serve`: --blob-existence-cache-ttl (6h) and --blob-existence-cache-max-memory (64MiB). Either at 0 turns it off.

The TTL is the one thing between a client and a wrong answer: a registry can garbage-collect a blob, and a push client trusting a stale hit would skip re-uploading a layer that is gone. Keep it inside the registry's collection window; see the README.