### PR TITLE
fix(cosign): strip build-from-source deps from released MODULE.bazel

### DIFF
--- a/.bcr/modules/rules_img_signer_cosign/presubmit.yml
+++ b/.bcr/modules/rules_img_signer_cosign/presubmit.yml
@@ -9,4 +9,4 @@ bcr_test_module:
       platform: ${{ platform }}
       bazel: ${{ bazel }}
       test_targets:
-        - "//..."
+        - "//:all"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -64,5 +64,6 @@ filegroup(
 
 exports_files([
     ".bcr/metadata.template.json",
+    "modules/rules_img_signer_cosign/MODULE.bazel",
     "prebuilt_lockfile.json",
 ])

--- a/img/private/release/BUILD.bazel
+++ b/img/private/release/BUILD.bazel
@@ -94,10 +94,9 @@ versioned_filename_info(
 # @rules_img_internal_tools//release:signer_*_prebuilt) into the packaged module
 # source, so a consumer (the e2e scratch workspace, or a real user of the
 # published module) downloads the prebuilt plugin instead of building it from
-# source. Building from this repo's root is what lets the release be fully
-# Bazel-native: the root MODULE.bazel carries the (root-only) gazelle proto
-# overrides the cosign plugin needs to compile, so the packaged plugin
-# MODULE.bazel stays clean and no MODULE.bazel rewriting is required.
+# source. source_bundle also injects a cleaned MODULE.bazel (with the
+# REMOVE_BEFORE_RELEASE sections stripped) so the released module no longer
+# carries the build-from-source gazelle setup that is broken outside this repo.
 # They are versioned independently of rules_img, so pin their BCR versions to
 # match module(version = ...) in each MODULE.bazel.
 version(
@@ -115,6 +114,7 @@ version(
 source_bundle(
     name = "signer_cosign_srcs",
     srcs = ["//:signer_cosign_source_files"],
+    module_bazel = "//img/private/release/module_bazel_release_prep:cleaned_cosign_module",
     overrides = ["@rules_img_internal_tools//release:signer_cosign_prebuilt"],
     strip_prefix = "modules/rules_img_signer_cosign/",
     tags = ["manual"],

--- a/img/private/release/defs.bzl
+++ b/img/private/release/defs.bzl
@@ -306,6 +306,13 @@ def _source_bundle_impl(ctx):
         attributes.update(override.attributes)
         dest_src_map.update(override.dest_src_map)
 
+    # Override MODULE.bazel if provided (e.g. a release-cleaned version). Keyed
+    # with the strip_prefix so the stripping step below lands it at MODULE.bazel.
+    if ctx.file.module_bazel:
+        module_key = (ctx.attr.strip_prefix or "") + "MODULE.bazel"
+        dest_src_map[module_key] = ctx.file.module_bazel
+        attributes[module_key] = DEFAULT_ATTRIBUTES
+
     # Strip a leading path prefix from every destination (both source files and
     # override entries) so a module living in a subdirectory (e.g. a signer
     # plugin under modules/rules_img_signer_*) is packaged relative to its own
@@ -334,6 +341,10 @@ source_bundle = rule(
         "overrides": attr.label_list(providers = [OverrideSourceFilesInfo]),
         "strip_prefix": attr.string(
             doc = "Leading path prefix stripped from every packaged destination.",
+        ),
+        "module_bazel": attr.label(
+            allow_single_file = True,
+            doc = "Optional MODULE.bazel to substitute in the bundle (e.g. a release-cleaned version).",
         ),
     },
 )

--- a/img/private/release/module_bazel_release_prep/BUILD.bazel
+++ b/img/private/release/module_bazel_release_prep/BUILD.bazel
@@ -11,6 +11,12 @@ clean_module_bazel(
     visibility = ["//visibility:public"],
 )
 
+clean_module_bazel(
+    name = "cleaned_cosign_module",
+    src = "//:modules/rules_img_signer_cosign/MODULE.bazel",
+    visibility = ["//img/private/release:__subpackages__"],
+)
+
 bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],

--- a/modules/rules_img_signer_cosign/MODULE.bazel
+++ b/modules/rules_img_signer_cosign/MODULE.bazel
@@ -5,6 +5,9 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "platforms", version = "1.0.0")
+
+### REMOVE_BEFORE_RELEASE_START
+
 bazel_dep(name = "rules_go", version = "0.61.1")
 bazel_dep(name = "gazelle", version = "0.51.3")
 
@@ -41,8 +44,8 @@ use_repo(
 #       directives = ["gazelle:go_generate_proto false"],
 #       path = "github.com/google/certificate-transparency-go",
 #   )
-#
-# Released versions ship a prebuilt binary and need none of this.
+
+### REMOVE_BEFORE_RELEASE_END
 
 # Resolve the plugin binary: prebuilt download for released versions, or the
 # source-built go_binary for any other commit / local / git_override build.


### PR DESCRIPTION
fix(cosign): strip build-from-source deps from released MODULE.bazel

The cosign signer plugin has issues building from source due to broken
gazelle proto generation for sigstore transitive deps. Strip the
gazelle/rules_go setup (and the source-build NOTE comment) from the
released MODULE.bazel using the same REMOVE_BEFORE_RELEASE_START/END
marker mechanism as the root module. Add a cleaned_cosign_module target
in module_bazel_release_prep and a new module_bazel attr on source_bundle
to inject it into the packaged archive.

Also fix the BCR presubmit test target from //... to //:all.