### PR TITLE
feat(registry): add --insecure for plain-HTTP registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,16 @@ common --@rules_img//img/settings:registry_gateway=unix:/run/img-gateway.sock
 common --@rules_img//img/settings:registry_push_gateway=https://push-gateway.example.com
 common --@rules_img//img/settings:registry_pull_gateway=https://pull-gateway.example.com
 
+# Talk to registries insecurely: over plain HTTP instead of HTTPS, accepting
+# untrusted TLS certificates. The equivalent of crane's --insecure, meant for local
+# development registries (k3d, kind, `docker run registry:2`) that don't serve
+# HTTPS. Applies to `bazel run` pushes/loads and to the registry-touching build
+# actions. Hosts go-containerregistry already treats as local (localhost:PORT,
+# *.localhost, 127.0.0.1, ::1, RFC1918 addresses) don't need it. Disables transport
+# security for every registry the build talks to -- see
+# docs/insecure-registries.md.
+common --@rules_img//img/settings:insecure=enabled
+
 # [Experimental] Store layers compactly instead of as full tarballs.
 # When enabled, layer rules no longer produce the layer tar as a file output, so
 # layer blobs are never written to (or fetched from) the Bazel remote cache.
@@ -574,6 +584,7 @@ This results in a more complex implementation, but also allows for interesting o
 - [Image Signing Guide](docs/image-signing.md) - Sign pushed images with pluggable signer plugins (Notation, cosign, or your own)
 - [Push Strategies](docs/push-strategies.md) - Push strategies and [push at build time](docs/push-strategies.md#push-at-build-time)
 - [Authenticating Build Actions](docs/authenticating-build-actions.md) - Registry credentials for build-time pull/push, and the OCI distribution gateway
+- [Insecure (Plain-HTTP) Registries](docs/insecure-registries.md) - Push to a local development registry that speaks HTTP or has an untrusted certificate
 - [Compact Stream Representation](docs/compact-stream.md) - On-disk format behind the experimental cache-efficient layers (`experimental_compact_layers`)
 - [Migration Guide from rules_oci](docs/migration-from-rules_oci.md)
 

--- a/docs/insecure-registries.md
+++ b/docs/insecure-registries.md
@@ -1,0 +1,91 @@
+# Insecure (Plain-HTTP) Registries
+
+Local development registries — `k3d`'s built-in registry, `kind`'s registry
+container, a bare `docker run registry:2`, MicroK8s' `localhost:32000` — usually
+speak **plain HTTP** and have no valid TLS certificate. rules_img addresses
+registries over HTTPS by default, so pushing to one of those fails with:
+
+```
+Get "https://k3d-myregistry.localhost:12345/v2/": http: server gave HTTP response to HTTPS client
+```
+
+Prefixing the registry with `http://` does not help: `registry` is a registry
+*host*, not a URL, so `http://…` is rejected as an invalid repository name.
+Instead, tell rules_img that the registry is insecure.
+
+## Enabling insecure access
+
+Set the global flag (the equivalent of [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane.md)'s
+`--insecure`):
+
+```bash
+bazel run //path/to:push --@rules_img//img/settings:insecure=enabled
+```
+
+or, more commonly, in `.bazelrc` for the configuration that deploys locally:
+
+```
+build:dev --@rules_img//img/settings:insecure=enabled
+```
+
+This does two things for every registry operation:
+
+1. Registries are addressed over `http://` instead of `https://`.
+2. TLS certificates are not verified, so a registry that *does* serve HTTPS with
+   a self-signed or expired certificate is accepted too.
+
+> **This disables transport security.** Credentials and image data travel in
+> plaintext (or to an unverified peer) and are open to interception and
+> tampering. Use it for local development registries only, never for a shared or
+> production registry. The flag is global — it applies to every registry the
+> build talks to, not just the local one.
+
+The setting covers:
+
+- `bazel run` on `image_push`, `image_load`, and `multi_deploy` targets.
+- The registry-touching build actions: [push at build time](push-strategies.md#push-at-build-time)
+  (`PushImage`) and lazily pulled base-image layers (`DownloadBlob`).
+
+## Registries that are insecure without the flag
+
+The flag is not needed for hosts that are unambiguously local, which are always
+reached over HTTP:
+
+- `localhost:PORT`
+- any `*.localhost` host (with or without a port)
+- the loopback addresses `127.0.0.1` and `::1`
+- RFC 1918 addresses (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`)
+
+A k3d registry reached as `k3d-myregistry.localhost:12345` therefore works out of
+the box; the same registry reached under a hostname that is not one of the above
+(for example an entry you added to `/etc/hosts`, or `host.docker.internal`) needs
+the flag.
+
+## The `img` tool
+
+The same switch exists on the `img` tool that the rules invoke, either as a
+global flag accepted by any subcommand or as an environment variable:
+
+```bash
+img --insecure deploy --request-file request.json
+IMG_INSECURE=1 img deploy --request-file request.json
+```
+
+Because `image_push` targets forward their arguments, `--insecure` also works
+ad hoc without setting the Bazel flag:
+
+```bash
+bazel run //path/to:push -- --insecure
+```
+
+`IMG_INSECURE` is inherited by `bazel run` deploys, so exporting it in your shell
+works as well. Any value other than `0`/`false` enables insecure access.
+
+Base images pulled by the [`pull`](pull.md#pull) repository rule are fetched while
+Bazel loads the workspace, before build settings exist, so the Bazel flag does not
+apply there. Pass the environment variable into repository fetching instead (with
+the default `downloader = "img_tool"`):
+
+```
+common --repo_env=IMG_INSECURE=1
+```

--- a/img/private/download_blobs.bzl
+++ b/img/private/download_blobs.bzl
@@ -43,6 +43,11 @@ def _download_blob(ctx, output):
     if pull_gateway:
         env["IMG_REGISTRY_PULL_GATEWAY"] = pull_gateway
 
+    # Address the registry over plain HTTP (and accept untrusted certificates)
+    # when asked to, like the img tool's global --insecure flag.
+    if ctx.attr._insecure[BuildSettingInfo].value == "enabled":
+        env["IMG_INSECURE"] = "1"
+
     ctx.actions.run(
         outputs = [output],
         executable = img_toolchain_info.tool_exe,
@@ -112,6 +117,10 @@ If omitted, this falls back to `//img/settings:docker_config_path`.""",
         ),
         "_registry_pull_gateway": attr.label(
             default = Label("//img/settings:registry_pull_gateway"),
+            providers = [BuildSettingInfo],
+        ),
+        "_insecure": attr.label(
+            default = Label("//img/settings:insecure"),
             providers = [BuildSettingInfo],
         ),
     },

--- a/img/private/load.bzl
+++ b/img/private/load.bzl
@@ -187,9 +187,16 @@ def _image_load_impl(ctx):
         "IMG_CREDENTIAL_HELPER_OCI_REGISTRY",
         "IMG_CREDENTIAL_HELPER_REMOTE_CACHE",
         "IMG_AUTH_DEBUG",
+        "IMG_INSECURE",
         "DOCKER_CONFIG",
         "LOADER_BINARY",
     ]
+
+    # Insecure registry access (plain HTTP, untrusted certificates) for the base
+    # image reads a lazy load performs. Only set when the global flag asks for it,
+    # so IMG_INSECURE from the environment keeps working when it doesn't.
+    if ctx.attr._load_settings[LoadSettingsInfo].insecure:
+        environment["IMG_INSECURE"] = "1"
 
     # Add REGISTRY_AUTH_FILE if docker_config_path is set
     docker_config_path = ctx.attr._docker_config_path[BuildSettingInfo].value

--- a/img/private/multi_deploy.bzl
+++ b/img/private/multi_deploy.bzl
@@ -214,6 +214,13 @@ def _multi_deploy_impl(ctx):
         environment["IMG_CREDENTIAL_HELPER_REMOTE_CACHE"] = push_settings.credential_helper_remote_cache or load_settings.credential_helper_remote_cache
         inherited_environment.append("IMG_CREDENTIAL_HELPER_REMOTE_CACHE")
 
