### PR TITLE
feat(deploy): add crane-style progress logs for non-interactive deploys

### DIFF
--- a/img_tool/cmd/deploy/BUILD.bazel
+++ b/img_tool/cmd/deploy/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/load",
         "//pkg/ocilayout",
         "//pkg/persistentworker",
+        "//pkg/progress",
         "//pkg/proto/blobcache",
         "//pkg/push",
         "//pkg/registryopts",
@@ -37,6 +38,7 @@ go_library(
 go_test(
     name = "deploy_test",
     srcs = [
+        "progress_test.go",
         "sign_sink_test.go",
         "sink_test.go",
         "sink_vfs_test.go",
@@ -46,6 +48,7 @@ go_test(
         "//pkg/api",
         "//pkg/deployvfs",
         "//pkg/ocilayout",
+        "//pkg/progress",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_google_go_containerregistry//pkg/v1/empty",
         "@com_github_google_go_containerregistry//pkg/v1/mutate",

--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -31,6 +31,7 @@ import (
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/gateway"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/load"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/persistentworker"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/progress"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/proto/blobcache"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/push"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/registryopts"
@@ -60,6 +61,10 @@ func DeployProcess(ctx context.Context, args []string) {
 	}
 	if isPersistentWorker {
 		jobs := extractJobsFlag(processedArgs)
+		if err := applyProgressMode(extractProgressFlag(processedArgs), true); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 		if err := persistentWorker(jobs, sinkSpec); err != nil {
 			fmt.Fprintf(os.Stderr, "Error in persistent worker: %v\n", err)
 			os.Exit(1)
@@ -78,6 +83,7 @@ func DeployProcess(ctx context.Context, args []string) {
 	var explicitLayers stringSliceFlag
 	var jobs int
 	var sink string
+	var progressMode string
 	var signSettingFiles stringSliceFlag
 	var defaultSignSetting string
 	var signForce bool
@@ -95,6 +101,7 @@ func DeployProcess(ctx context.Context, args []string) {
 	flagSet.Var(&explicitLayers, "layer", "Layer as digest=path or a bare path (can be used multiple times). The file may be a raw compressed layer blob or a compact stream (.cstream), auto-detected. For a bare path: a raw blob is hashed to derive its digest; a .cstream must embed its compressed digest.")
 	flagSet.IntVar(&jobs, "jobs", defaultDeployJobs(), "Maximum number of parallel push operations (defaults to GOMAXPROCS)")
 	flagSet.StringVar(&sink, "sink", "", "Override the destination of all push/load/registry_tag operations for testing. Format: <type>:<path> where type is one of oci-tar, docker-save, oci, distribution, distribution-flat. No registry or daemon network I/O is performed.")
+	flagSet.StringVar(&progressMode, "progress", "", "How to report progress on stderr: 'bar' (interactive progress bars), 'log' (one crane-style line per blob), 'none', or 'auto' (default: bars on a terminal, log lines otherwise). Overridable with $IMG_PROGRESS.")
 	flagSet.Var(&signSettingFiles, "sign_setting_file", "Additional sign_setting config file to ingest for signing (can be used multiple times)")
 	flagSet.StringVar(&defaultSignSetting, "default_sign_setting", "", "Default sign_setting for operations without one: a path to a config file, or sha256:<hex> referencing a discovered setting")
 	flagSet.BoolVar(&signForce, "sign_force", false, "Sign every push operation using the default sign_setting, even operations not configured to sign at build time")
@@ -112,6 +119,12 @@ func DeployProcess(ctx context.Context, args []string) {
 
 	if len(requestFiles) == 0 {
 		fmt.Fprintln(os.Stderr, "Error: at least one --request-file is required")
+		flagSet.Usage()
+		os.Exit(1)
+	}
+
+	if err := applyProgressMode(progressMode, false); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		flagSet.Usage()
 		os.Exit(1)
 	}
@@ -697,9 +710,21 @@ func extractJobsFlag(args []string) int {
 // a global oci-tar/docker-save sink must force one-shot mode before the normal
 // flag set is parsed.
 func extractSinkFlag(args []string) string {
+	return extractFlag(args, "--sink")
+}
+
+// extractProgressFlag pre-scans args for --progress, which the persistent
+// worker needs before (and instead of) the one-shot flag set is parsed.
+func extractProgressFlag(args []string) string {
+	return extractFlag(args, "--progress")
+}
+
+// extractFlag returns the value of the given `--flag=value` / `--flag value`
+// argument, or the empty string if it is not present.
+func extractFlag(args []string, flag string) string {
 	for i := 0; i < len(args); i++ {
 		key, value, hasValue := strings.Cut(args[i], "=")
-		if key == "--sink" {
+		if key == flag {
 			if !hasValue && i+1 < len(args) {
 				value = args[i+1]
 			}
@@ -707,6 +732,26 @@ func extractSinkFlag(args []string) string {
 		}
 	}
 	return ""
+}
+
+// applyProgressMode selects how the deploy reports progress on stderr. An empty
+// value auto-detects: interactive progress bars when stderr is a terminal,
+// crane-style log lines otherwise. Progress bars can't work in the persistent
+// worker - requests are multiplexed onto one stderr (the Bazel worker log) - so
+// they degrade to log lines there.
+func applyProgressMode(value string, isPersistentWorker bool) error {
+	mode, err := progress.ParseMode(value)
+	if err != nil {
+		return err
+	}
+	if mode == progress.ModeAuto {
+		mode = progress.AutoMode(progress.ModeLog)
+	}
+	if isPersistentWorker && mode == progress.ModeBar {
+		mode = progress.ModeLog
+	}
+	progress.SetMode(mode)
+	return nil
 }
 
 // deployToSink builds the requested sink, routes every operation into it, and

--- a/img_tool/cmd/deploy/progress_test.go
+++ b/img_tool/cmd/deploy/progress_test.go
@@ -1,0 +1,67 @@
+package deploy
+
+import (
+	"testing"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/progress"
+)
+
+func TestExtractProgressFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "absent", args: []string{"--request-file", "req.json"}, want: ""},
+		{name: "joined", args: []string{"--progress=log", "--jobs=4"}, want: "log"},
+		{name: "separate", args: []string{"--progress", "none"}, want: "none"},
+		{name: "missing value", args: []string{"--jobs=4", "--progress"}, want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractProgressFlag(tc.args); got != tc.want {
+				t.Errorf("extractProgressFlag(%q) = %q, want %q", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyProgressMode(t *testing.T) {
+	// Auto-detection depends on the environment, so only explicit values are
+	// asserted here (see the progress package for the auto-detection tests).
+	for _, tc := range []struct {
+		name             string
+		value            string
+		persistentWorker bool
+		want             progress.Mode
+	}{
+		{name: "bar", value: "bar", want: progress.ModeBar},
+		{name: "log", value: "log", want: progress.ModeLog},
+		{name: "none", value: "none", want: progress.ModeNone},
+		{
+			// Bars can't work when requests are multiplexed onto one stderr.
+			name:             "bar degrades to log in the worker",
+			value:            "bar",
+			persistentWorker: true,
+			want:             progress.ModeLog,
+		},
+		{
+			name:             "none is honored in the worker",
+			value:            "none",
+			persistentWorker: true,
+			want:             progress.ModeNone,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := applyProgressMode(tc.value, tc.persistentWorker); err != nil {
+				t.Fatalf("applyProgressMode(%q, %v) returned error: %v", tc.value, tc.persistentWorker, err)
+			}
+			if got := progress.CurrentMode(); got != tc.want {
+				t.Errorf("progress mode = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	if err := applyProgressMode("bogus", false); err == nil {
+		t.Error("applyProgressMode(\"bogus\", false) = nil error, want an error")
+	}
+}

--- a/img_tool/pkg/load/BUILD.bazel
+++ b/img_tool/pkg/load/BUILD.bazel
@@ -25,15 +25,19 @@ go_test(
     name = "load_test",
     srcs = [
         "loader_test.go",
+        "progress_test.go",
         "streamdockertar_test.go",
     ],
     embed = [":load"],
     deps = [
         "//pkg/api",
+        "//pkg/containerd",
+        "//pkg/progress",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_google_go_containerregistry//pkg/v1/empty",
         "@com_github_google_go_containerregistry//pkg/v1/mutate",
         "@com_github_google_go_containerregistry//pkg/v1/static",
         "@com_github_google_go_containerregistry//pkg/v1/types",
+        "@com_github_opencontainers_go_digest//:go-digest",
     ],
 )

--- a/img_tool/pkg/load/load.go
+++ b/img_tool/pkg/load/load.go
@@ -157,7 +157,7 @@ func storeBlob(ctx context.Context, store containerd.Store, desc ocispec.Descrip
 	if err == nil && info.Digest == desc.Digest && info.Size == desc.Size {
 		// Blob already exists with correct size, nothing to do.
 		// We still print a progress writer for consistency.
-		if err := progress.CompletedWriter(ctx, desc.Size, desc.Digest.Hex()[:12]); err != nil {
+		if err := progress.CompletedWriter(ctx, desc.Size, desc.Digest.String()); err != nil {
 			return fmt.Errorf("creating completed progress writer: %w", err)
 		}
 
@@ -179,7 +179,7 @@ func storeBlob(ctx context.Context, store containerd.Store, desc ocispec.Descrip
 	}
 	defer reader.Close()
 
-	pw, err := progress.Writer(ctx, desc.Size, desc.Digest.Hex()[:12])
+	pw, err := progress.Writer(ctx, desc.Size, desc.Digest.String())
 	if err != nil {
 		return fmt.Errorf("creating progress bar: %w", err)
 	}
@@ -197,14 +197,13 @@ func storeBlob(ctx context.Context, store containerd.Store, desc ocispec.Descrip
 		commitOpts = append(commitOpts, containerd.WithLabels(labels))
 	}
 
-	if err := writer.Commit(ctx, desc.Size, desc.Digest, commitOpts...); err != nil {
-		if containerd.IsAlreadyExists(err) {
-			// Blob was written by another process, that's ok
-			return nil
-		}
+	// An AlreadyExists error means the blob was written by another process
+	// concurrently, which is ok: the content store holds it either way.
+	if err := writer.Commit(ctx, desc.Size, desc.Digest, commitOpts...); err != nil && !containerd.IsAlreadyExists(err) {
 		return fmt.Errorf("committing data: %w", err)
 	}
 
+	progress.Transferred(ctx, desc.Digest.String())
 	return nil
 }
 

--- a/img_tool/pkg/load/loader.go
+++ b/img_tool/pkg/load/loader.go
@@ -193,7 +193,7 @@ func (l *loader) LoadAll(ctx context.Context, ops []api.IndexedLoadDeployOperati
 				blobSizes := make([]int64, len(blobs))
 				for i, blob := range blobs {
 					digest, _ := blob.layer.Digest()
-					blobNames[i] = digest.Hex[:12]
+					blobNames[i] = digest.String()
 					blobSizes[i], err = blob.layer.Size()
 					if err != nil {
 						return nil, fmt.Errorf("getting size of blob %s: %w", digest.String(), err)

--- a/img_tool/pkg/load/progress_test.go
+++ b/img_tool/pkg/load/progress_test.go
@@ -1,0 +1,251 @@
+package load
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+
+	registryv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	ocigodigest "github.com/opencontainers/go-digest"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/containerd"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/progress"
+)
+
+// TestUploadBlobsReportsCraneStyleProgress covers the incremental containerd
+// load: every blob written to the content store, and every blob the store
+// already had, is reported in crane's style.
+func TestUploadBlobsReportsCraneStyleProgress(t *testing.T) {
+	out := captureProgress(t, progress.ModeLog)
+
+	store := newFakeContentStore()
+	newBlob := blobWorkItem{
+		layer:  staticLayer(t, "a new layer"),
+		labels: map[string]string{"containerd.io/gc.ref.content.l.0": "sha256:cafe"},
+	}
+	existingBlob := blobWorkItem{layer: staticLayer(t, "a layer containerd already has")}
+	store.add(t, existingBlob)
+
+	// The containerd branch of LoadAll reports under the "loaded" verb.
+	ctx, stop := progress.InitProgress(context.Background(), "loaded")
+	defer stop()
+
+	if err := uploadBlobsParallel(ctx, store, []blobWorkItem{newBlob, existingBlob}, 1); err != nil {
+		t.Fatalf("uploadBlobsParallel() returned error: %v", err)
+	}
+
+	// Same shape as crane: one timestamped line per event, nothing else.
+	got := out.String()
+	craneLine := regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} \S`)
+	for _, line := range strings.Split(strings.TrimSuffix(got, "\n"), "\n") {
+		if !craneLine.MatchString(line) {
+			t.Errorf("progress line %q is not in crane's format", line)
+		}
+	}
+	// The full digest is reported, like crane does - the shortened form is only
+	// used to label progress bars.
+	if want := "loaded blob: " + digestOf(t, newBlob); !strings.Contains(got, want) {
+		t.Errorf("missing %q in progress output:\n%s", want, got)
+	}
+	if want := "existing blob: " + digestOf(t, existingBlob); !strings.Contains(got, want) {
+		t.Errorf("missing %q in progress output:\n%s", want, got)
+	}
+
+	// The blob that was missing ended up in the content store, with its labels.
+	if got, want := store.content(t, digestOf(t, newBlob)), "a new layer"; got != want {
+		t.Errorf("content store holds %q for the new blob, want %q", got, want)
+	}
+	if got := store.labelsOf(t, digestOf(t, newBlob))["containerd.io/gc.ref.content.l.0"]; got != "sha256:cafe" {
+		t.Errorf("committed GC label = %q, want %q", got, "sha256:cafe")
+	}
+}
+
+// TestUploadBlobsStaysSilentWithoutProgress covers `--progress=none`: the same
+// load reports nothing at all.
+func TestUploadBlobsStaysSilentWithoutProgress(t *testing.T) {
+	out := captureProgress(t, progress.ModeNone)
+
+	store := newFakeContentStore()
+	blob := blobWorkItem{layer: staticLayer(t, "a new layer")}
+
+	ctx, stop := progress.InitProgress(context.Background(), "loaded")
+	defer stop()
+
+	if err := uploadBlobsParallel(ctx, store, []blobWorkItem{blob}, 1); err != nil {
+		t.Fatalf("uploadBlobsParallel() returned error: %v", err)
+	}
+	if got := out.String(); got != "" {
+		t.Errorf("reported progress with progress reporting off:\n%s", got)
+	}
+}
+
+func staticLayer(t *testing.T, content string) registryv1.Layer {
+	t.Helper()
+	return static.NewLayer([]byte(content), types.DockerLayer)
+}
+
+func digestOf(t *testing.T, blob blobWorkItem) string {
+	t.Helper()
+	digest, err := blob.layer.Digest()
+	if err != nil {
+		t.Fatalf("digesting test layer: %v", err)
+	}
+	return digest.String()
+}
+
+// fakeContentStore is an in-memory stand-in for containerd's content store.
+type fakeContentStore struct {
+	mu     sync.Mutex
+	blobs  map[ocigodigest.Digest][]byte
+	labels map[ocigodigest.Digest]map[string]string
+}
+
+func newFakeContentStore() *fakeContentStore {
+	return &fakeContentStore{
+		blobs:  make(map[ocigodigest.Digest][]byte),
+		labels: make(map[ocigodigest.Digest]map[string]string),
+	}
+}
+
+// add seeds the store with a blob, as if a previous load had written it.
+func (s *fakeContentStore) add(t *testing.T, blob blobWorkItem) {
+	t.Helper()
+	reader, err := blob.layer.Compressed()
+	if err != nil {
+		t.Fatalf("reading test layer: %v", err)
+	}
+	defer reader.Close()
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("reading test layer: %v", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.blobs[ocigodigest.Digest(digestOf(t, blob))] = content
+}
+
+// content returns a stored blob's bytes.
+func (s *fakeContentStore) content(t *testing.T, digest string) string {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	content, ok := s.blobs[ocigodigest.Digest(digest)]
+	if !ok {
+		t.Fatalf("content store has no blob %s", digest)
+	}
+	return string(content)
+}
+
+// labelsOf returns the labels a blob was committed with.
+func (s *fakeContentStore) labelsOf(t *testing.T, digest string) map[string]string {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.labels[ocigodigest.Digest(digest)]
+}
+
+func (s *fakeContentStore) Info(_ context.Context, digest ocigodigest.Digest) (containerd.Info, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	content, ok := s.blobs[digest]
+	if !ok {
+		return containerd.Info{}, fmt.Errorf("content %s: not found", digest)
+	}
+	return containerd.Info{Digest: digest, Size: int64(len(content))}, nil
+}
+
+func (s *fakeContentStore) Writer(_ context.Context, opts ...containerd.WriterOpt) (containerd.Writer, error) {
+	var writerOpts containerd.WriterOpts
+	for _, opt := range opts {
+		opt(&writerOpts)
+	}
+	return &fakeContentWriter{store: s, expected: writerOpts.Digest}, nil
+}
+
+type fakeContentWriter struct {
+	store    *fakeContentStore
+	expected ocigodigest.Digest
+	content  []byte
+}
+
+func (w *fakeContentWriter) Write(p []byte) (int, error) {
+	w.content = append(w.content, p...)
+	return len(p), nil
+}
+
+func (w *fakeContentWriter) Close() error { return nil }
+
+func (w *fakeContentWriter) Commit(_ context.Context, size int64, expected ocigodigest.Digest, opts ...containerd.Opt) error {
+	if size != int64(len(w.content)) {
+		return fmt.Errorf("committing %s: wrote %d bytes, expected %d", expected, len(w.content), size)
+	}
+	if got := ocigodigest.FromBytes(w.content); got != expected {
+		return fmt.Errorf("committing %s: content has digest %s", expected, got)
+	}
+	var commitOpts containerd.CommitOpts
+	for _, opt := range opts {
+		opt(&commitOpts)
+	}
+	w.store.mu.Lock()
+	defer w.store.mu.Unlock()
+	w.store.blobs[expected] = w.content
+	w.store.labels[expected] = commitOpts.Labels
+	return nil
+}
+
+func (w *fakeContentWriter) Status() (containerd.Status, error) {
+	return containerd.Status{Offset: int64(len(w.content))}, nil
+}
+
+func (w *fakeContentWriter) Digest() ocigodigest.Digest { return w.expected }
+
+func (w *fakeContentWriter) Truncate(int64) error {
+	w.content = nil
+	return nil
+}
+
+// captureProgress applies the given progress mode for the duration of the test
+// with stderr redirected, so that everything the mode reports to the user can be
+// inspected. The mode is applied after the redirect because it captures
+// os.Stderr by value.
+func captureProgress(t *testing.T, mode progress.Mode) *stderrCapture {
+	t.Helper()
+	file, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatalf("creating stderr capture file: %v", err)
+	}
+	previousStderr := os.Stderr
+	previousMode := progress.CurrentMode()
+	t.Cleanup(func() {
+		os.Stderr = previousStderr
+		// Restoring the mode also restores the loggers it owns.
+		progress.SetMode(previousMode)
+		file.Close()
+	})
+
+	os.Stderr = file
+	progress.SetMode(mode)
+	return &stderrCapture{t: t, file: file}
+}
+
+// stderrCapture reads back what was written to the redirected stderr.
+type stderrCapture struct {
+	t    *testing.T
+	file *os.File
+}
+
+func (c *stderrCapture) String() string {
+	c.t.Helper()
+	data, err := os.ReadFile(c.file.Name())
+	if err != nil {
+		c.t.Fatalf("reading stderr capture: %v", err)
+	}
+	return string(data)
+}

--- a/img_tool/pkg/progress/BUILD.bazel
+++ b/img_tool/pkg/progress/BUILD.bazel
@@ -1,12 +1,24 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "progress",
-    srcs = ["progress.go"],
+    srcs = [
+        "mode.go",
+        "progress.go",
+    ],
     importpath = "github.com/bazel-contrib/rules_img/img_tool/pkg/progress",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_google_go_containerregistry//pkg/logs",
         "@com_github_jedib0t_go_pretty_v6//progress",
         "@org_golang_x_term//:term",
     ],
+)
+
+go_test(
+    name = "progress_test",
+    size = "small",
+    srcs = ["progress_test.go"],
+    embed = [":progress"],
+    deps = ["@com_github_google_go_containerregistry//pkg/logs"],
 )

--- a/img_tool/pkg/progress/mode.go
+++ b/img_tool/pkg/progress/mode.go
@@ -1,0 +1,156 @@
+package progress
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/logs"
+	"golang.org/x/term"
+)
+
+// Mode selects how progress is reported to the user.
+type Mode int
+
+const (
+	// ModeAuto asks for the mode to be derived from the environment.
+	// It is never the mode in effect: see SetMode and AutoMode.
+	ModeAuto Mode = iota
+	// ModeBar renders self-updating progress bars on stderr, one per blob.
+	ModeBar
+	// ModeLog writes one line per blob to stderr, in the style of crane
+	// ("existing blob: sha256:...", "pushed blob: sha256:..."). The lines for
+	// registry traffic come from go-containerregistry itself.
+	ModeLog
+	// ModeNone reports no progress at all.
+	ModeNone
+)
+
+// progressEnvVar overrides the automatically detected mode.
+const progressEnvVar = "IMG_PROGRESS"
+
+// noProgressEnvVar disables progress reporting entirely.
+const noProgressEnvVar = "NO_PROGRESS"
+
+// noBarEnvVars disable the interactive progress bars, even on a terminal.
+var noBarEnvVars = []string{
+	"NO_INTERACTIVE",
+	"NO_COLOR",
+}
+
+// String returns the flag value that selects the mode.
+func (m Mode) String() string {
+	switch m {
+	case ModeAuto:
+		return "auto"
+	case ModeBar:
+		return "bar"
+	case ModeLog:
+		return "log"
+	case ModeNone:
+		return "none"
+	}
+	return fmt.Sprintf("Mode(%d)", int(m))
+}
+
+// ParseMode parses a mode name: "auto", "bar", "log", or "none".
+// The empty string parses as ModeAuto.
+func ParseMode(value string) (Mode, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "auto":
+		return ModeAuto, nil
+	case "bar", "bars":
+		return ModeBar, nil
+	case "log", "logs", "plain":
+		return ModeLog, nil
+	case "none", "off", "quiet":
+		return ModeNone, nil
+	}
+	return ModeAuto, fmt.Errorf("invalid progress mode %q: want one of auto, bar, log, none", value)
+}
+
+var (
+	modeMu sync.Mutex
+	// mode is the mode in effect, or ModeAuto while it is still unresolved.
+	mode Mode
+)
+
+// SetMode selects how progress is reported for the remainder of the process and
+// returns the mode that is now in effect. ModeAuto is resolved with
+// AutoMode(ModeNone), i.e. commands that don't opt into another fallback stay
+// silent when stderr is not a terminal.
+//
+// The mode owns the go-containerregistry loggers: they are the ones printing
+// the per-blob lines for registry traffic, so they are enabled in ModeLog and
+// silenced in every other mode.
+//
+// Call it once during startup, before any progress is reported: reporting that
+// is already in flight keeps using the mode it was started with.
+func SetMode(m Mode) Mode {
+	if m == ModeAuto {
+		m = AutoMode(ModeNone)
+	}
+	modeMu.Lock()
+	defer modeMu.Unlock()
+	mode = m
+	if m == ModeLog {
+		// go-containerregistry logs one line per blob it pushes, pulls, mounts
+		// or skips, and one per manifest it writes - which is exactly what crane
+		// prints. Its warnings (registry retries, missing credentials) are
+		// useful in the same situations, so enable both, like crane does.
+		logs.Progress.SetOutput(os.Stderr)
+		logs.Warn.SetOutput(os.Stderr)
+	} else {
+		// A stray line would corrupt the progress bars, and nothing at all is
+		// reported in ModeNone.
+		logs.Progress.SetOutput(io.Discard)
+		logs.Warn.SetOutput(io.Discard)
+	}
+	return m
+}
+
+// CurrentMode returns the mode in effect, resolving it from the environment on
+// first use if SetMode was never called.
+func CurrentMode() Mode {
+	modeMu.Lock()
+	resolved := mode
+	modeMu.Unlock()
+	if resolved != ModeAuto {
+		return resolved
+	}
+	return SetMode(ModeAuto)
+}
+
+// AutoMode returns the mode to use when the user didn't ask for a specific one.
+// notATerminal is returned when progress bars can't be rendered because stderr
+// is not an interactive terminal: `img deploy` passes ModeLog to get
+// crane-style output, build actions stay silent with ModeNone.
+//
+// $NO_PROGRESS turns progress reporting off entirely, $NO_INTERACTIVE and
+// $NO_COLOR turn off the progress bars, and $IMG_PROGRESS overrides the whole
+// decision with an explicit mode.
+func AutoMode(notATerminal Mode) Mode {
+	if raw, ok := os.LookupEnv(progressEnvVar); ok && strings.TrimSpace(raw) != "" {
+		m, err := ParseMode(raw)
+		switch {
+		case err != nil:
+			fmt.Fprintf(os.Stderr, "WARNING: ignoring invalid %s=%q: %v\n", progressEnvVar, raw, err)
+		case m != ModeAuto:
+			return m
+		}
+	}
+	if _, ok := os.LookupEnv(noProgressEnvVar); ok {
+		return ModeNone
+	}
+	for _, envVar := range noBarEnvVars {
+		if _, ok := os.LookupEnv(envVar); ok {
+			return notATerminal
+		}
+	}
+	if !term.IsTerminal(int(os.Stderr.Fd())) {
+		return notATerminal
+	}
+	return ModeBar
+}

--- a/img_tool/pkg/progress/progress.go
+++ b/img_tool/pkg/progress/progress.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"io"
 	"os"
-	"sync"
+	"strings"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/jedib0t/go-pretty/v6/progress"
-	"golang.org/x/term"
 )
 
 type contextKey string
@@ -17,19 +17,29 @@ type contextKey string
 const (
 	writerKey   contextKey = "progressWriter"
 	trackersKey contextKey = "progressTrackers"
+	logVerbKey  contextKey = "progressLogVerb"
 )
 
-// InitProgress creates and starts a progress writer for tracking multiple concurrent operations.
-// Returns a context with the writer attached and a stop function to call when done.
-// Progress bars are only displayed if stderr is a TTY.
+// InitProgress starts progress reporting for multiple concurrent operations.
+// Returns a context to hand to the reporting functions below and a stop
+// function to call when done.
+//
+// doneMessage describes a finished transfer ("pushed", "loaded"): it labels the
+// completed progress bars in ModeBar and is the verb of the per-blob lines in
+// ModeLog.
 //
 // Usage:
 //
-//	ctx, stop := progress.InitProgress(ctx)
+//	ctx, stop := progress.InitProgress(ctx, "pushed")
 //	defer stop()
 func InitProgress(ctx context.Context, doneMessage string) (context.Context, func()) {
-	if !wantProgressBar() {
-		return ctx, func() {} // no-op when not a TTY
+	switch CurrentMode() {
+	case ModeBar:
+		// fall through to the progress bar setup below
+	case ModeLog:
+		return context.WithValue(ctx, logVerbKey, doneMessage), func() {}
+	default:
+		return ctx, func() {} // no-op when progress is not reported
 	}
 
 	pw := progress.NewWriter()
@@ -77,6 +87,16 @@ func trackersFromContext(ctx context.Context) map[string]*progress.Tracker {
 	return nil
 }
 
+// logVerbFromContext retrieves the verb describing a finished transfer
+// ("pushed", "loaded") from the context, as set by InitProgress. It reports
+// false if the context was not derived from an InitProgress context, in which
+// case nothing is reported - just like ModeBar reports nothing without a
+// progress writer in the context.
+func logVerbFromContext(ctx context.Context) (string, bool) {
+	verb, ok := ctx.Value(logVerbKey).(string)
+	return verb, ok
+}
+
 // DeclareTrackers pre-creates progress trackers in the specified order with DeferStart enabled.
 // This allows displaying all trackers in a deterministic order, even before they start.
 //
@@ -109,7 +129,7 @@ func DeclareTrackers(ctx context.Context, names []string, sizes []int64) context
 	trackers := make(map[string]*progress.Tracker)
 	for i, name := range names {
 		tracker := &progress.Tracker{
-			Message:    name,
+			Message:    barLabel(name),
 			Total:      sizes[i],
 			Units:      progress.UnitsBytes,
 			DeferStart: true,
@@ -124,21 +144,24 @@ func DeclareTrackers(ctx context.Context, names []string, sizes []int64) context
 // Writer creates an io.Writer that tracks progress for a single operation.
 // The io.Writer should be used with io.MultiWriter to track progress while writing to a destination.
 //
-// If a pre-declared tracker exists for the given description (via DeclareTrackers), it will be used
-// and started. Otherwise, a new tracker is created and appended dynamically.
+// In ModeBar, a pre-declared tracker for the given description (via
+// DeclareTrackers) is used if one exists, and a new tracker is appended
+// dynamically otherwise. ModeLog doesn't report a transfer while it is in
+// flight; call Transferred once it finished.
 //
-// Returns an error if no progress writer is in the context.
+// Returns an error if progress bars are requested but no progress writer is in the context.
 //
 // Usage:
 //
-//	ctx, stop := progress.InitProgress(ctx, "done")
+//	ctx, stop := progress.InitProgress(ctx, "pushed")
 //	defer stop()
 //
-//	pw, err := progress.Writer(ctx, size, "downloading layer")
+//	pw, err := progress.Writer(ctx, size, digest)
 //	if err != nil { return err }
 //	io.Copy(io.MultiWriter(destFile, pw), srcReader)
+//	progress.Transferred(ctx, digest)
 func Writer(ctx context.Context, size int64, desc string) (io.Writer, error) {
-	if !wantProgressBar() {
+	if CurrentMode() != ModeBar {
 		return io.Discard, nil
 	}
 
@@ -160,7 +183,7 @@ func Writer(ctx context.Context, size int64, desc string) (io.Writer, error) {
 
 	// No pre-declared tracker, create a new one dynamically
 	tracker := &progress.Tracker{
-		Message: desc,
+		Message: barLabel(desc),
 		Total:   size,
 		Units:   progress.UnitsBytes,
 	}
@@ -169,8 +192,34 @@ func Writer(ctx context.Context, size int64, desc string) (io.Writer, error) {
 	return &trackerWriter{tracker: tracker}, nil
 }
 
+// Transferred reports a transfer that finished, once its bytes are committed at
+// the destination: crane's "pushed blob: <desc>" line in ModeLog, with the verb
+// taken from InitProgress's doneMessage ("pushed", "loaded").
+//
+// It is a no-op in ModeBar, where the tracker of the matching Writer completes
+// as the bytes are written.
+func Transferred(ctx context.Context, desc string) {
+	if CurrentMode() != ModeLog {
+		return
+	}
+	if verb, ok := logVerbFromContext(ctx); ok {
+		logs.Progress.Printf("%s blob: %s", verb, desc)
+	}
+}
+
+// CompletedWriter reports an operation that finished without transferring any
+// bytes because the destination already had them: a full progress bar in
+// ModeBar, and crane's "existing blob" line in ModeLog.
 func CompletedWriter(ctx context.Context, size int64, desc string) error {
-	if !wantProgressBar() {
+	switch CurrentMode() {
+	case ModeBar:
+		// fall through to the tracker setup below
+	case ModeLog:
+		if _, ok := logVerbFromContext(ctx); ok {
+			logs.Progress.Printf("existing blob: %s", desc)
+		}
+		return nil
+	default:
 		return nil
 	}
 
@@ -192,7 +241,7 @@ func CompletedWriter(ctx context.Context, size int64, desc string) error {
 
 	// No pre-declared tracker, create a completed one dynamically
 	tracker := &progress.Tracker{
-		Message: desc,
+		Message: barLabel(desc),
 		Total:   size,
 		Units:   progress.UnitsBytes,
 	}
@@ -211,6 +260,27 @@ func (tw *trackerWriter) Write(p []byte) (int, error) {
 	tw.tracker.Increment(int64(n))
 	return n, nil
 }
+
+// barLabel shortens a digest to the first 12 hex characters, which is what the
+// progress bars are labelled with - a full digest would make every line wrap.
+// Descriptions that are not digests are used as they are. The log lines always
+// carry the full digest, like crane's do.
+func barLabel(desc string) string {
+	_, hex, ok := strings.Cut(desc, ":")
+	if !ok || len(hex) <= shortDigestLength {
+		return desc
+	}
+	for _, c := range hex {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return desc
+		}
+	}
+	return hex[:shortDigestLength]
+}
+
+// shortDigestLength is the number of hex characters of a digest shown in a
+// progress bar's label.
+const shortDigestLength = 12
 
 // Indeterminate represents a progress tracker with an initially unknown total.
 // The total can be updated once known using SetTotal, and progress is updated with SetComplete.
@@ -247,6 +317,10 @@ func (i *Indeterminate) Done(err error) {
 // If a progress writer is attached to the context (via InitProgress), it will add a tracker to it.
 // Otherwise, returns a no-op tracker.
 //
+// An aggregate byte counter has no crane-style equivalent, so this is a no-op
+// tracker in ModeLog: the per-blob lines are reported by go-containerregistry
+// and by Writer/CompletedWriter instead.
+//
 // Usage:
 //
 //	ctx, stop := progress.InitProgress(ctx)
@@ -256,8 +330,8 @@ func (i *Indeterminate) Done(err error) {
 //	tracker.SetTotal(totalSize) // once known
 //	tracker.SetComplete(bytesUploaded) // as progress is made
 func NewIndeterminate(ctx context.Context, message string) *Indeterminate {
-	if !wantProgressBar() {
-		return &Indeterminate{} // Return empty struct when not a TTY
+	if CurrentMode() != ModeBar {
+		return &Indeterminate{} // Return empty struct when progress bars are off
 	}
 
 	pw := fromContext(ctx)
@@ -275,18 +349,3 @@ func NewIndeterminate(ctx context.Context, message string) *Indeterminate {
 
 	return &Indeterminate{tracker: tracker}
 }
-
-var noProgressEnvVars = []string{
-	"NO_PROGRESS",
-	"NO_INTERACTIVE",
-	"NO_COLOR",
-}
-
-var wantProgressBar = sync.OnceValue(func() bool {
-	for _, envVar := range noProgressEnvVars {
-		if _, exists := os.LookupEnv(envVar); exists {
-			return false
-		}
-	}
-	return term.IsTerminal(int(os.Stderr.Fd()))
-})

--- a/img_tool/pkg/progress/progress_test.go
+++ b/img_tool/pkg/progress/progress_test.go
@@ -1,0 +1,382 @@
+package progress
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/logs"
+)
+
+func TestParseMode(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  Mode
+	}{
+		{value: "", want: ModeAuto},
+		{value: "auto", want: ModeAuto},
+		{value: "AUTO", want: ModeAuto},
+		{value: " bar ", want: ModeBar},
+		{value: "bars", want: ModeBar},
+		{value: "log", want: ModeLog},
+		{value: "logs", want: ModeLog},
+		{value: "plain", want: ModeLog},
+		{value: "none", want: ModeNone},
+		{value: "off", want: ModeNone},
+		{value: "quiet", want: ModeNone},
+	} {
+		got, err := ParseMode(tc.value)
+		if err != nil {
+			t.Errorf("ParseMode(%q) returned error: %v", tc.value, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("ParseMode(%q) = %v, want %v", tc.value, got, tc.want)
+		}
+	}
+
+	if _, err := ParseMode("bogus"); err == nil {
+		t.Error("ParseMode(\"bogus\") = nil error, want an error")
+	}
+}
+
+func TestModeString(t *testing.T) {
+	for _, tc := range []struct {
+		mode Mode
+		want string
+	}{
+		{mode: ModeAuto, want: "auto"},
+		{mode: ModeBar, want: "bar"},
+		{mode: ModeLog, want: "log"},
+		{mode: ModeNone, want: "none"},
+	} {
+		if got := tc.mode.String(); got != tc.want {
+			t.Errorf("%d.String() = %q, want %q", int(tc.mode), got, tc.want)
+		}
+		// Every mode name round-trips through ParseMode.
+		parsed, err := ParseMode(tc.want)
+		if err != nil || parsed != tc.mode {
+			t.Errorf("ParseMode(%q) = %v, %v, want %v, nil", tc.want, parsed, err, tc.mode)
+		}
+	}
+}
+
+func TestAutoMode(t *testing.T) {
+	// Test binaries never run with stderr attached to a terminal, so the
+	// caller's non-terminal fallback is what auto-detection settles on.
+	for _, tc := range []struct {
+		name string
+		env  map[string]string
+		want Mode
+	}{
+		{
+			name: "not a terminal",
+			want: ModeLog,
+		},
+		{
+			name: "NO_PROGRESS wins over the fallback",
+			env:  map[string]string{"NO_PROGRESS": "1"},
+			want: ModeNone,
+		},
+		{
+			name: "NO_COLOR only turns off the bars",
+			env:  map[string]string{"NO_COLOR": "1"},
+			want: ModeLog,
+		},
+		{
+			name: "NO_INTERACTIVE only turns off the bars",
+			env:  map[string]string{"NO_INTERACTIVE": "1"},
+			want: ModeLog,
+		},
+		{
+			name: "IMG_PROGRESS overrides",
+			env:  map[string]string{"IMG_PROGRESS": "none"},
+			want: ModeNone,
+		},
+		{
+			name: "IMG_PROGRESS overrides NO_PROGRESS",
+			env:  map[string]string{"IMG_PROGRESS": "bar", "NO_PROGRESS": "1"},
+			want: ModeBar,
+		},
+		{
+			name: "IMG_PROGRESS=auto defers to detection",
+			env:  map[string]string{"IMG_PROGRESS": "auto"},
+			want: ModeLog,
+		},
+		{
+			name: "invalid IMG_PROGRESS is ignored",
+			env:  map[string]string{"IMG_PROGRESS": "bogus"},
+			want: ModeLog,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearProgressEnv(t)
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			if got := AutoMode(ModeLog); got != tc.want {
+				t.Errorf("AutoMode(ModeLog) = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAutoModeNonInteractiveFallbackIsCallerChosen(t *testing.T) {
+	clearProgressEnv(t)
+	// Build actions opt out of any output when they can't render bars.
+	if got := AutoMode(ModeNone); got != ModeNone {
+		t.Errorf("AutoMode(ModeNone) = %v, want %v", got, ModeNone)
+	}
+}
+
+func TestSetModeLogEnablesRegistryLogging(t *testing.T) {
+	restoreMode(t)
+	restoreLogs(t)
+
+	logs.Progress.SetOutput(io.Discard)
+	logs.Warn.SetOutput(io.Discard)
+	if got := SetMode(ModeLog); got != ModeLog {
+		t.Fatalf("SetMode(ModeLog) = %v, want %v", got, ModeLog)
+	}
+	// The per-blob lines for registry traffic are printed by
+	// go-containerregistry, so its loggers have to reach the user.
+	if got := logs.Progress.Writer(); got != os.Stderr {
+		t.Errorf("logs.Progress writes to %v, want os.Stderr", got)
+	}
+	if got := logs.Warn.Writer(); got != os.Stderr {
+		t.Errorf("logs.Warn writes to %v, want os.Stderr", got)
+	}
+}
+
+func TestSetModeBarSilencesRegistryLogging(t *testing.T) {
+	restoreMode(t)
+	restoreLogs(t)
+
+	logs.Progress.SetOutput(os.Stderr)
+	logs.Warn.SetOutput(os.Stderr)
+	if got := SetMode(ModeBar); got != ModeBar {
+		t.Fatalf("SetMode(ModeBar) = %v, want %v", got, ModeBar)
+	}
+	// A stray log line would corrupt the progress bars.
+	if got := logs.Progress.Writer(); got != io.Discard {
+		t.Errorf("logs.Progress writes to %v, want io.Discard", got)
+	}
+	if got := logs.Warn.Writer(); got != io.Discard {
+		t.Errorf("logs.Warn writes to %v, want io.Discard", got)
+	}
+}
+
+func TestSetModeAutoResolvesToConcreteMode(t *testing.T) {
+	restoreMode(t)
+	restoreLogs(t)
+	clearProgressEnv(t)
+
+	if got := SetMode(ModeAuto); got != ModeNone {
+		t.Errorf("SetMode(ModeAuto) = %v, want %v", got, ModeNone)
+	}
+	if got := CurrentMode(); got != ModeNone {
+		t.Errorf("CurrentMode() = %v, want %v", got, ModeNone)
+	}
+}
+
+func TestLogModeWritesCraneStyleLines(t *testing.T) {
+	out := setModeForTest(t, ModeLog)
+
+	ctx, stop := InitProgress(context.Background(), "pushed")
+	defer stop()
+
+	if err := CompletedWriter(ctx, 1024, "sha256:cafe"); err != nil {
+		t.Fatalf("CompletedWriter() returned error: %v", err)
+	}
+
+	// A transfer in flight is not reported; only its completion is.
+	w, err := Writer(ctx, 4, "sha256:beef")
+	if err != nil {
+		t.Fatalf("Writer() returned error: %v", err)
+	}
+	if _, err := w.Write([]byte("abcd")); err != nil {
+		t.Fatalf("Write() returned error: %v", err)
+	}
+	if got := out.String(); strings.Contains(got, "sha256:beef") {
+		t.Errorf("transfer in flight reported blob as done:\n%s", got)
+	}
+	Transferred(ctx, "sha256:beef")
+
+	lines := logLines(out)
+	want := []string{
+		"existing blob: sha256:cafe",
+		"pushed blob: sha256:beef",
+	}
+	if len(lines) != len(want) {
+		t.Fatalf("got %d log lines, want %d:\n%s", len(lines), len(want), out.String())
+	}
+	for i, line := range lines {
+		if !strings.HasSuffix(line, want[i]) {
+			t.Errorf("log line %d = %q, want it to end with %q", i, line, want[i])
+		}
+	}
+}
+
+// TestLogModeUsesTheInitProgressVerb covers the load path, which reports the
+// same events with its own verb.
+func TestLogModeUsesTheInitProgressVerb(t *testing.T) {
+	out := setModeForTest(t, ModeLog)
+
+	ctx, stop := InitProgress(context.Background(), "loaded")
+	defer stop()
+
+	Transferred(ctx, "sha256:empty")
+
+	lines := logLines(out)
+	if len(lines) != 1 || !strings.HasSuffix(lines[0], "loaded blob: sha256:empty") {
+		t.Errorf("got log lines %q, want one line ending in %q", lines, "loaded blob: sha256:empty")
+	}
+}
+
+func TestLogModeWithoutInitProgressIsSilent(t *testing.T) {
+	out := setModeForTest(t, ModeLog)
+
+	ctx := context.Background()
+	w, err := Writer(ctx, 2, "sha256:cafe")
+	if err != nil {
+		t.Fatalf("Writer() returned error: %v", err)
+	}
+	if _, err := w.Write([]byte("ab")); err != nil {
+		t.Fatalf("Write() returned error: %v", err)
+	}
+	Transferred(ctx, "sha256:cafe")
+	if err := CompletedWriter(ctx, 2, "sha256:beef"); err != nil {
+		t.Fatalf("CompletedWriter() returned error: %v", err)
+	}
+	if got := out.String(); got != "" {
+		t.Errorf("reported progress outside of an InitProgress scope:\n%s", got)
+	}
+}
+
+func TestModeNoneIsSilent(t *testing.T) {
+	out := setModeForTest(t, ModeNone)
+
+	ctx, stop := InitProgress(context.Background(), "pushed")
+	defer stop()
+
+	w, err := Writer(ctx, 2, "sha256:cafe")
+	if err != nil {
+		t.Fatalf("Writer() returned error: %v", err)
+	}
+	if w != io.Discard {
+		t.Errorf("Writer() = %T, want io.Discard", w)
+	}
+	if _, err := w.Write([]byte("ab")); err != nil {
+		t.Fatalf("Write() returned error: %v", err)
+	}
+	Transferred(ctx, "sha256:cafe")
+	if err := CompletedWriter(ctx, 2, "sha256:beef"); err != nil {
+		t.Fatalf("CompletedWriter() returned error: %v", err)
+	}
+	if tracker := NewIndeterminate(ctx, "pushing"); tracker.tracker != nil {
+		t.Error("NewIndeterminate() returned a live tracker, want a no-op one")
+	}
+	if got := out.String(); got != "" {
+		t.Errorf("reported progress in ModeNone:\n%s", got)
+	}
+}
+
+func TestLogModeIndeterminateIsNoOp(t *testing.T) {
+	out := setModeForTest(t, ModeLog)
+
+	ctx, stop := InitProgress(context.Background(), "pushed")
+	defer stop()
+
+	// An aggregate byte counter has no crane-style equivalent.
+	tracker := NewIndeterminate(ctx, "pushing")
+	tracker.SetTotal(1024)
+	tracker.SetComplete(512)
+	tracker.Done(nil)
+	if got := out.String(); got != "" {
+		t.Errorf("indeterminate tracker logged in ModeLog:\n%s", got)
+	}
+}
+
+// TestBarLabel covers the labels of the progress bars: a full digest would make
+// every bar wrap, so digests are shortened there (the log lines keep them whole).
+func TestBarLabel(t *testing.T) {
+	for _, tc := range []struct {
+		desc string
+		want string
+	}{
+		{
+			desc: "sha256:1110d13720997cdb8a454b0b27ac6454ecf35d8896bed0de38b31fb66954fd90",
+			want: "1110d1372099",
+		},
+		{desc: "1110d1372099", want: "1110d1372099"},
+		{desc: "sha256:cafe", want: "sha256:cafe"},
+		{desc: "downloading a layer of the base image", want: "downloading a layer of the base image"},
+		{desc: "pulling: some long description", want: "pulling: some long description"},
+	} {
+		if got := barLabel(tc.desc); got != tc.want {
+			t.Errorf("barLabel(%q) = %q, want %q", tc.desc, got, tc.want)
+		}
+	}
+}
+
+// setModeForTest switches to the given mode for the duration of the test and
+// returns a buffer capturing everything reported to the user.
+func setModeForTest(t *testing.T, m Mode) *bytes.Buffer {
+	t.Helper()
+	restoreMode(t)
+	restoreLogs(t)
+	SetMode(m)
+	var buf bytes.Buffer
+	logs.Progress.SetOutput(&buf)
+	return &buf
+}
+
+// restoreMode restores the process-wide reporting mode after the test.
+func restoreMode(t *testing.T) {
+	t.Helper()
+	modeMu.Lock()
+	previous := mode
+	modeMu.Unlock()
+	t.Cleanup(func() {
+		modeMu.Lock()
+		defer modeMu.Unlock()
+		mode = previous
+	})
+}
+
+// restoreLogs restores the go-containerregistry loggers after the test.
+func restoreLogs(t *testing.T) {
+	t.Helper()
+	progressOut := logs.Progress.Writer()
+	warnOut := logs.Warn.Writer()
+	t.Cleanup(func() {
+		logs.Progress.SetOutput(progressOut)
+		logs.Warn.SetOutput(warnOut)
+	})
+}
+
+// clearProgressEnv unsets every environment variable that influences
+// auto-detection, so a test only sees the ones it sets itself.
+func clearProgressEnv(t *testing.T) {
+	t.Helper()
+	for _, envVar := range append([]string{progressEnvVar, noProgressEnvVar}, noBarEnvVars...) {
+		value, ok := os.LookupEnv(envVar)
+		if !ok {
+			continue
+		}
+		// t.Setenv registers the restore; unsetting afterwards keeps it.
+		t.Setenv(envVar, value)
+		os.Unsetenv(envVar)
+	}
+}
+
+func logLines(out *bytes.Buffer) []string {
+	trimmed := strings.TrimSuffix(out.String(), "\n")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
+}

--- a/img_tool/pkg/push/BUILD.bazel
+++ b/img_tool/pkg/push/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "push",
@@ -15,5 +15,23 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_google_go_containerregistry//pkg/v1/remote",
         "@org_golang_x_sync//errgroup",
+    ],
+)
+
+go_test(
+    name = "push_test",
+    size = "small",
+    srcs = ["push_test.go"],
+    embed = [":push"],
+    deps = [
+        "//pkg/api",
+        "//pkg/progress",
+        "@com_github_google_go_containerregistry//pkg/logs",
+        "@com_github_google_go_containerregistry//pkg/registry",
+        "@com_github_google_go_containerregistry//pkg/v1:pkg",
+        "@com_github_google_go_containerregistry//pkg/v1/mutate",
+        "@com_github_google_go_containerregistry//pkg/v1/random",
+        "@com_github_google_go_containerregistry//pkg/v1/remote",
+        "@com_github_google_go_containerregistry//pkg/v1/types",
     ],
 )

--- a/img_tool/pkg/push/push_test.go
+++ b/img_tool/pkg/push/push_test.go
@@ -1,0 +1,343 @@
+package push
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/google/go-containerregistry/pkg/registry"
+	registryv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/progress"
+)
+
+// TestPushAllReportsCraneStyleProgress pushes real images into an in-memory
+// registry and asserts that the crane-style progress mode reports every blob:
+// the ones it uploads, and the ones the registry already has.
+func TestPushAllReportsCraneStyleProgress(t *testing.T) {
+	host, transport := newTestRegistry(t)
+	out := captureProgress(t, progress.ModeLog)
+
+	image, err := random.Image(256, 2)
+	if err != nil {
+		t.Fatalf("creating test image: %v", err)
+	}
+	digest, err := image.Digest()
+	if err != nil {
+		t.Fatalf("digesting test image: %v", err)
+	}
+	vfs := imageVFS{}
+	vfs.add(t, image)
+	uploader := NewBuilder(vfs).
+		WithJobs(1).
+		WithRemoteOptions(transport).
+		Build()
+
+	tags, err := uploader.PushAll(context.Background(), pushOps(host, "test/image", digest, "latest"), "eager")
+	if err != nil {
+		t.Fatalf("PushAll() returned error: %v", err)
+	}
+	wantTags := []string{
+		host + "/test/image@" + digest.String(),
+		host + "/test/image:latest",
+	}
+	if strings.Join(tags, ",") != strings.Join(wantTags, ",") {
+		t.Errorf("PushAll() = %q, want %q", tags, wantTags)
+	}
+
+	// Same shape as crane: one timestamped line per event, nothing else.
+	got := out.String()
+	craneLine := regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} \S`)
+	for _, line := range strings.Split(strings.TrimSuffix(got, "\n"), "\n") {
+		if !craneLine.MatchString(line) {
+			t.Errorf("progress line %q is not in crane's format", line)
+		}
+	}
+	// Every layer and the config are reported as uploaded, and every reference
+	// gets crane's "<ref>: digest: <digest> size: <size>" line.
+	for _, blob := range blobDigests(t, image) {
+		if want := "pushed blob: " + blob; !strings.Contains(got, want) {
+			t.Errorf("missing %q in progress output:\n%s", want, got)
+		}
+	}
+	for _, tag := range wantTags {
+		if want := fmt.Sprintf("%s: digest: %s size:", tag, digest); !strings.Contains(got, want) {
+			t.Errorf("missing %q in progress output:\n%s", want, got)
+		}
+	}
+
+	// Pushing an image on top of the one already in the registry reports its
+	// shared layers as existing and uploads only what is new.
+	extraLayer, err := random.Layer(128, types.DockerLayer)
+	if err != nil {
+		t.Fatalf("creating test layer: %v", err)
+	}
+	extended, err := mutate.AppendLayers(image, extraLayer)
+	if err != nil {
+		t.Fatalf("appending layer to test image: %v", err)
+	}
+	extendedDigest, err := extended.Digest()
+	if err != nil {
+		t.Fatalf("digesting extended test image: %v", err)
+	}
+	vfs.add(t, extended)
+	extraDigest, err := extraLayer.Digest()
+	if err != nil {
+		t.Fatalf("digesting test layer: %v", err)
+	}
+
+	out.Reset()
+	if _, err := uploader.PushAll(context.Background(), pushOps(host, "test/image", extendedDigest), "eager"); err != nil {
+		t.Fatalf("second PushAll() returned error: %v", err)
+	}
+	got = out.String()
+	for _, layer := range mustLayerDigests(t, image) {
+		if want := "existing blob: " + layer; !strings.Contains(got, want) {
+			t.Errorf("missing %q in progress output:\n%s", want, got)
+		}
+	}
+	if want := "pushed blob: " + extraDigest.String(); !strings.Contains(got, want) {
+		t.Errorf("missing %q in progress output:\n%s", want, got)
+	}
+
+	// Re-pushing an image the registry already serves skips it entirely.
+	out.Reset()
+	if _, err := uploader.PushAll(context.Background(), pushOps(host, "test/image", extendedDigest), "eager"); err != nil {
+		t.Fatalf("third PushAll() returned error: %v", err)
+	}
+	got = out.String()
+	if want := "existing manifest: " + extendedDigest.String(); !strings.Contains(got, want) {
+		t.Errorf("missing %q in progress output:\n%s", want, got)
+	}
+	if strings.Contains(got, "pushed blob:") {
+		t.Errorf("re-uploaded a blob the registry already had:\n%s", got)
+	}
+}
+
+// TestPushAllStaysSilentWithoutProgress covers the mode that build actions and
+// `--progress=none` use: the same push reports nothing at all.
+func TestPushAllStaysSilentWithoutProgress(t *testing.T) {
+	host, transport := newTestRegistry(t)
+	out := captureProgress(t, progress.ModeNone)
+
+	image, err := random.Image(256, 1)
+	if err != nil {
+		t.Fatalf("creating test image: %v", err)
+	}
+	digest, err := image.Digest()
+	if err != nil {
+		t.Fatalf("digesting test image: %v", err)
+	}
+	vfs := imageVFS{}
+	vfs.add(t, image)
+
+	uploader := NewBuilder(vfs).
+		WithJobs(1).
+		WithRemoteOptions(transport).
+		Build()
+	if _, err := uploader.PushAll(context.Background(), pushOps(host, "test/image", digest), "eager"); err != nil {
+		t.Fatalf("PushAll() returned error: %v", err)
+	}
+	if got := out.String(); got != "" {
+		t.Errorf("reported progress with progress reporting off:\n%s", got)
+	}
+}
+
+// pushOps builds a single-manifest push operation for the given image digest.
+func pushOps(host, repository string, digest registryv1.Hash, tags ...string) []api.IndexedPushDeployOperation {
+	return []api.IndexedPushDeployOperation{{
+		PushDeployOperation: api.PushDeployOperation{
+			BaseCommandOperation: api.BaseCommandOperation{
+				Command:  "push",
+				RootKind: "manifest",
+				Root:     api.Descriptor{Digest: digest.String()},
+			},
+			PushTarget: api.PushTarget{
+				Registry:   host,
+				Repository: repository,
+				Tags:       tags,
+			},
+		},
+	}}
+}
+
+// imageVFS serves in-memory images to the uploader, keyed by manifest digest.
+type imageVFS map[registryv1.Hash]registryv1.Image
+
+func (v imageVFS) add(t *testing.T, image registryv1.Image) {
+	t.Helper()
+	digest, err := image.Digest()
+	if err != nil {
+		t.Fatalf("digesting test image: %v", err)
+	}
+	v[digest] = image
+}
+
+func (v imageVFS) Taggable(digest registryv1.Hash) (remote.Taggable, error) {
+	image, ok := v[digest]
+	if !ok {
+		return nil, fmt.Errorf("unexpected digest %s", digest)
+	}
+	return image, nil
+}
+
+func (v imageVFS) Digests() ([]registryv1.Hash, error) {
+	var hashes []registryv1.Hash
+	for _, image := range v {
+		imageHashes, err := blobHashes(image)
+		if err != nil {
+			return nil, err
+		}
+		hashes = append(hashes, imageHashes...)
+	}
+	return hashes, nil
+}
+
+func (v imageVFS) SizeOf(digest registryv1.Hash) (int64, error) {
+	for _, image := range v {
+		if layer, err := image.LayerByDigest(digest); err == nil {
+			return layer.Size()
+		}
+	}
+	return 0, fmt.Errorf("unknown blob %s", digest)
+}
+
+func blobHashes(image registryv1.Image) ([]registryv1.Hash, error) {
+	manifest, err := image.Manifest()
+	if err != nil {
+		return nil, err
+	}
+	hashes := []registryv1.Hash{manifest.Config.Digest}
+	for _, layer := range manifest.Layers {
+		hashes = append(hashes, layer.Digest)
+	}
+	return hashes, nil
+}
+
+// blobDigests returns the digests of the config and of every layer of the image.
+func blobDigests(t *testing.T, image registryv1.Image) []string {
+	t.Helper()
+	hashes, err := blobHashes(image)
+	if err != nil {
+		t.Fatalf("listing blobs of test image: %v", err)
+	}
+	digests := make([]string, 0, len(hashes))
+	for _, hash := range hashes {
+		digests = append(digests, hash.String())
+	}
+	return digests
+}
+
+// mustLayerDigests returns the digests of the image's layers.
+func mustLayerDigests(t *testing.T, image registryv1.Image) []string {
+	t.Helper()
+	manifest, err := image.Manifest()
+	if err != nil {
+		t.Fatalf("reading manifest of test image: %v", err)
+	}
+	digests := make([]string, 0, len(manifest.Layers))
+	for _, layer := range manifest.Layers {
+		digests = append(digests, layer.Digest.String())
+	}
+	return digests
+}
+
+// captureProgress applies the given progress mode for the duration of the test
+// with stderr redirected, so that everything the mode reports to the user can be
+// inspected. The mode is applied after the redirect because it captures
+// os.Stderr by value.
+func captureProgress(t *testing.T, mode progress.Mode) *stderrCapture {
+	t.Helper()
+	file, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatalf("creating stderr capture file: %v", err)
+	}
+	previousStderr := os.Stderr
+	previousMode := progress.CurrentMode()
+	progressOut := logs.Progress.Writer()
+	warnOut := logs.Warn.Writer()
+	t.Cleanup(func() {
+		os.Stderr = previousStderr
+		progress.SetMode(previousMode)
+		logs.Progress.SetOutput(progressOut)
+		logs.Warn.SetOutput(warnOut)
+		file.Close()
+	})
+
+	os.Stderr = file
+	progress.SetMode(mode)
+	return &stderrCapture{t: t, file: file}
+}
+
+// stderrCapture reads back what was written to the redirected stderr.
+type stderrCapture struct {
+	t    *testing.T
+	file *os.File
+}
+
+func (c *stderrCapture) String() string {
+	c.t.Helper()
+	data, err := os.ReadFile(c.file.Name())
+	if err != nil {
+		c.t.Fatalf("reading stderr capture: %v", err)
+	}
+	return string(data)
+}
+
+// Reset drops everything reported so far.
+func (c *stderrCapture) Reset() {
+	c.t.Helper()
+	if err := c.file.Truncate(0); err != nil {
+		c.t.Fatalf("truncating stderr capture: %v", err)
+	}
+	if _, err := c.file.Seek(0, io.SeekStart); err != nil {
+		c.t.Fatalf("rewinding stderr capture: %v", err)
+	}
+}
+
+// newTestRegistry returns an in-memory registry, the host to address it under,
+// and the remote option that routes all requests to it. The registry is served
+// directly from the transport instead of over a socket, because the sandboxes
+// these tests run in don't allow binding a loopback port.
+func newTestRegistry(t *testing.T) (string, remote.Option) {
+	t.Helper()
+	handler := registry.New(registry.Logger(log.New(io.Discard, "", 0)))
+	return "localhost:1234", remote.WithTransport(&handlerTransport{handler: handler})
+}
+
+// handlerTransport serves HTTP requests from an in-process handler.
+type handlerTransport struct {
+	handler http.Handler
+}
+
+func (t *handlerTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	// Handlers may assume the server-side invariants that net/http would
+	// establish when reading the request off a connection.
+	served := request.Clone(request.Context())
+	if served.Body == nil {
+		served.Body = http.NoBody
+	}
+	if served.Host == "" {
+		served.Host = served.URL.Host
+	}
+	served.RequestURI = served.URL.RequestURI()
+
+	recorder := httptest.NewRecorder()
+	t.handler.ServeHTTP(recorder, served)
+	response := recorder.Result()
+	response.Request = request
+	return response, nil
+}


### PR DESCRIPTION
`img deploy` only reported progress as interactive progress bars, so a
deploy that was not attached to a terminal (CI, a log file, a persistent
worker) reported nothing at all.

Add a progress mode to pkg/progress. ModeLog enables
go-containerregistry's own Progress/Warn loggers, which print one
timestamped line per blob and manifest, exactly like crane
("existing blob: sha256:...", "pushed blob: sha256:...",
"<ref>: digest: ... size: ..."), and reports the incremental containerd
load in the same style ("loaded blob: sha256:..."). Assembling a full
image tar for `docker load` keeps reporting nothing, where per-blob lines
would be meaningless.

`img deploy` picks bars on a terminal and log lines otherwise; the
persistent worker always uses log lines because its requests are
multiplexed onto one stderr. `--progress=bar|log|none|auto` and
$IMG_PROGRESS select a mode explicitly, $NO_PROGRESS turns reporting off,
and $NO_INTERACTIVE / $NO_COLOR fall back from bars to log lines.

Commands other than deploy keep their current behavior: bars on a
terminal, silence otherwise, so build action output is unchanged.