+    # Insecure registry access (plain HTTP, untrusted certificates). Always
+    # inherited, so IMG_INSECURE from the environment works when the flag is off;
+    # only set when the flag asks for it.
+    inherited_environment.append("IMG_INSECURE")
+    if push_settings.insecure or load_settings.insecure:
+        environment["IMG_INSECURE"] = "1"
+
     # Add REGISTRY_AUTH_FILE if docker_config_path is set
     docker_config_path = ctx.attr._docker_config_path[BuildSettingInfo].value
     if docker_config_path:

--- a/img/private/providers/load_settings_info.bzl
+++ b/img/private/providers/load_settings_info.bzl
@@ -12,6 +12,7 @@ FIELDS = dict(
     credential_helper = "Credential helper to use for registry requests and load-strategy gRPC connections. See docs/credential-helpers.md for details. Uses $IMG_CREDENTIAL_HELPER env var or tools/credential-helper if not set.",
     credential_helper_oci_registry = "Credential helper used only for OCI registry operations. Takes precedence over credential_helper for registry auth. Uses $IMG_CREDENTIAL_HELPER_OCI_REGISTRY env var if not set. See docs/credential-helpers.md.",
     credential_helper_remote_cache = "Credential helper used only to authenticate gRPC calls to the remote cache / remote execution API. Takes precedence over credential_helper for those calls. Uses $IMG_CREDENTIAL_HELPER_REMOTE_CACHE env var if not set. See docs/credential-helpers.md.",
+    insecure = "Bool: when True, registries are addressed over plain HTTP and untrusted TLS certificates are accepted (like crane's --insecure). Maps to the IMG_INSECURE env var of the img tool.",
 )
 
 LoadSettingsInfo = provider(

--- a/img/private/providers/push_config_info.bzl
+++ b/img/private/providers/push_config_info.bzl
@@ -30,6 +30,7 @@ FIELDS = dict(
     push_at_build_time_gateway = "Shared OCI distribution gateway endpoint for the build-time push actions, or ''.",
     push_at_build_time_push_gateway = "Push OCI distribution gateway endpoint for the build-time push actions, or ''.",
     push_at_build_time_pull_gateway = "Pull OCI distribution gateway endpoint for the build-time push actions, or ''.",
+    insecure = "Bool: when True, the build-time push actions address registries over plain HTTP and accept untrusted TLS certificates (IMG_INSECURE).",
 )
 
 PushConfigInfo = provider(

--- a/img/private/providers/push_settings_info.bzl
+++ b/img/private/providers/push_settings_info.bzl
@@ -14,6 +14,7 @@ FIELDS = dict(
     cross_mount = "Cross-mount configuration. Either 'same_registry', 'cross_registry' or 'disabled'.",
     blob_repository = "When non-empty, the staging repository that image blobs are pushed to and cross-mounted from when pushing manifests. At build time every blob (layers and config) is staged here; layers are cross-mounted into the image's real repository. Empty means blobs go to the image's own repository.",
     forbid_layer_push = "Bool: when True, `img deploy` refuses to upload layer blob bytes (layers must be cross-mounted or already present).",
+    insecure = "Bool: when True, registries are addressed over plain HTTP and untrusted TLS certificates are accepted (like crane's --insecure). Maps to the IMG_INSECURE env var of the img tool.",
 )
 
 PushSettingsInfo = provider(

--- a/img/private/push.bzl
+++ b/img/private/push.bzl
@@ -176,8 +176,15 @@ def _image_push_impl(ctx):
         "IMG_CREDENTIAL_HELPER_OCI_REGISTRY",
         "IMG_CREDENTIAL_HELPER_REMOTE_CACHE",
         "IMG_AUTH_DEBUG",
+        "IMG_INSECURE",
         "DOCKER_CONFIG",
     ]
+
+    # Insecure registry access (plain HTTP, untrusted certificates). Only set when
+    # the global flag asks for it, so that IMG_INSECURE from the environment (and
+    # `bazel run ... -- --insecure`) keeps working when it doesn't.
+    if ctx.attr._push_settings[PushSettingsInfo].insecure:
+        environment["IMG_INSECURE"] = "1"
 
     # Add REGISTRY_AUTH_FILE if docker_config_path is set
     docker_config_path = ctx.attr._docker_config_path[BuildSettingInfo].value
@@ -212,6 +219,7 @@ def _image_push_impl(ctx):
             gateway = pbt.gateway,
             push_gateway = pbt.push_gateway,
             pull_gateway = pbt.pull_gateway,
+            insecure = ctx.attr._push_settings[PushSettingsInfo].insecure,
             pull_info = ctx.attr.image[PullInfo] if PullInfo in ctx.attr.image else None,
             exec_requirements = pbt.exec_properties,
         )

--- a/img/private/push_metadata.bzl
+++ b/img/private/push_metadata.bzl
@@ -445,11 +445,13 @@ def compute_load_metadata(
     )
     return metadata_out, layer_hints_file
 
-def _gateway_env(gateway, push_gateway, pull_gateway):
-    """Build the IMG_REGISTRY_*_GATEWAY env dict, omitting empty entries.
+def _registry_env(gateway, push_gateway, pull_gateway, insecure):
+    """Build the registry-related action env dict, omitting empty entries.
 
     IMG_REGISTRY_GATEWAY is the shared fallback for both push and pull; the
     mode-specific vars take precedence (resolved by the img tool at runtime).
+    IMG_INSECURE lets the actions talk to a plain-HTTP registry (or one with an
+    untrusted certificate), like the img tool's global --insecure flag.
     """
     env = {}
     if gateway:
@@ -458,6 +460,8 @@ def _gateway_env(gateway, push_gateway, pull_gateway):
         env["IMG_REGISTRY_PUSH_GATEWAY"] = push_gateway
     if pull_gateway:
         env["IMG_REGISTRY_PULL_GATEWAY"] = pull_gateway
+    if insecure:
+        env["IMG_INSECURE"] = "1"
     return env
 
 def build_time_push_actions(
@@ -475,6 +479,7 @@ def build_time_push_actions(
         gateway,
         push_gateway,
         pull_gateway,
+        insecure,
         pull_info,
         exec_requirements):
     """Create the PushImage validation actions for one push operation.
@@ -517,6 +522,8 @@ def build_time_push_actions(
       gateway: default registry gateway for both push and pull, or None.
       push_gateway: push-specific registry gateway override, or None.
       pull_gateway: pull-specific registry gateway override, or None.
+      insecure: when True, the actions address registries over plain HTTP and
+        accept untrusted TLS certificates (IMG_INSECURE).
       pull_info: PullInfo used when computing the manifest push metadata.
       exec_requirements: dict forwarded as the execution_requirements of every
         emitted PushImage action (e.g. {"requires-network": "1"}).
@@ -529,10 +536,11 @@ def build_time_push_actions(
     img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
     tool = img_toolchain_info.tool_exe
 
-    # Route registry requests through the configured gateway(s), if any. These
-    # actions both push (upload) and pull (shallow base layers), so all three
-    # env vars are set; the img tool resolves push/pull precedence at runtime.
-    gateway_env = _gateway_env(gateway, push_gateway, pull_gateway)
+    # Route registry requests through the configured gateway(s), if any, and pass
+    # on insecure-registry access. These actions both push (upload) and pull
+    # (shallow base layers), so all three gateway env vars are set; the img tool
+    # resolves push/pull precedence at runtime.
+    registry_env = _registry_env(gateway, push_gateway, pull_gateway, insecure)
     prefix = "{}.push_at_build_time.{}".format(ctx.label.name, push_idx)
 
     if manifest_info != None:
@@ -586,8 +594,8 @@ def build_time_push_actions(
                 execution_requirements = exec_requirements,
                 progress_message = "Pushing layer blob %s (manifest %d, layer %d)" % (ctx.label, mi, li),
             )
-            if gateway_env:
-                blob_run_kwargs["env"] = gateway_env
+            if registry_env:
+                blob_run_kwargs["env"] = registry_env
             ctx.actions.run(**blob_run_kwargs)
             layer_results.append(result)
 
@@ -617,8 +625,8 @@ def build_time_push_actions(
                 execution_requirements = exec_requirements,
                 progress_message = "Pushing ztoc blob %s (soci manifest %d, layer %d)" % (ctx.label, mi, li),
             )
-            if gateway_env:
-                ztoc_run_kwargs["env"] = gateway_env
+            if registry_env:
+                ztoc_run_kwargs["env"] = registry_env
             ctx.actions.run(**ztoc_run_kwargs)
             layer_results.append(result)
 
@@ -650,8 +658,8 @@ def build_time_push_actions(
             execution_requirements = exec_requirements,
             progress_message = "Pushing config blob %s (manifest %d)" % (ctx.label, mi),
         )
-        if gateway_env:
-            config_run_kwargs["env"] = gateway_env
+        if registry_env:
+            config_run_kwargs["env"] = registry_env
         ctx.actions.run(**config_run_kwargs)
         config_results.append(config_result)
 
@@ -702,8 +710,8 @@ def build_time_push_actions(
         execution_requirements = exec_requirements,
         progress_message = "Pushing config and manifest(s) %s" % ctx.label,
     )
-    if gateway_env:
-        manifest_run_kwargs["env"] = gateway_env
+    if registry_env:
+        manifest_run_kwargs["env"] = registry_env
     ctx.actions.run(**manifest_run_kwargs)
     return [marker] + config_results
 
@@ -846,6 +854,7 @@ def process_deploy_specs(
                 gateway = push_config.push_at_build_time_gateway,
                 push_gateway = push_config.push_at_build_time_push_gateway,
                 pull_gateway = push_config.push_at_build_time_pull_gateway,
+                insecure = push_config.insecure,
                 pull_info = pull_info,
                 exec_requirements = push_config.push_at_build_time_exec_properties,
             ))

--- a/img/private/push_spec.bzl
+++ b/img/private/push_spec.bzl
@@ -43,6 +43,7 @@ def _image_push_spec_impl(ctx):
         push_at_build_time_gateway = pbt.gateway,
         push_at_build_time_push_gateway = pbt.push_gateway,
         push_at_build_time_pull_gateway = pbt.pull_gateway,
+        insecure = ctx.attr._push_settings[PushSettingsInfo].insecure,
     )]
 
 image_push_spec = rule(

--- a/img/private/settings/load.bzl
+++ b/img/private/settings/load.bzl
@@ -12,6 +12,7 @@ def _load_settings_impl(ctx):
         credential_helper = ctx.attr._credential_helper[BuildSettingInfo].value,
         credential_helper_oci_registry = ctx.attr._credential_helper_oci_registry[BuildSettingInfo].value,
         credential_helper_remote_cache = ctx.attr._credential_helper_remote_cache[BuildSettingInfo].value,
+        insecure = ctx.attr._insecure[BuildSettingInfo].value == "enabled",
     )]
 
 load_settings = rule(
@@ -43,6 +44,10 @@ load_settings = rule(
         ),
         "_credential_helper_remote_cache": attr.label(
             default = Label("//img/settings:credential_helper_remote_cache"),
+            providers = [BuildSettingInfo],
+        ),
+        "_insecure": attr.label(
+            default = Label("//img/settings:insecure"),
             providers = [BuildSettingInfo],
         ),
     },

--- a/img/private/settings/settings.bzl
+++ b/img/private/settings/settings.bzl
@@ -13,6 +13,7 @@ def _push_settings_impl(ctx):
     cross_mount = ctx.attr._cross_mount[BuildSettingInfo].value
     blob_repository = ctx.attr._blob_repository[BuildSettingInfo].value
     forbid_layer_push = ctx.attr._forbid_layer_push[BuildSettingInfo].value == "enabled"
+    insecure = ctx.attr._insecure[BuildSettingInfo].value == "enabled"
 
     return [PushSettingsInfo(
         strategy = strategy,
@@ -24,6 +25,7 @@ def _push_settings_impl(ctx):
         cross_mount = cross_mount,
         blob_repository = blob_repository,
         forbid_layer_push = forbid_layer_push,
+        insecure = insecure,
     )]
 
 push_settings = rule(
@@ -63,6 +65,10 @@ push_settings = rule(
         ),
         "_forbid_layer_push": attr.label(
             default = Label("//img/settings:forbid_layer_push"),
+            providers = [BuildSettingInfo],
+        ),
+        "_insecure": attr.label(
+            default = Label("//img/settings:insecure"),
             providers = [BuildSettingInfo],
         ),
     },

--- a/img/settings/BUILD.bazel
+++ b/img/settings/BUILD.bazel
@@ -351,6 +351,27 @@ string_flag(
     visibility = ["//visibility:public"],
 )
 
+# Talk to registries insecurely: address them over plain HTTP instead of HTTPS and
+# accept untrusted (self-signed, expired, ...) TLS certificates. This is the
+# equivalent of crane's --insecure flag and is meant for local development
+# registries (k3d, `docker run registry:2`, kind, ...) that don't serve HTTPS.
+# It applies to `bazel run` pushes and loads as well as to the registry-touching
+# build actions (push at build time, lazy layer downloads). It maps to the
+# IMG_INSECURE environment variable / the img tool's global --insecure flag.
+#
+# Registries that go-containerregistry already treats as local (localhost:PORT,
+# *.localhost, 127.0.0.1, ::1, RFC1918 addresses) are reached over HTTP without
+# this flag.
+string_flag(
+    name = "insecure",
+    build_setting_default = "disabled",
+    values = [
+        "disabled",
+        "enabled",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 # When "enabled", `img deploy` (image_push / multi_deploy) is forbidden from
 # uploading layer blob bytes: layers may still be cross-mounted server-side or
 # skipped when already present, but an actual upload fails loudly. Use when layer

--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -494,7 +494,7 @@ func applyRegistryTagOperations(ctx context.Context, vfs *deployvfs.VFS, pusher 
 			return nil, fmt.Errorf("locating manifest %s for registry_tag on %s: %w", op.Root.Digest, baseRef, err)
 		}
 		for _, tag := range op.Tags {
-			ref, err := name.NewTag(baseRef + ":" + tag)
+			ref, err := name.NewTag(baseRef+":"+tag, registryopts.NameOptions()...)
 			if err != nil {
 				return nil, fmt.Errorf("creating registry_tag ref %q: %w", tag, err)
 			}
@@ -548,7 +548,7 @@ func preUploadStagingBlobs(ctx context.Context, vfs *deployvfs.VFS, ops []api.In
 		if overrideRegistry != "" {
 			reg = overrideRegistry
 		}
-		repo, err := name.NewRepository(reg + "/" + blobRepository)
+		repo, err := name.NewRepository(reg+"/"+blobRepository, registryopts.NameOptions()...)
 		if err != nil {
 			return fmt.Errorf("parsing staging repository %s/%s: %w", reg, blobRepository, err)
 		}

--- a/img_tool/cmd/deploy/persistentworker.go
+++ b/img_tool/cmd/deploy/persistentworker.go
@@ -349,7 +349,7 @@ func (h *deployWorkerHandler) registryTagOps(ctx context.Context, vfs *deployvfs
 			return nil, fmt.Errorf("locating manifest %s for registry_tag: %w", op.Root.Digest, err)
 		}
 		for _, tag := range op.Tags {
-			ref, err := name.NewTag(baseRef + ":" + tag)
+			ref, err := name.NewTag(baseRef+":"+tag, registryopts.NameOptions()...)
 			if err != nil {
 				return nil, fmt.Errorf("creating registry_tag ref %q: %w", tag, err)
 			}
@@ -478,6 +478,14 @@ func parseWorkerArgs(args []string) (*workerOpts, error) {
 				return nil, fmt.Errorf("--sink %q may only be set on the img deploy command line, not in a work request", value)
 			}
 			opts.sink = value
+		case key == "--insecure":
+			// The worker builds its transports and pusher once, at startup, so
+			// insecure mode cannot be turned on per work request. Reject it
+			// instead of silently pushing to https:// after the user asked for
+			// plain HTTP.
+			if !registryopts.Insecure() {
+				return nil, fmt.Errorf("--insecure must be passed when starting the img deploy worker (or set %s=1); it cannot be enabled per work request", registryopts.EnvInsecure)
+			}
 		}
 	}
 

--- a/img_tool/cmd/deploy/sign.go
+++ b/img_tool/cmd/deploy/sign.go
@@ -88,7 +88,7 @@ func applySignOperations(ctx context.Context, pushOps []api.IndexedPushDeployOpe
 	}
 	emit := func(ctx context.Context, op api.IndexedPushDeployOperation, subject api.Descriptor, imgs []registryv1.Image) error {
 		reg, repo := opRegistry(op, opts), opRepository(op, opts)
-		repository, err := name.NewRepository(reg + "/" + repo)
+		repository, err := name.NewRepository(reg+"/"+repo, registryopts.NameOptions()...)
 		if err != nil {
 			return fmt.Errorf("parsing repository %q: %w", reg+"/"+repo, err)
 		}

--- a/img_tool/cmd/downloadblob/downloadblob.go
+++ b/img_tool/cmd/downloadblob/downloadblob.go
@@ -121,7 +121,7 @@ func DownloadBlobProcess(ctx context.Context, args []string) {
 }
 
 func downloadFromRegistry(registry, repository, digest, outputPath string) (retErr error) {
-	ref, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", registry, repository, digest))
+	ref, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", registry, repository, digest), registryopts.NameOptions()...)
 	if err != nil {
 		return fmt.Errorf("creating blob reference: %w", err)
 	}

--- a/img_tool/cmd/downloadmanifest/downloadmanifest.go
+++ b/img_tool/cmd/downloadmanifest/downloadmanifest.go
@@ -136,7 +136,7 @@ type Source struct {
 }
 
 func downloadManifestByDigest(registry, repository, digest, outputPath string, printDigest bool, resolvedDigest *string) error {
-	ref, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", registry, repository, digest))
+	ref, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", registry, repository, digest), registryopts.NameOptions()...)
 	if err != nil {
 		return fmt.Errorf("creating manifest reference: %w", err)
 	}
@@ -145,7 +145,7 @@ func downloadManifestByDigest(registry, repository, digest, outputPath string, p
 }
 
 func downloadManifestByTag(registry, repository, tag, outputPath string, printDigest bool, resolvedDigest *string) error {
-	ref, err := name.NewTag(fmt.Sprintf("%s/%s:%s", registry, repository, tag))
+	ref, err := name.NewTag(fmt.Sprintf("%s/%s:%s", registry, repository, tag), registryopts.NameOptions()...)
 	if err != nil {
 		return fmt.Errorf("creating tag reference: %w", err)
 	}

--- a/img_tool/cmd/img/BUILD.bazel
+++ b/img_tool/cmd/img/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "img_lib",
@@ -33,6 +33,7 @@ go_library(
         "//cmd/sparseocilayout",
         "//cmd/syncocirefgraph",
         "//cmd/validate",
+        "//pkg/registryopts",
         "@com_github_google_go_containerregistry//pkg/logs",
     ],
 )
@@ -75,4 +76,11 @@ platform_tuples = [
 build_test(
     name = "test",
     targets = [":img"],
+)
+
+go_test(
+    name = "img_test",
+    srcs = ["img_test.go"],
+    embed = [":img_lib"],
+    deps = ["//pkg/registryopts"],
 )

--- a/img_tool/cmd/img/img.go
+++ b/img_tool/cmd/img/img.go
@@ -33,12 +33,16 @@ import (
 	"github.com/bazel-contrib/rules_img/img_tool/cmd/sparseocilayout"
 	"github.com/bazel-contrib/rules_img/img_tool/cmd/syncocirefgraph"
 	"github.com/bazel-contrib/rules_img/img_tool/cmd/validate"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/registryopts"
 )
 
 const usage = `Usage: img [COMMAND] [ARGS...]
 
 Global flags (accepted by any command):
   --verbose                enables debug logging
+  --insecure               allows registries to be addressed over plain HTTP and
+                           accepts untrusted TLS certificates (like crane's
+                           --insecure). Also settable via IMG_INSECURE=1.
 
 Commands:
   compress                 (re-)compresses a layer
@@ -71,10 +75,10 @@ Commands:
   push                     pushes image blobs/manifests at build time (subcommands: blob, manifest)`
 
 func Run(ctx context.Context, args []string) {
-	// Handle the global --verbose flag for all subcommands. We strip it from
+	// Handle the global flags for all subcommands. We strip them from
 	// the arguments before dispatching so each subcommand's own flag parser
-	// doesn't have to know about it.
-	args = handleVerbose(args)
+	// doesn't have to know about them.
+	args = handleGlobalFlags(args)
 
 	if len(args) < 2 {
 		fmt.Fprintln(os.Stderr, usage)
@@ -150,22 +154,34 @@ func main() {
 	Run(ctx, os.Args)
 }
 
-// handleVerbose looks for a global --verbose (or -verbose) flag anywhere in
-// args. If present, it enables debug logging to stderr and returns args with
-// the flag removed so the individual subcommand flag parsers don't see it.
-func handleVerbose(args []string) []string {
+// handleGlobalFlags looks for the global flags (--verbose, --insecure) anywhere
+// in args, applies them, and returns args with those flags removed so the
+// individual subcommand flag parsers don't see them.
+//
+//   - --verbose enables debug logging to stderr.
+//   - --insecure lets every registry operation talk plain HTTP and accept
+//     untrusted TLS certificates, like crane's --insecure. It is only ever
+//     enabling: without the flag, IMG_INSECURE still decides.
+func handleGlobalFlags(args []string) []string {
 	filtered := make([]string, 0, len(args))
 	verbose := false
+	insecure := false
 	for _, arg := range args {
 		switch arg {
 		case "--verbose", "-verbose":
 			verbose = true
+			continue
+		case "--insecure", "-insecure":
+			insecure = true
 			continue
 		}
 		filtered = append(filtered, arg)
 	}
 	if verbose {
 		logs.Debug.SetOutput(os.Stderr)
+	}
+	if insecure {
+		registryopts.SetInsecure(true)
 	}
 	return filtered
 }

--- a/img_tool/cmd/img/img_test.go
+++ b/img_tool/cmd/img/img_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/registryopts"
+)
+
+// TestHandleGlobalFlags verifies that the global flags are consumed before a
+// subcommand's own flag parser sees them, and that --insecure switches the
+// process into insecure-registry mode.
+func TestHandleGlobalFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantArgs     []string
+		wantInsecure bool
+	}{
+		{
+			name:     "no global flags",
+			args:     []string{"img", "deploy", "--request-file", "req.json"},
+			wantArgs: []string{"img", "deploy", "--request-file", "req.json"},
+		},
+		{
+			name:         "insecure before the subcommand",
+			args:         []string{"img", "--insecure", "deploy", "--request-file", "req.json"},
+			wantArgs:     []string{"img", "deploy", "--request-file", "req.json"},
+			wantInsecure: true,
+		},
+		{
+			name:         "insecure after the subcommand args",
+			args:         []string{"img", "deploy", "--request-file", "req.json", "--insecure"},
+			wantArgs:     []string{"img", "deploy", "--request-file", "req.json"},
+			wantInsecure: true,
+		},
+		{
+			name:         "single-dash spelling, mixed with verbose",
+			args:         []string{"img", "-insecure", "push", "blob", "--verbose"},
+			wantArgs:     []string{"img", "push", "blob"},
+			wantInsecure: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			previous := registryopts.Insecure()
+			registryopts.SetInsecure(false)
+			t.Cleanup(func() { registryopts.SetInsecure(previous) })
+
+			got := handleGlobalFlags(tc.args)
+			if !slices.Equal(got, tc.wantArgs) {
+				t.Errorf("handleGlobalFlags(%v) = %v, want %v", tc.args, got, tc.wantArgs)
+			}
+			if registryopts.Insecure() != tc.wantInsecure {
+				t.Errorf("insecure mode = %v, want %v", registryopts.Insecure(), tc.wantInsecure)
+			}
+		})
+	}
+}
+
+// TestHandleGlobalFlagsKeepsEnvInsecure documents that the flag is only ever
+// enabling: its absence must not undo IMG_INSECURE.
+func TestHandleGlobalFlagsKeepsEnvInsecure(t *testing.T) {
+	previous := registryopts.Insecure()
+	registryopts.SetInsecure(true)
+	t.Cleanup(func() { registryopts.SetInsecure(previous) })
+
+	handleGlobalFlags([]string{"img", "deploy", "--request-file", "req.json"})
+	if !registryopts.Insecure() {
+		t.Error("insecure mode was disabled by args that don't mention --insecure")
+	}
+}

--- a/img_tool/cmd/pull/pull.go
+++ b/img_tool/cmd/pull/pull.go
@@ -82,7 +82,7 @@ func PullProcess(ctx context.Context, args []string) {
 	// Create a custom HTTP client with cached blob transport. When a registry
 	// gateway is configured (IMG_REGISTRY_PULL_GATEWAY / IMG_REGISTRY_GATEWAY),
 	// cache misses are routed through it.
-	gatewayBase, err := gateway.WrapTransport(http.DefaultTransport, gateway.ModePull)
+	gatewayBase, err := gateway.WrapTransport(registryopts.BaseTransport(), gateway.ModePull)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error configuring registry gateway: %v\n", err)
 		os.Exit(1)
@@ -369,13 +369,13 @@ func downloadManifest(registry, repository, tag, digest string, store *blobstore
 	var ref name.Reference
 	if len(digest) > 0 {
 		var err error
-		ref, err = name.NewDigest(fmt.Sprintf("%s/%s@%s", registry, repository, digest))
+		ref, err = name.NewDigest(fmt.Sprintf("%s/%s@%s", registry, repository, digest), registryopts.NameOptions()...)
 		if err != nil {
 			return nil, fmt.Errorf("creating manifest reference with digest: %w", err)
 		}
 	} else {
 		var err error
-		ref, err = name.NewTag(fmt.Sprintf("%s/%s:%s", registry, repository, tag))
+		ref, err = name.NewTag(fmt.Sprintf("%s/%s:%s", registry, repository, tag), registryopts.NameOptions()...)
 		if err != nil {
 			return nil, fmt.Errorf("creating manifest reference: %w", err)
 		}

--- a/img_tool/cmd/push/blob.go
+++ b/img_tool/cmd/push/blob.go
@@ -123,7 +123,7 @@ func pushBlob(ctx context.Context, registryStr, targetRepository string, desc ap
 		return fmt.Errorf("configuring pull transport: %w", err)
 	}
 
-	repoRef, err := name.NewRepository(registryStr + "/" + targetRepository)
+	repoRef, err := name.NewRepository(registryStr+"/"+targetRepository, registryopts.NameOptions()...)
 	if err != nil {
 		return fmt.Errorf("parsing target repository %s/%s: %w", registryStr, targetRepository, err)
 	}
@@ -176,7 +176,7 @@ func layerForBlob(ctx context.Context, desc api.Descriptor, blobPath, compactStr
 		// MountableLayer so that, if the target is in the same registry, the
 		// upload becomes a cross-repo mount instead of a byte transfer.
 		src := sources[0]
-		ref, err := name.NewDigest(src + "@" + desc.Digest)
+		ref, err := name.NewDigest(src+"@"+desc.Digest, registryopts.NameOptions()...)
 		if err != nil {
 			return nil, fmt.Errorf("parsing source reference %s@%s: %w", src, desc.Digest, err)
 		}

--- a/img_tool/cmd/syncocirefgraph/syncocirefgraph.go
+++ b/img_tool/cmd/syncocirefgraph/syncocirefgraph.go
@@ -320,12 +320,12 @@ func downloadManifestFromSources(digest string, sources map[string][]string) ([]
 
 // downloadManifest downloads a manifest from a specific registry/repository
 func downloadManifest(registry, repository, digest string) ([]byte, error) {
-	ref, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", registry, repository, digest))
+	ref, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", registry, repository, digest), registryopts.NameOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("creating manifest reference: %w", err)
 	}
 
-	descriptor, err := remote.Get(ref, registryopts.Default().WithTransport(registryopts.WrapRetryAfter(remote.DefaultTransport)).Remote()...)
+	descriptor, err := remote.Get(ref, registryopts.Default().WithTransport(registryopts.WrapRetryAfter(registryopts.BaseTransport())).Remote()...)
 	if err != nil {
 		return nil, fmt.Errorf("getting manifest: %w", err)
 	}

--- a/img_tool/pkg/deployvfs/BUILD.bazel
+++ b/img_tool/pkg/deployvfs/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/cas",
         "//pkg/compactstream",
         "//pkg/prefetch",
+        "//pkg/registryopts",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",
         "@com_github_google_go_containerregistry//pkg/v1/remote",

--- a/img_tool/pkg/deployvfs/deployvfs.go
+++ b/img_tool/pkg/deployvfs/deployvfs.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/cas"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/prefetch"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/registryopts"
 )
 
 // Stats tracks statistics about blob access in the VFS.
@@ -119,7 +120,7 @@ func (vfs *VFS) Layer(digest registryv1.Hash) (registryv1.Layer, error) {
 	}
 
 	if hint, found := vfs.crossMountHints[digest.String()]; found {
-		reg, err := registryname.NewRegistry(hint.Registry, registryname.WithDefaultRegistry(""))
+		reg, err := registryname.NewRegistry(hint.Registry, registryopts.NameOptions(registryname.WithDefaultRegistry(""))...)
 		if err != nil {
 			return nil, fmt.Errorf("parsing cross-mount registry %q: %w", hint.Registry, err)
 		}
@@ -851,7 +852,7 @@ func (b *Builder) layerFromRegistry(sources []api.LayerSource, desc api.Descript
 		Opener: func() (io.ReadCloser, error) {
 			var attempts []string
 			for _, source := range sources {
-				ref, err := registryname.NewDigest(fmt.Sprintf("%s/%s@%s", source.Registry, source.Repository, desc.Digest))
+				ref, err := registryname.NewDigest(fmt.Sprintf("%s/%s@%s", source.Registry, source.Repository, desc.Digest), registryopts.NameOptions()...)
 				if err != nil {
 					attempts = append(attempts, fmt.Sprintf("%s/%s: %v", source.Registry, source.Repository, err))
 					continue

--- a/img_tool/pkg/push/BUILD.bazel
+++ b/img_tool/pkg/push/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     deps = [
         "//pkg/api",
         "//pkg/progress",
+        "//pkg/registryopts",
         "@com_github_google_go_containerregistry//pkg/logs",
         "@com_github_google_go_containerregistry//pkg/registry",
         "@com_github_google_go_containerregistry//pkg/v1:pkg",

--- a/img_tool/pkg/push/push.go
+++ b/img_tool/pkg/push/push.go
@@ -201,7 +201,7 @@ func (u *uploader) tags(op api.IndexedPushDeployOperation) ([]name.Reference, er
 		return nil, err
 	}
 
-	digestRef, err := name.NewDigest(baseRef + "@" + h.String())
+	digestRef, err := name.NewDigest(baseRef+"@"+h.String(), registryopts.NameOptions()...)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func (u *uploader) tags(op api.IndexedPushDeployOperation) ([]name.Reference, er
 	allTags := append(op.Tags, u.extraTags...)
 	allTags = deduplicateAndSort(allTags)
 	for _, tag := range allTags {
-		tagRef, err := name.NewTag(baseRef + ":" + tag)
+		tagRef, err := name.NewTag(baseRef+":"+tag, registryopts.NameOptions()...)
 		if err != nil {
 			return nil, err
 		}

--- a/img_tool/pkg/push/push_test.go
+++ b/img_tool/pkg/push/push_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/progress"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/registryopts"
 )
 
 // TestPushAllReportsCraneStyleProgress pushes real images into an in-memory
@@ -153,6 +154,45 @@ func TestPushAllStaysSilentWithoutProgress(t *testing.T) {
 	}
 	if got := out.String(); got != "" {
 		t.Errorf("reported progress with progress reporting off:\n%s", got)
+	}
+}
+
+// TestTagsSchemeFollowsInsecureMode pins the behavior behind the global
+// --insecure flag for the `img deploy` push path: every reference we push to must
+// address its registry over http, otherwise go-containerregistry talks HTTPS to a
+// plain-HTTP registry ("server gave HTTP response to HTTPS client").
+func TestTagsSchemeFollowsInsecureMode(t *testing.T) {
+	digest := registryv1.Hash{Algorithm: "sha256", Hex: strings.Repeat("0", 64)}
+
+	tests := []struct {
+		name       string
+		insecure   bool
+		wantScheme string
+	}{
+		{name: "secure", insecure: false, wantScheme: "https"},
+		{name: "insecure", insecure: true, wantScheme: "http"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			previous := registryopts.Insecure()
+			registryopts.SetInsecure(tc.insecure)
+			t.Cleanup(func() { registryopts.SetInsecure(previous) })
+
+			ops := pushOps("registry.example.com", "my/app", digest, "latest")
+			refs, err := NewBuilder(nil).Build().tags(ops[0])
+			if err != nil {
+				t.Fatalf("tags: %v", err)
+			}
+			// One digest reference plus the operation's single tag.
+			if len(refs) != 2 {
+				t.Fatalf("got %d references, want 2 (digest + tag)", len(refs))
+			}
+			for _, ref := range refs {
+				if got := ref.Context().Registry.Scheme(); got != tc.wantScheme {
+					t.Errorf("scheme of %s = %q, want %q", ref, got, tc.wantScheme)
+				}
+			}
+		})
 	}
 }
 

--- a/img_tool/pkg/registryopts/BUILD.bazel
+++ b/img_tool/pkg/registryopts/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/auth/registry",
         "//pkg/gateway",
+        "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1/remote",
     ],
 )
@@ -19,6 +20,9 @@ go_test(
     embed = [":registryopts"],
     deps = [
         "//pkg/gateway",
+        "@com_github_google_go_containerregistry//pkg/name",
+        "@com_github_google_go_containerregistry//pkg/registry",
+        "@com_github_google_go_containerregistry//pkg/v1/random",
         "@com_github_google_go_containerregistry//pkg/v1/remote",
     ],
 )

--- a/img_tool/pkg/registryopts/registryopts.go
+++ b/img_tool/pkg/registryopts/registryopts.go
@@ -13,17 +13,27 @@
 //
 // Because go-cr applies options in order (last wins), any option added via
 // With/WithJobs/WithTransport overrides the corresponding default.
+//
+// It also holds the process-wide insecure-registry switch (the global --insecure
+// flag / IMG_INSECURE). Insecure mode has two halves, both of which a caller
+// must honor: the transport built here skips TLS verification, and references
+// must be parsed with [NameOptions] so the registry resolves to http:// instead
+// of https://.
 package registryopts
 
 import (
 	"bytes"
+	"crypto/tls"
 	"io"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/auth/registry"
@@ -46,6 +56,67 @@ const (
 	// server's Retry-After header.
 	EnvRetryMaxDelay = "IMG_REGISTRY_RETRY_MAX_DELAY"
 )
+
+// EnvInsecure enables insecure registry access for every registry operation,
+// exactly like the global --insecure flag: references address their registry over
+// plain HTTP and TLS certificates are not verified. Any non-empty value other
+// than "0"/"false" enables it, so both IMG_INSECURE=1 and IMG_INSECURE=true work
+// and an empty value (as set by a Bazel RunEnvironmentInfo default) leaves it
+// disabled.
+const EnvInsecure = "IMG_INSECURE"
+
+// insecure is the process-wide insecure-registry switch. It is initialized from
+// EnvInsecure and can be overridden by [SetInsecure] (the global --insecure
+// flag). It is read from every goroutine that builds a reference or a transport,
+// hence the atomic.
+var insecure atomic.Bool
+
+func init() {
+	insecure.Store(insecureFromEnv())
+}
+
+// SetInsecure enables or disables insecure registry access for the rest of the
+// process. It is called by the global --insecure flag before any subcommand runs
+// and overrides EnvInsecure.
+func SetInsecure(enabled bool) {
+	insecure.Store(enabled)
+}
+
+// Insecure reports whether registries are addressed insecurely: over plain HTTP
+// and without verifying TLS certificates.
+func Insecure() bool {
+	return insecure.Load()
+}
+
+// insecureFromEnv reports whether EnvInsecure asks for insecure registry access.
+func insecureFromEnv() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvInsecure))) {
+	case "", "0", "false":
+		return false
+	default:
+		return true
+	}
+}
+
+// NameOptions returns the go-cr name-parsing options that every registry
+// reference must be parsed with, appended to the given ones: in insecure mode
+// name.Insecure, which makes the reference's registry resolve to http:// instead
+// of https://. Without it, go-cr would still speak HTTPS to a plain-HTTP
+// registry (unless the host happens to look local to go-cr, e.g. "localhost:5000"),
+// which fails with "server gave HTTP response to HTTPS client".
+//
+// Pass it at every site that turns a registry/repository string into a
+// name.Reference:
+//
+//	ref, err := name.NewTag(reg+"/"+repo+":"+tag, registryopts.NameOptions()...)
+func NameOptions(opts ...name.Option) []name.Option {
+	if !Insecure() {
+		return opts
+	}
+	all := make([]name.Option, 0, len(opts)+1)
+	all = append(all, opts...)
+	return append(all, name.Insecure)
+}
 
 // DefaultJobs is the default registry concurrency (concurrent manifest pushes,
 // and the per-pusher concurrent blob transfers via remote.WithJobs). It matches
@@ -74,15 +145,22 @@ type Options struct {
 }
 
 // Default returns the transport-independent enforced defaults: multi-keychain
-// auth, retry backoff, and default concurrency. Callers routing through the
-// gateway should use [Push]/[Pull]; callers with a bespoke transport (caching,
-// redirect, ...) start here and add [Options.WithTransport].
+// auth, retry backoff, and default concurrency. In insecure mode it also installs
+// [BaseTransport] so that untrusted TLS certificates are accepted; callers that
+// override the transport must build theirs on top of [BaseTransport] to keep that
+// property. Callers routing through the gateway should use [Push]/[Pull]; callers
+// with a bespoke transport (caching, redirect, ...) start here and add
+// [Options.WithTransport].
 func Default() *Options {
-	return &Options{opts: []remote.Option{
+	opts := []remote.Option{
 		registry.WithAuthFromMultiKeychain(),
 		RetryBackoffOption(),
 		remote.WithJobs(DefaultJobs),
-	}}
+	}
+	if Insecure() {
+		opts = append(opts, remote.WithTransport(BaseTransport()))
+	}
+	return &Options{opts: opts}
 }
 
 // Push returns the enforced defaults for push (write) operations, including a
@@ -147,12 +225,43 @@ func (o *Options) Remote() []remote.Option {
 // one transport across several pushers (e.g. `img deploy`) can build it once
 // here and pass it to [Options.WithTransport].
 func Transport(mode gateway.Mode) (http.RoundTripper, error) {
-	base, err := gateway.WrapTransport(remote.DefaultTransport, mode)
+	base, err := gateway.WrapTransport(BaseTransport(), mode)
 	if err != nil {
 		return nil, err
 	}
 	return WrapRetryAfter(base), nil
 }
+
+// BaseTransport returns the transport every registry request starts from:
+// go-cr's remote.DefaultTransport, or -- in insecure mode -- a clone of it that
+// accepts untrusted (e.g. self-signed or expired) TLS certificates. This mirrors
+// what crane's --insecure does to its default transport. Callers that build a
+// bespoke transport (caching, gateway routing, ...) should wrap this rather than
+// remote.DefaultTransport so insecure mode keeps working.
+//
+// Like remote.DefaultTransport, the returned transport is shared, so all callers
+// keep using one connection pool.
+func BaseTransport() http.RoundTripper {
+	if !Insecure() {
+		return remote.DefaultTransport
+	}
+	return insecureTransport()
+}
+
+// insecureTransport is the shared TLS-verification-skipping clone of
+// remote.DefaultTransport, built at most once. remote.DefaultTransport itself is
+// never mutated: it is shared with every other go-cr user in the process.
+var insecureTransport = sync.OnceValue(func() http.RoundTripper {
+	base, ok := remote.DefaultTransport.(*http.Transport)
+	if !ok {
+		return remote.DefaultTransport
+	}
+	clone := base.Clone()
+	clone.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // requested via --insecure / IMG_INSECURE
+	}
+	return clone
+})
 
 // RetryBackoff returns the exponential backoff policy used for registry
 // operations. It deliberately replaces go-cr's short default (3 attempts over

--- a/img_tool/pkg/registryopts/registryopts_test.go
+++ b/img_tool/pkg/registryopts/registryopts_test.go
@@ -2,12 +2,19 @@ package registryopts
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/gateway"
@@ -93,6 +100,118 @@ func TestTransportBuilds(t *testing.T) {
 	}
 	if _, ok := rt.(*retryAfterTransport); !ok {
 		t.Fatalf("Transport = %T, want *retryAfterTransport", rt)
+	}
+}
+
+// setInsecureForTest turns insecure mode on (or off) for the duration of the
+// test, restoring the previous process-wide value afterwards.
+func setInsecureForTest(t *testing.T, enabled bool) {
+	t.Helper()
+	previous := Insecure()
+	SetInsecure(enabled)
+	t.Cleanup(func() { SetInsecure(previous) })
+}
+
+func TestInsecureFromEnv(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{value: "", want: false},
+		{value: "0", want: false},
+		{value: "false", want: false},
+		{value: "FALSE", want: false},
+		{value: " ", want: false},
+		{value: "1", want: true},
+		{value: "true", want: true},
+		{value: "True", want: true},
+		{value: "yes", want: true},
+	}
+	for _, tc := range tests {
+		t.Run("value="+tc.value, func(t *testing.T) {
+			t.Setenv(EnvInsecure, tc.value)
+			if got := insecureFromEnv(); got != tc.want {
+				t.Fatalf("insecureFromEnv() with %s=%q = %v, want %v", EnvInsecure, tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNameOptionsInsecure covers the half of insecure mode that made pushes to a
+// plain-HTTP registry fail with "server gave HTTP response to HTTPS client": the
+// reference's registry must resolve to http.
+func TestNameOptionsInsecure(t *testing.T) {
+	setInsecureForTest(t, false)
+	if got := len(NameOptions()); got != 0 {
+		t.Fatalf("NameOptions() with insecure off returned %d options, want 0", got)
+	}
+	secureRef, err := name.NewTag("registry.example.com/app:latest", NameOptions()...)
+	if err != nil {
+		t.Fatalf("NewTag: %v", err)
+	}
+	if got := secureRef.Context().Registry.Scheme(); got != "https" {
+		t.Fatalf("scheme with insecure off = %q, want https", got)
+	}
+
+	SetInsecure(true)
+	insecureRef, err := name.NewTag("registry.example.com/app:latest", NameOptions()...)
+	if err != nil {
+		t.Fatalf("NewTag: %v", err)
+	}
+	if got := insecureRef.Context().Registry.Scheme(); got != "http" {
+		t.Fatalf("scheme with insecure on = %q, want http", got)
+	}
+
+	// Caller-supplied options are kept, and name.Insecure is appended to them.
+	ref, err := name.NewRegistry("", NameOptions(name.WithDefaultRegistry("registry.example.com"))...)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if ref.RegistryStr() != "registry.example.com" {
+		t.Fatalf("RegistryStr = %q, want the default registry passed in", ref.RegistryStr())
+	}
+	if got := ref.Scheme(); got != "http" {
+		t.Fatalf("scheme = %q, want http", got)
+	}
+}
+
+// TestBaseTransportInsecure covers the other half: untrusted TLS certificates are
+// accepted, without mutating go-cr's shared default transport.
+func TestBaseTransportInsecure(t *testing.T) {
+	setInsecureForTest(t, false)
+	if got := BaseTransport(); got != remote.DefaultTransport {
+		t.Fatalf("BaseTransport() with insecure off = %v, want remote.DefaultTransport", got)
+	}
+
+	SetInsecure(true)
+	rt := BaseTransport()
+	transport, ok := rt.(*http.Transport)
+	if !ok {
+		t.Fatalf("BaseTransport() = %T, want *http.Transport", rt)
+	}
+	if transport == remote.DefaultTransport {
+		t.Fatalf("BaseTransport() returned the shared remote.DefaultTransport; it must be a clone")
+	}
+	if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatalf("BaseTransport() TLSClientConfig = %+v, want InsecureSkipVerify", transport.TLSClientConfig)
+	}
+	if defaultTransport, ok := remote.DefaultTransport.(*http.Transport); ok {
+		if defaultTransport.TLSClientConfig != nil && defaultTransport.TLSClientConfig.InsecureSkipVerify {
+			t.Fatalf("remote.DefaultTransport was mutated to skip TLS verification")
+		}
+	}
+}
+
+// TestDefaultInsecureInstallsTransport verifies that callers which only take the
+// enforced defaults (no explicit transport) still get the insecure transport.
+func TestDefaultInsecureInstallsTransport(t *testing.T) {
+	setInsecureForTest(t, true)
+	if got := len(Default().Remote()); got != 4 {
+		t.Fatalf("Default() with insecure on has %d options, want 4 (auth, retry, jobs, transport)", got)
+	}
+	SetInsecure(false)
+	if got := len(Default().Remote()); got != 3 {
+		t.Fatalf("Default() with insecure off has %d options, want 3", got)
 	}
 }
 
@@ -286,4 +405,88 @@ func TestWrapRetryAfterRespectsContextCancellation(t *testing.T) {
 
 func isContextError(err error) bool {
 	return err == context.Canceled || err == context.DeadlineExceeded
+}
+
+// plainHTTPRegistry returns a RoundTripper that behaves like a registry which only
+// speaks plain HTTP: an https request fails the way a TLS handshake against a
+// plaintext server does, an http request is served by an in-memory OCI registry.
+// It also records the scheme of every request, so a test can tell which one
+// go-containerregistry ended up using. No socket is bound.
+func plainHTTPRegistry() (http.RoundTripper, *[]string) {
+	handler := registry.New()
+	var mu sync.Mutex
+	schemes := &[]string{}
+	return roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		mu.Lock()
+		*schemes = append(*schemes, req.URL.Scheme)
+		mu.Unlock()
+		if req.URL.Scheme != "http" {
+			return nil, errors.New("http: server gave HTTP response to HTTPS client")
+		}
+		// The handler expects a server-side request, which always has a body.
+		serverReq := req.Clone(req.Context())
+		if serverReq.Body == nil {
+			serverReq.Body = http.NoBody
+		}
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, serverReq)
+		resp := recorder.Result()
+		resp.Request = req
+		return resp, nil
+	}), schemes
+}
+
+// TestInsecurePushToPlainHTTPRegistry is the end-to-end shape of the problem
+// insecure mode solves: pushing to a registry that only speaks plain HTTP under a
+// host name go-containerregistry does not recognize as local (so not localhost,
+// *.localhost, a loopback address or an RFC1918 address) -- the shape of a k3d
+// registry or an /etc/hosts-mapped development registry.
+func TestInsecurePushToPlainHTTPRegistry(t *testing.T) {
+	const host = "registry.example.com:5000"
+
+	// A failing request must not burn the patient production backoff.
+	t.Setenv(EnvRetryMaxAttempts, "1")
+
+	image, err := random.Image(64, 1)
+	if err != nil {
+		t.Fatalf("building test image: %v", err)
+	}
+
+	// With insecure mode on, the push and the read-back fall back to http and
+	// succeed.
+	setInsecureForTest(t, true)
+	transport, schemes := plainHTTPRegistry()
+	opts := Default().WithTransport(transport).Remote()
+	ref, err := name.NewTag(host+"/app:latest", NameOptions()...)
+	if err != nil {
+		t.Fatalf("NewTag: %v", err)
+	}
+	if err := remote.Write(ref, image, opts...); err != nil {
+		t.Fatalf("pushing to a plain-HTTP registry with insecure mode on: %v", err)
+	}
+	if _, err := remote.Get(ref, opts...); err != nil {
+		t.Fatalf("reading back from a plain-HTTP registry with insecure mode on: %v", err)
+	}
+	if !slices.Contains(*schemes, "http") {
+		t.Fatalf("no request was made over http (schemes: %v)", *schemes)
+	}
+
+	// Without it, go-cr only ever tries https and the push fails -- the error
+	// reported in the issue this flag fixes.
+	SetInsecure(false)
+	secureTransport, secureSchemes := plainHTTPRegistry()
+	secureRef, err := name.NewTag(host+"/app:latest", NameOptions()...)
+	if err != nil {
+		t.Fatalf("NewTag: %v", err)
+	}
+	err = remote.Write(secureRef, image, Default().WithTransport(secureTransport).Remote()...)
+	if err == nil {
+		t.Fatal("pushing over https to a plain-HTTP registry succeeded, want a failure")
+	}
+	if !strings.Contains(err.Error(), "gave HTTP response to HTTPS client") {
+		t.Fatalf("error = %v, want the plain-HTTP-vs-HTTPS failure", err)
+	}
+	if slices.Contains(*secureSchemes, "http") {
+		t.Fatalf("an http request was made with insecure mode off (schemes: %v)", *secureSchemes)
+	}
 }

--- a/img_tool/pkg/serve/bes/syncer/syncer.go
+++ b/img_tool/pkg/serve/bes/syncer/syncer.go
@@ -214,16 +214,16 @@ func (s *Syncer) commitRegistryTag(ctx context.Context, op api.IndexedRegistryTa
 	}
 
 	baseReference := fmt.Sprintf("%s/%s", op.Registry, op.Repository)
-	ref, err := name.NewRepository(baseReference)
+	ref, err := name.NewRepository(baseReference, registryopts.NameOptions()...)
 	if err != nil {
 		return fmt.Errorf("invalid repository %s: %w", baseReference, err)
 	}
 	remoteOpts := registryopts.Default().
-		WithTransport(registryopts.WrapRetryAfter(remote.DefaultTransport)).
+		WithTransport(registryopts.WrapRetryAfter(registryopts.BaseTransport())).
 		With(remote.WithContext(ctx)).
 		Remote()
 
-	digestRef, err := name.ParseReference(ref.String() + "@" + op.Root.Digest)
+	digestRef, err := name.ParseReference(ref.String()+"@"+op.Root.Digest, registryopts.NameOptions()...)
 	if err != nil {
 		return fmt.Errorf("failed to parse digest reference: %w", err)
 	}
@@ -263,13 +263,13 @@ func (s *Syncer) commitOne(ctx context.Context, pushOp api.IndexedPushDeployOper
 		pushOp.PushTarget.Registry,
 		pushOp.PushTarget.Repository)
 
-	ref, err := name.NewRepository(baseReference)
+	ref, err := name.NewRepository(baseReference, registryopts.NameOptions()...)
 	if err != nil {
 		return fmt.Errorf("invalid repository %s: %w", baseReference, err)
 	}
 
 	remoteOpts := registryopts.Default().
-		WithTransport(registryopts.WrapRetryAfter(remote.DefaultTransport)).
+		WithTransport(registryopts.WrapRetryAfter(registryopts.BaseTransport())).
 		With(remote.WithContext(ctx)).
 		Remote()
 
@@ -305,7 +305,7 @@ func (s *Syncer) commitOne(ctx context.Context, pushOp api.IndexedPushDeployOper
 		return nil
 	}
 
-	digestRef, err := name.ParseReference(ref.String() + "@" + rootBlob.Digest)
+	digestRef, err := name.ParseReference(ref.String()+"@"+rootBlob.Digest, registryopts.NameOptions()...)
 	if err != nil {
 		return fmt.Errorf("failed to parse digest reference: %w", err)
 	}
@@ -1120,12 +1120,12 @@ func (l *remoteStreamingLayer) Compressed() (io.ReadCloser, error) {
 	}
 	var attempts []string
 	for _, source := range l.sources {
-		ref, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", source.Registry, source.Repository, l.digest))
+		ref, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", source.Registry, source.Repository, l.digest), registryopts.NameOptions()...)
 		if err != nil {
 			attempts = append(attempts, fmt.Sprintf("%s/%s: %v", source.Registry, source.Repository, err))
 			continue
 		}
-		layer, err := remote.Layer(ref, registryopts.Default().WithTransport(registryopts.WrapRetryAfter(remote.DefaultTransport)).Remote()...)
+		layer, err := remote.Layer(ref, registryopts.Default().WithTransport(registryopts.WrapRetryAfter(registryopts.BaseTransport())).Remote()...)
 		if err != nil {
 			attempts = append(attempts, fmt.Sprintf("%s: %v", ref, err))
 			continue

--- a/img_tool/pkg/serve/registry/upstream/upstream.go
+++ b/img_tool/pkg/serve/registry/upstream/upstream.go
@@ -26,12 +26,12 @@ func New(registryURL string) *UpstreamBlobHandler {
 }
 
 func (h *UpstreamBlobHandler) Get(ctx context.Context, repo string, hash registryv1.Hash) (io.ReadCloser, error) {
-	ref, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", h.registryURL, repo, hash.String()))
+	ref, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", h.registryURL, repo, hash.String()), registryopts.NameOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("creating blob reference: %w", err)
 	}
 	transport := &redirectHandler{
-		underlying: remote.DefaultTransport,
+		underlying: registryopts.BaseTransport(),
 	}
 	layer, err := remote.Layer(ref, registryopts.Default().WithTransport(transport).Remote()...)
 	if err != nil {
@@ -52,13 +52,13 @@ func (h *UpstreamBlobHandler) Get(ctx context.Context, repo string, hash registr
 }
 
 func (h *UpstreamBlobHandler) Stat(ctx context.Context, repo string, hash registryv1.Hash) (int64, error) {
-	ref, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", h.registryURL, repo, hash.String()))
+	ref, err := name.NewDigest(fmt.Sprintf("%s/%s@%s", h.registryURL, repo, hash.String()), registryopts.NameOptions()...)
 	if err != nil {
 		return 0, fmt.Errorf("creating blob reference: %w", err)
 	}
 	transport := &redirectHandler{
 		hash:       hash,
-		underlying: remote.DefaultTransport,
+		underlying: registryopts.BaseTransport(),
 	}
 	layer, err := remote.Layer(ref, registryopts.Default().WithTransport(transport).Remote()...)
 	if err != nil {


### PR DESCRIPTION
Registries were always addressed over HTTPS, so pushing to a local
development registry failed with "http: server gave HTTP response to
HTTPS client" (and a `http://` prefix is rejected, since `registry` is a
host, not a URL).

Add a crane-style insecure switch -- http:// instead of https:// plus
untrusted TLS certificates accepted -- available as the img tool's global
`--insecure` flag, the `IMG_INSECURE` env var, and
`--@rules_img//img/settings:insecure=enabled`, which covers `bazel run`
pushes/loads/multi_deploys and the registry-touching build actions.
See docs/insecure-registries.md.

Closes https://github.com/bazel-contrib/rules_img/issues/526