### PR TITLE
feat(push): make --jobs the cap on destination registry connections

### DIFF
--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -99,7 +99,7 @@ func DeployProcess(ctx context.Context, args []string) {
 	flagSet.StringVar(&platforms, "platform", "", "Comma-separated list of platforms to load (e.g., linux/amd64). If not set, loads the platform closest to the host (or the single available platform). Use 'all' to load the full multi-platform index. Doesn't affect push, only load.")
 	flagSet.Var(&ociLayouts, "oci-layout", "Path to an OCI layout directory, sparse or standard (can be used multiple times)")
 	flagSet.Var(&explicitLayers, "layer", "Layer as digest=path or a bare path (can be used multiple times). The file may be a raw compressed layer blob or a compact stream (.cstream), auto-detected. For a bare path: a raw blob is hashed to derive its digest; a .cstream must embed its compressed digest.")
-	flagSet.IntVar(&jobs, "jobs", defaultDeployJobs(), "Maximum number of parallel push operations (defaults to GOMAXPROCS)")
+	flagSet.IntVar(&jobs, "jobs", defaultDeployJobs(), "Maximum number of concurrent requests to the destination registry, and of parallel push operations (defaults to GOMAXPROCS)")
 	flagSet.StringVar(&sink, "sink", "", "Override the destination of all push/load/registry_tag operations for testing. Format: <type>:<path> where type is one of oci-tar, docker-save, oci, distribution, distribution-flat. No registry or daemon network I/O is performed.")
 	flagSet.StringVar(&progressMode, "progress", "", "How to report progress on stderr: 'bar' (interactive progress bars), 'log' (one crane-style line per blob), 'none', or 'auto' (default: bars on a terminal, log lines otherwise). Overridable with $IMG_PROGRESS.")
 	flagSet.Var(&signSettingFiles, "sign_setting_file", "Additional sign_setting config file to ingest for signing (can be used multiple times)")
@@ -220,6 +220,9 @@ type DeployOptions struct {
 }
 
 func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions) error {
+	// --jobs is the ceiling on requests in flight to the destination registry.
+	registryopts.LimitConcurrencyToJobs(opts.Jobs)
+
 	var req api.DeployManifest
 	decoder := json.NewDecoder(bytes.NewReader(rawRequest))
 	decoder.DisallowUnknownFields()
@@ -347,6 +350,10 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 			return fmt.Errorf("creating pusher: %w", err)
 		}
 	}
+
+	// Report how concurrent the registry traffic got (opt-in, see
+	// registryopts.EnvLogConcurrency), including on the failure paths below.
+	defer registryopts.LogConcurrencySummary(os.Stderr)
 
 	var pushedTags []string
 	// groupCtx is cancelled once g.Wait returns; keep the outer ctx for work after it (registry_tag ops).

--- a/img_tool/cmd/deploy/persistentworker.go
+++ b/img_tool/cmd/deploy/persistentworker.go
@@ -38,6 +38,11 @@ type deployWorkerHandler struct {
 }
 
 func newDeployWorkerHandler(jobs int, sinkSpec string) (*deployWorkerHandler, error) {
+	// --jobs is the ceiling on requests in flight to the destination registry.
+	// The worker handles several work requests at once, all sharing the pusher
+	// and transport built here, so the limit is process-wide by construction.
+	registryopts.LimitConcurrencyToJobs(jobs)
+
 	// Configure optional registry gateways. When IMG_REGISTRY_*_GATEWAY is set,
 	// push and base-image (pull) requests are routed through the gateway; when
 	// unset, WrapTransport returns the base transport unchanged.
@@ -198,6 +203,10 @@ func (h *deployWorkerHandler) processRequest(ctx context.Context, req persistent
 			return "", fmt.Errorf("load: %w", err)
 		}
 	}
+
+	// Registry counters are process-wide and this worker is long-lived, so the
+	// summary covers every request since startup, not just this request.
+	registryopts.LogConcurrencySummary(os.Stderr)
 
 	return output.String(), nil
 }

--- a/img_tool/cmd/pull/pull.go
+++ b/img_tool/cmd/pull/pull.go
@@ -87,7 +87,7 @@ func PullProcess(ctx context.Context, args []string) {
 		fmt.Fprintf(os.Stderr, "Error configuring registry gateway: %v\n", err)
 		os.Exit(1)
 	}
-	transport := cachedblob.NewTransport(outputDir, registryopts.WrapRetryAfter(gatewayBase), cachedblob.WithAirgapped(airgapped))
+	transport := cachedblob.NewTransport(outputDir, registryopts.WrapRetryAfter(registryopts.WrapConcurrency(gatewayBase, registryopts.RoleSource)), cachedblob.WithAirgapped(airgapped))
 
 	// Default to docker.io if no registries specified
 	if len(registries) == 0 {

--- a/img_tool/cmd/push/manifest.go
+++ b/img_tool/cmd/push/manifest.go
@@ -31,7 +31,7 @@ func manifestProcess(ctx context.Context, args []string) {
 	flagSet.StringVar(&manifestRepository, "manifest-repository", "", "Repository to upload the manifest(s)/index and config to instead of the operation's own repository. Layer blobs are still cross-mounted from where `push blob` put them (this does not change blob mounting).")
 	flagSet.StringVar(&mode, "mode", "enabled", "Failure mode: 'best_effort' (log, don't fail build) or 'enabled' (fail build).")
 	flagSet.StringVar(&markerPath, "marker", "", "Path to the marker file to write on success. Required.")
-	flagSet.IntVar(&jobs, "jobs", registryopts.DefaultJobs, "Maximum number of parallel push operations.")
+	flagSet.IntVar(&jobs, "jobs", registryopts.DefaultJobs, "Maximum number of concurrent requests to the destination registry, and of parallel push operations.")
 
 	if err := flagSet.Parse(args); err != nil {
 		os.Exit(1)
@@ -45,6 +45,9 @@ func manifestProcess(ctx context.Context, args []string) {
 }
 
 func pushManifest(ctx context.Context, requestFile string, ociLayouts, layerResults []string, manifestRepository string, jobs int) error {
+	// --jobs is the ceiling on requests in flight to the destination registry.
+	registryopts.LimitConcurrencyToJobs(jobs)
+
 	raw, err := os.ReadFile(requestFile)
 	if err != nil {
 		return fmt.Errorf("reading request file %s: %w", requestFile, err)

--- a/img_tool/cmd/syncocirefgraph/syncocirefgraph.go
+++ b/img_tool/cmd/syncocirefgraph/syncocirefgraph.go
@@ -325,7 +325,7 @@ func downloadManifest(registry, repository, digest string) ([]byte, error) {
 		return nil, fmt.Errorf("creating manifest reference: %w", err)
 	}
 
-	descriptor, err := remote.Get(ref, registryopts.Default().WithTransport(registryopts.WrapRetryAfter(registryopts.BaseTransport())).Remote()...)
+	descriptor, err := remote.Get(ref, registryopts.Default().WithTransport(registryopts.DirectTransport()).Remote()...)
 	if err != nil {
 		return nil, fmt.Errorf("getting manifest: %w", err)
 	}

--- a/img_tool/pkg/registryopts/BUILD.bazel
+++ b/img_tool/pkg/registryopts/BUILD.bazel
@@ -2,12 +2,16 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "registryopts",
-    srcs = ["registryopts.go"],
+    srcs = [
+        "concurrency.go",
+        "registryopts.go",
+    ],
     importpath = "github.com/bazel-contrib/rules_img/img_tool/pkg/registryopts",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/auth/registry",
         "//pkg/gateway",
+        "@com_github_google_go_containerregistry//pkg/logs",
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1/remote",
     ],
@@ -16,7 +20,10 @@ go_library(
 go_test(
     name = "registryopts_test",
     size = "small",
-    srcs = ["registryopts_test.go"],
+    srcs = [
+        "concurrency_test.go",
+        "registryopts_test.go",
+    ],
     embed = [":registryopts"],
     deps = [
         "//pkg/gateway",

--- a/img_tool/pkg/registryopts/concurrency.go
+++ b/img_tool/pkg/registryopts/concurrency.go
@@ -1,0 +1,525 @@
+package registryopts
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/logs"
+)
+
+// Environment variables that expose and bound how many registry requests the
+// process has in flight at once.
+const (
+	// EnvMaxConcurrentRequests overrides how many requests to the destination
+	// registry may be in flight at once, process-wide. It takes precedence over
+	// the --jobs value a command passes to [LimitConcurrencyToJobs]; <= 0 means
+	// unlimited.
+	EnvMaxConcurrentRequests = "IMG_REGISTRY_MAX_CONCURRENT_REQUESTS"
+	// EnvLogConcurrency turns on concurrency logging to stderr:
+	//
+	//	requests  log every registry request as it is admitted, with the
+	//	          current and peak in-flight counts ("1"/"true"/"on"/"all"
+	//	          are accepted as synonyms)
+	//	summary   only print the end-of-run summary line
+	//	off       neither (the default; "0"/"false" are synonyms)
+	//
+	// `img --verbose` implies "requests" when this variable is unset.
+	EnvLogConcurrency = "IMG_REGISTRY_LOG_CONCURRENCY"
+)
+
+// Role selects which pool of registry requests a transport's traffic belongs to.
+type Role int
+
+const (
+	// RoleDestination is traffic to the registry we are writing to: blob and
+	// manifest uploads plus the existence checks that precede them. This is the
+	// pool --jobs bounds.
+	RoleDestination Role = iota
+	// RoleSource is traffic to registries we read from (base images, referrer
+	// lookups). It is counted but never throttled — throttling it would only
+	// slow data on its way into the img tool.
+	RoleSource
+	// RoleAuto classifies each request by method: writes are destination
+	// traffic, reads are source traffic. It is for transports that do both (the
+	// BES syncer streams source blobs into destination uploads over one
+	// transport).
+	RoleAuto
+)
+
+func (r Role) pool(method string) poolID {
+	switch r {
+	case RoleSource:
+		return poolSource
+	case RoleAuto:
+		switch method {
+		case http.MethodGet, http.MethodHead, "":
+			return poolSource
+		default:
+			return poolDestination
+		}
+	default:
+		return poolDestination
+	}
+}
+
+type poolID int
+
+const (
+	poolDestination poolID = iota
+	poolSource
+	numPools
+)
+
+func (p poolID) String() string {
+	if p == poolSource {
+		return "source"
+	}
+	return "destination"
+}
+
+// logMode selects how much the concurrency tracker reports.
+type logMode int
+
+const (
+	logOff logMode = iota
+	logSummary
+	logRequests
+)
+
+// slotPool admits requests belonging to one pool, optionally bounded to a fixed
+// number of slots, and records how concurrent they got. The limit can be changed
+// at any time — commands learn it from --jobs after transports are already
+// built — so slots are handed out through a FIFO queue of waiters rather than a
+// fixed-capacity channel.
+type slotPool struct {
+	id poolID
+
+	mu      sync.Mutex
+	limit   int // 0 means unlimited
+	held    int
+	waiters []chan int
+
+	peak      int
+	total     int64
+	blocked   int64
+	waitNanos int64
+}
+
+func newSlotPool(id poolID, limit int) *slotPool {
+	if limit < 0 {
+		limit = 0
+	}
+	return &slotPool{id: id, limit: limit}
+}
+
+// setLimit changes the number of slots. Requests already in flight are never
+// interrupted, so held may exceed a freshly lowered limit until they drain.
+func (p *slotPool) setLimit(limit int) {
+	if limit < 0 {
+		limit = 0
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.limit = limit
+	p.grantLocked()
+}
+
+// acquire takes a slot, blocking until one is free when the pool is bounded. It
+// reports how many requests are now in flight (including this one) and how long
+// it waited, plus a release function that is safe to call more than once.
+func (p *slotPool) acquire(ctx context.Context) (inFlight int, waited time.Duration, release func(), err error) {
+	p.mu.Lock()
+	if p.hasCapacityLocked() {
+		inFlight = p.admitLocked()
+		p.mu.Unlock()
+		return inFlight, 0, p.releaser(), nil
+	}
+	ch := make(chan int, 1)
+	p.waiters = append(p.waiters, ch)
+	p.blocked++
+	p.mu.Unlock()
+
+	start := time.Now()
+	select {
+	case inFlight = <-ch:
+		waited = time.Since(start)
+		p.mu.Lock()
+		p.waitNanos += int64(waited)
+		p.mu.Unlock()
+		return inFlight, waited, p.releaser(), nil
+	case <-ctx.Done():
+		p.mu.Lock()
+		if !p.dequeueLocked(ch) {
+			// The slot was granted while we were giving up on it; hand it back.
+			p.releaseLocked()
+		}
+		p.mu.Unlock()
+		return 0, 0, nil, ctx.Err()
+	}
+}
+
+func (p *slotPool) hasCapacityLocked() bool {
+	return p.limit == 0 || p.held < p.limit
+}
+
+func (p *slotPool) admitLocked() int {
+	p.held++
+	p.total++
+	if p.held > p.peak {
+		p.peak = p.held
+	}
+	return p.held
+}
+
+// grantLocked hands free slots to queued requests, oldest first.
+func (p *slotPool) grantLocked() {
+	for len(p.waiters) > 0 && p.hasCapacityLocked() {
+		ch := p.waiters[0]
+		p.waiters = p.waiters[1:]
+		ch <- p.admitLocked()
+	}
+}
+
+// dequeueLocked removes ch from the queue, reporting whether it was still
+// waiting. A false return means the slot was already granted to it.
+func (p *slotPool) dequeueLocked(ch chan int) bool {
+	for i, queued := range p.waiters {
+		if queued == ch {
+			p.waiters = append(p.waiters[:i], p.waiters[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func (p *slotPool) releaser() func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			p.mu.Lock()
+			p.releaseLocked()
+			p.mu.Unlock()
+		})
+	}
+}
+
+func (p *slotPool) releaseLocked() {
+	p.held--
+	p.grantLocked()
+}
+
+func (p *slotPool) stats() PoolStats {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return PoolStats{
+		Limit:    p.limit,
+		InFlight: p.held,
+		Peak:     p.peak,
+		Total:    p.total,
+		Blocked:  p.blocked,
+		Wait:     time.Duration(p.waitNanos),
+	}
+}
+
+// PoolStats is a snapshot of one pool of registry requests.
+type PoolStats struct {
+	// Limit is the configured cap, or 0 when unlimited.
+	Limit int
+	// InFlight is how many requests are in flight right now.
+	InFlight int
+	// Peak is the highest InFlight value observed so far.
+	Peak int
+	// Total is how many requests were admitted so far.
+	Total int64
+	// Blocked is how many requests had to wait for a free slot.
+	Blocked int64
+	// Wait is the total time requests spent waiting for a free slot.
+	Wait time.Duration
+}
+
+// ConcurrencyStats is a snapshot of process-wide registry request concurrency.
+type ConcurrencyStats struct {
+	// Destination covers requests to the registry being written to (bounded by
+	// --jobs).
+	Destination PoolStats
+	// Source covers requests to registries being read from (counted only).
+	Source PoolStats
+}
+
+// concurrencyTracker holds the pools and the reporting settings.
+type concurrencyTracker struct {
+	pools [numPools]*slotPool
+	// envLimit records that EnvMaxConcurrentRequests set the destination limit
+	// explicitly, which makes LimitConcurrencyToJobs a no-op.
+	envLimit bool
+	mode     logMode
+	logger   *log.Logger
+}
+
+func newConcurrencyTracker(destinationLimit int, envLimit bool, mode logMode, out io.Writer) *concurrencyTracker {
+	t := &concurrencyTracker{envLimit: envLimit, mode: mode}
+	t.pools[poolDestination] = newSlotPool(poolDestination, destinationLimit)
+	t.pools[poolSource] = newSlotPool(poolSource, 0)
+	if mode != logOff {
+		t.logger = log.New(out, "img registry: ", log.Ltime|log.Lmicroseconds)
+	}
+	return t
+}
+
+func (t *concurrencyTracker) limitToJobs(jobs int) {
+	if t.envLimit || jobs <= 0 {
+		return
+	}
+	t.pools[poolDestination].setLimit(jobs)
+}
+
+func (t *concurrencyTracker) stats() ConcurrencyStats {
+	return ConcurrencyStats{
+		Destination: t.pools[poolDestination].stats(),
+		Source:      t.pools[poolSource].stats(),
+	}
+}
+
+func (t *concurrencyTracker) logAdmitted(p *slotPool, req *http.Request, inFlight int, waited time.Duration) {
+	if t.mode < logRequests {
+		return
+	}
+	s := p.stats()
+	var limit string
+	if s.Limit > 0 {
+		limit = "/" + strconv.Itoa(s.Limit)
+	}
+	var wait string
+	if waited > 0 {
+		wait = " waited=" + waited.Round(time.Millisecond).String()
+	}
+	t.logger.Printf("%s in-flight=%d%s peak=%d total=%d%s %s %s",
+		p.id, inFlight, limit, s.Peak, s.Total, wait, req.Method, requestTarget(req.URL))
+}
+
+// summary renders one line describing every registry request made so far. It
+// returns "" when reporting is disabled or nothing was requested.
+func (t *concurrencyTracker) summary() string {
+	if t.mode == logOff {
+		return ""
+	}
+	s := t.stats()
+	if s.Destination.Total == 0 && s.Source.Total == 0 {
+		return ""
+	}
+	return fmt.Sprintf("registry requests: %s, %s",
+		formatPoolStats("to destination", s.Destination),
+		formatPoolStats("from sources", s.Source))
+}
+
+func formatPoolStats(name string, s PoolStats) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d %s (peak %d", s.Total, name, s.Peak)
+	if s.Limit > 0 {
+		fmt.Fprintf(&b, "/%d", s.Limit)
+	}
+	b.WriteString(" concurrent")
+	if s.Blocked > 0 {
+		fmt.Fprintf(&b, ", %d throttled, %s waiting", s.Blocked, s.Wait.Round(time.Millisecond))
+	}
+	b.WriteString(")")
+	return b.String()
+}
+
+// globalTracker is the process-wide tracker. Every transport built by this
+// package shares it, so the counts and the destination limit cover all registry
+// traffic regardless of how many pushers, pullers and errgroups are layered
+// above it.
+var globalTracker = sync.OnceValue(func() *concurrencyTracker {
+	limit, fromEnv := maxConcurrentRequestsEnv()
+	return newConcurrencyTracker(limit, fromEnv, concurrencyLogMode(), os.Stderr)
+})
+
+// LimitConcurrencyToJobs bounds requests to the destination registry to the
+// command's --jobs value: at most jobs blob/manifest uploads and existence
+// checks are in flight at once, process-wide. Reads from source registries are
+// left unbounded — they carry data towards the img tool, not towards the
+// registry being written to.
+//
+// This is what makes --jobs mean "connections to the destination registry".
+// Without it, jobs is only a per-fan-out limit that rules_img and
+// go-containerregistry each apply again at every level (push operations, then a
+// manifest's children, then an image's layers), so the requests actually in
+// flight are the product of the nested limits.
+//
+// Commands call it once, as early as they know their --jobs value; it may be
+// called after transports have been built, since the pool is resized in place.
+// [EnvMaxConcurrentRequests] takes precedence when set.
+func LimitConcurrencyToJobs(jobs int) {
+	globalTracker().limitToJobs(jobs)
+}
+
+// Concurrency reports process-wide registry request concurrency: how many
+// requests are in flight, how concurrent they got, and how much they were
+// throttled. Counting is always on.
+func Concurrency() ConcurrencyStats {
+	return globalTracker().stats()
+}
+
+// ConcurrencySummary renders [Concurrency] as a single human-readable line, or
+// "" when concurrency reporting is disabled (see [EnvLogConcurrency]) or no
+// registry request was made.
+func ConcurrencySummary() string {
+	return globalTracker().summary()
+}
+
+// LogConcurrencySummary writes [ConcurrencySummary] to w when it is non-empty.
+// Commands call it once they are done talking to registries.
+func LogConcurrencySummary(w io.Writer) {
+	if summary := ConcurrencySummary(); summary != "" {
+		fmt.Fprintf(w, "    %s\n", summary)
+	}
+}
+
+// WrapConcurrency wraps base so that every registry request it carries is
+// counted against the process-wide tracker and, for destination traffic, waits
+// for a free slot before it is sent (see [LimitConcurrencyToJobs]).
+//
+// This is the only place where the number of concurrent registry requests can be
+// observed or bounded, because it is the only place all of them pass through
+// exactly once.
+//
+// The destination pool releases its slot when the round trip returns. That is
+// the whole upload: an upload's request body is streamed during the round trip.
+// It also means a destination request never holds a slot while another one has to
+// finish, so the limit cannot deadlock the push — in particular a layer streamed
+// out of a source registry (a shallow base image) opens its read before the
+// upload that consumes it, and reads are never throttled.
+//
+// Source blob downloads do hold their slot until the response body is closed, so
+// the reported concurrency reflects connections that stay busy while a body
+// streams. That pool is counted, not bounded.
+//
+// Wrap the base transport, not go-cr's authenticated client: this must sit below
+// go-cr's auth and retry wrapping so that token fetches are counted too and each
+// retry attempt takes its own slot.
+func WrapConcurrency(base http.RoundTripper, role Role) http.RoundTripper {
+	return wrapConcurrency(base, role, globalTracker())
+}
+
+func wrapConcurrency(base http.RoundTripper, role Role, tracker *concurrencyTracker) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &concurrencyTransport{inner: base, role: role, tracker: tracker}
+}
+
+type concurrencyTransport struct {
+	inner   http.RoundTripper
+	role    Role
+	tracker *concurrencyTracker
+}
+
+func (t *concurrencyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	pool := t.tracker.pools[t.role.pool(req.Method)]
+	inFlight, waited, release, err := pool.acquire(req.Context())
+	if err != nil {
+		return nil, err
+	}
+	t.tracker.logAdmitted(pool, req, inFlight, waited)
+
+	resp, err := t.inner.RoundTrip(req)
+	if err != nil || resp == nil {
+		release()
+		return resp, err
+	}
+	if !holdsSlotUntilBodyClose(pool.id, req, resp) {
+		release()
+		return resp, nil
+	}
+	resp.Body = &releaseOnClose{ReadCloser: resp.Body, release: release}
+	return resp, nil
+}
+
+// holdsSlotUntilBodyClose reports whether resp is a body the caller streams off
+// the connection (a blob or manifest download), which keeps the request alive
+// well past the round trip.
+//
+// Only source reads qualify. Error and redirect responses are excluded even
+// there: their bodies are small, and go-cr issues follow-up requests (token
+// refresh, redirect hops) while it still holds them.
+func holdsSlotUntilBodyClose(pool poolID, req *http.Request, resp *http.Response) bool {
+	if pool != poolSource || req.Method != http.MethodGet {
+		return false
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		return false
+	}
+	return resp.Body != nil && resp.Body != http.NoBody
+}
+
+// releaseOnClose frees a slot once the response body is closed. A caller that
+// leaks the body leaks the slot; go-cr always closes what it opens.
+type releaseOnClose struct {
+	io.ReadCloser
+	release func()
+}
+
+func (r *releaseOnClose) Close() error {
+	err := r.ReadCloser.Close()
+	r.release()
+	return err
+}
+
+// requestTarget renders a request URL for logging without its query string,
+// which can carry credentials on pre-signed blob URLs.
+func requestTarget(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	trimmed := url.URL{Scheme: u.Scheme, Host: u.Host, Path: u.Path}
+	return trimmed.String()
+}
+
+// maxConcurrentRequestsEnv reads the destination limit from the environment,
+// reporting whether it was set explicitly.
+func maxConcurrentRequestsEnv() (int, bool) {
+	raw := os.Getenv(EnvMaxConcurrentRequests)
+	if raw == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: ignoring invalid %s=%q, falling back to --jobs\n", EnvMaxConcurrentRequests, raw)
+		return 0, false
+	}
+	if n < 0 {
+		n = 0
+	}
+	return n, true
+}
+
+func concurrencyLogMode() logMode {
+	raw := strings.ToLower(strings.TrimSpace(os.Getenv(EnvLogConcurrency)))
+	switch raw {
+	case "":
+		// `img --verbose` points go-cr's debug logger at stderr; follow it.
+		if logs.Enabled(logs.Debug) {
+			return logRequests
+		}
+		return logOff
+	case "0", "false", "off", "no", "none":
+		return logOff
+	case "summary":
+		return logSummary
+	case "1", "true", "on", "yes", "all", "requests":
+		return logRequests
+	default:
+		fmt.Fprintf(os.Stderr, "WARNING: unknown %s=%q, logging every request (accepted values: requests, summary, off)\n", EnvLogConcurrency, raw)
+		return logRequests
+	}
+}

--- a/img_tool/pkg/registryopts/concurrency_test.go
+++ b/img_tool/pkg/registryopts/concurrency_test.go
@@ -1,0 +1,585 @@
+package registryopts
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// blockingTransport answers requests only once release is closed, and records the
+// highest number of round trips that were inside it at the same time.
+type blockingTransport struct {
+	entered chan struct{}
+	release chan struct{}
+	status  int
+
+	mu      sync.Mutex
+	current int
+	max     int
+}
+
+func newBlockingTransport(status int) *blockingTransport {
+	return &blockingTransport{
+		entered: make(chan struct{}, 256),
+		release: make(chan struct{}),
+		status:  status,
+	}
+}
+
+func (b *blockingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	b.mu.Lock()
+	b.current++
+	if b.current > b.max {
+		b.max = b.current
+	}
+	b.mu.Unlock()
+	b.entered <- struct{}{}
+	<-b.release
+	b.mu.Lock()
+	b.current--
+	b.mu.Unlock()
+	return &http.Response{
+		StatusCode: b.status,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("payload")),
+		Request:    req,
+	}, nil
+}
+
+func (b *blockingTransport) maxConcurrent() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.max
+}
+
+func respondingTransport(status int, body string) roundTripFunc {
+	return func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: status,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    r,
+		}, nil
+	}
+}
+
+func testTracker(t *testing.T, destinationLimit int) *concurrencyTracker {
+	t.Helper()
+	return newConcurrencyTracker(destinationLimit, destinationLimit > 0, logOff, io.Discard)
+}
+
+func request(t *testing.T, ctx context.Context, method, url string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	return req
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// drain runs n concurrent round trips through rt and returns once they are all
+// done, releasing the blocking transport after everyone that can be admitted has
+// entered it.
+func drain(t *testing.T, rt http.RoundTripper, method, url string, n int) {
+	t.Helper()
+	var wg sync.WaitGroup
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := rt.RoundTrip(request(t, context.Background(), method, url))
+			if err != nil {
+				return
+			}
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestDestinationRequestsAreBoundedByTheLimit(t *testing.T) {
+	const limit = 3
+	inner := newBlockingTransport(http.StatusCreated)
+	tracker := testTracker(t, limit)
+	rt := wrapConcurrency(inner, RoleDestination, tracker)
+
+	go drain(t, rt, http.MethodPut, "https://registry.test/v2/foo/blobs/uploads/1", 12)
+
+	// Once `limit` requests are inside the inner transport, no more may enter.
+	for range limit {
+		<-inner.entered
+	}
+	select {
+	case <-inner.entered:
+		t.Fatalf("a %dth request entered the transport while %d slots were held", limit+1, limit)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(inner.release)
+
+	waitFor(t, "all destination requests to finish", func() bool {
+		return tracker.stats().Destination.Total == 12 && tracker.stats().Destination.InFlight == 0
+	})
+	if got := inner.maxConcurrent(); got != limit {
+		t.Fatalf("max concurrent round trips = %d, want %d", got, limit)
+	}
+	stats := tracker.stats()
+	if stats.Destination.Peak != limit {
+		t.Fatalf("destination peak = %d, want %d", stats.Destination.Peak, limit)
+	}
+	if stats.Destination.Blocked == 0 {
+		t.Fatalf("destination blocked = 0, want the queued requests to be counted")
+	}
+	if stats.Source.Total != 0 {
+		t.Fatalf("source total = %d, want 0 (destination traffic must not touch the source pool)", stats.Source.Total)
+	}
+}
+
+// A HEAD to the destination registry is a connection to the destination registry,
+// so it draws from the same pool as the uploads.
+func TestDestinationReadsShareTheLimitWithWrites(t *testing.T) {
+	inner := newBlockingTransport(http.StatusOK)
+	tracker := testTracker(t, 2)
+	rt := wrapConcurrency(inner, RoleDestination, tracker)
+
+	go drain(t, rt, http.MethodHead, "https://registry.test/v2/foo/manifests/latest", 6)
+	for range 2 {
+		<-inner.entered
+	}
+	select {
+	case <-inner.entered:
+		t.Fatalf("a third HEAD entered while both destination slots were held")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(inner.release)
+	waitFor(t, "the HEADs to finish", func() bool { return tracker.stats().Destination.Total == 6 })
+	if got := tracker.stats().Destination.Peak; got != 2 {
+		t.Fatalf("destination peak = %d, want 2", got)
+	}
+}
+
+// Downloads carry data towards the img tool, so they are counted but never
+// throttled.
+func TestSourceRequestsAreCountedButNotBounded(t *testing.T) {
+	inner := newBlockingTransport(http.StatusOK)
+	tracker := testTracker(t, 2)
+	rt := wrapConcurrency(inner, RoleSource, tracker)
+
+	const n = 8
+	go drain(t, rt, http.MethodGet, "https://base.test/v2/foo/blobs/sha256:aa", n)
+	for range n {
+		<-inner.entered
+	}
+	close(inner.release)
+
+	waitFor(t, "the downloads to finish", func() bool { return tracker.stats().Source.InFlight == 0 })
+	stats := tracker.stats()
+	if stats.Source.Peak != n {
+		t.Fatalf("source peak = %d, want %d (downloads must not be throttled)", stats.Source.Peak, n)
+	}
+	if stats.Source.Blocked != 0 {
+		t.Fatalf("source blocked = %d, want 0", stats.Source.Blocked)
+	}
+	if stats.Source.Limit != 0 {
+		t.Fatalf("source limit = %d, want 0", stats.Source.Limit)
+	}
+}
+
+// The BES syncer streams source blobs into destination uploads over one
+// transport, so RoleAuto has to attribute each request by method.
+func TestRoleAutoAttributesByMethod(t *testing.T) {
+	tracker := testTracker(t, 4)
+	rt := wrapConcurrency(respondingTransport(http.StatusOK, "body"), RoleAuto, tracker)
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		resp, err := rt.RoundTrip(request(t, context.Background(), method, "https://base.test/v2/foo/blobs/sha256:aa"))
+		if err != nil {
+			t.Fatalf("%s error: %v", method, err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+	for _, method := range []string{http.MethodPost, http.MethodPatch, http.MethodPut} {
+		resp, err := rt.RoundTrip(request(t, context.Background(), method, "https://registry.test/v2/foo/blobs/uploads/1"))
+		if err != nil {
+			t.Fatalf("%s error: %v", method, err)
+		}
+		resp.Body.Close()
+	}
+
+	stats := tracker.stats()
+	if stats.Source.Total != 2 {
+		t.Fatalf("source total = %d, want 2 (GET+HEAD)", stats.Source.Total)
+	}
+	if stats.Destination.Total != 3 {
+		t.Fatalf("destination total = %d, want 3 (POST+PATCH+PUT)", stats.Destination.Total)
+	}
+}
+
+// A layer streamed out of a source registry holds its download open for the whole
+// duration of the upload that consumes it. The upload must not be able to block
+// behind it.
+func TestStreamingCopyCannotBlockItself(t *testing.T) {
+	tracker := testTracker(t, 1)
+	source := wrapConcurrency(respondingTransport(http.StatusOK, "layer bytes"), RoleSource, tracker)
+	destination := wrapConcurrency(respondingTransport(http.StatusCreated, ""), RoleDestination, tracker)
+
+	// Two copies in flight, both holding their source download open, with a
+	// destination limit of one.
+	var held []io.ReadCloser
+	for range 2 {
+		resp, err := source.RoundTrip(request(t, context.Background(), http.MethodGet, "https://base.test/v2/base/blobs/sha256:aa"))
+		if err != nil {
+			t.Fatalf("source GET error: %v", err)
+		}
+		held = append(held, resp.Body)
+	}
+	defer func() {
+		for _, body := range held {
+			body.Close()
+		}
+	}()
+	if got := tracker.stats().Source.InFlight; got != 2 {
+		t.Fatalf("source in-flight = %d, want 2", got)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		resp, err := destination.RoundTrip(request(t, context.Background(), http.MethodPut, "https://registry.test/v2/app/blobs/uploads/1"))
+		if resp != nil {
+			resp.Body.Close()
+		}
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("destination PUT error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("destination PUT blocked behind held source downloads")
+	}
+}
+
+func TestSourceDownloadHoldsItsSlotUntilBodyClose(t *testing.T) {
+	tracker := testTracker(t, 2)
+	rt := wrapConcurrency(respondingTransport(http.StatusOK, "blob bytes"), RoleSource, tracker)
+
+	resp, err := rt.RoundTrip(request(t, context.Background(), http.MethodGet, "https://base.test/v2/foo/blobs/sha256:aa"))
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	if got := tracker.stats().Source.InFlight; got != 1 {
+		t.Fatalf("in-flight while streaming the body = %d, want 1", got)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	if got := tracker.stats().Source.InFlight; got != 1 {
+		t.Fatalf("in-flight before Close = %d, want 1", got)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("closing body: %v", err)
+	}
+	if got := tracker.stats().Source.InFlight; got != 0 {
+		t.Fatalf("in-flight after Close = %d, want 0", got)
+	}
+	// Double-closing must not release the slot twice.
+	resp.Body.Close()
+	if got := tracker.stats().Source.InFlight; got != 0 {
+		t.Fatalf("in-flight after double Close = %d, want 0", got)
+	}
+}
+
+func TestSlotIsReleasedWhenTheBodyIsNotStreamed(t *testing.T) {
+	cases := []struct {
+		name   string
+		role   Role
+		method string
+		status int
+	}{
+		// A 401 must not hold its slot: go-cr fetches a fresh token right after
+		// it, over the same transport.
+		{name: "source unauthorized get", role: RoleSource, method: http.MethodGet, status: http.StatusUnauthorized},
+		{name: "source redirected get", role: RoleSource, method: http.MethodGet, status: http.StatusTemporaryRedirect},
+		{name: "source rate limited get", role: RoleSource, method: http.MethodGet, status: http.StatusTooManyRequests},
+		{name: "source head", role: RoleSource, method: http.MethodHead, status: http.StatusOK},
+		// Destination traffic never holds a slot past the round trip: an
+		// upload's request body has already been sent by then.
+		{name: "destination get", role: RoleDestination, method: http.MethodGet, status: http.StatusOK},
+		{name: "destination put", role: RoleDestination, method: http.MethodPut, status: http.StatusCreated},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := testTracker(t, 1)
+			rt := wrapConcurrency(respondingTransport(tc.status, "body"), tc.role, tracker)
+
+			resp, err := rt.RoundTrip(request(t, context.Background(), tc.method, "https://registry.test/v2/foo/blobs/sha256:aa"))
+			if err != nil {
+				t.Fatalf("RoundTrip error: %v", err)
+			}
+			stats := tracker.stats()
+			if stats.Destination.InFlight != 0 || stats.Source.InFlight != 0 {
+				t.Fatalf("in-flight = destination %d / source %d before the body was closed, want 0/0",
+					stats.Destination.InFlight, stats.Source.InFlight)
+			}
+			// The body is still readable after the slot was released.
+			if _, err := io.ReadAll(resp.Body); err != nil {
+				t.Fatalf("reading body: %v", err)
+			}
+			resp.Body.Close()
+		})
+	}
+}
+
+// Commands learn their --jobs value at different times, so the limit has to apply
+// to transports that already exist.
+func TestLimitToJobsAppliesToExistingTransports(t *testing.T) {
+	inner := newBlockingTransport(http.StatusCreated)
+	tracker := newConcurrencyTracker(0, false, logOff, io.Discard)
+	rt := wrapConcurrency(inner, RoleDestination, tracker)
+
+	tracker.limitToJobs(2)
+	if got := tracker.stats().Destination.Limit; got != 2 {
+		t.Fatalf("destination limit = %d, want 2", got)
+	}
+
+	go drain(t, rt, http.MethodPut, "https://registry.test/v2/foo/blobs/uploads/1", 6)
+	for range 2 {
+		<-inner.entered
+	}
+	select {
+	case <-inner.entered:
+		t.Fatalf("a third request entered after the limit was lowered to 2")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Raising the limit admits queued requests immediately.
+	tracker.limitToJobs(4)
+	for range 2 {
+		select {
+		case <-inner.entered:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("raising the limit did not admit the queued requests")
+		}
+	}
+	close(inner.release)
+	waitFor(t, "the uploads to finish", func() bool { return tracker.stats().Destination.Total == 6 })
+	if got := tracker.stats().Destination.Peak; got != 4 {
+		t.Fatalf("destination peak = %d, want 4", got)
+	}
+}
+
+func TestLimitToJobsIgnoredWhenTheEnvironmentSetTheLimit(t *testing.T) {
+	tracker := newConcurrencyTracker(3, true, logOff, io.Discard)
+	tracker.limitToJobs(64)
+	if got := tracker.stats().Destination.Limit; got != 3 {
+		t.Fatalf("destination limit = %d, want the environment's 3", got)
+	}
+
+	// Non-positive jobs values leave the limit alone.
+	unset := newConcurrencyTracker(0, false, logOff, io.Discard)
+	unset.limitToJobs(0)
+	unset.limitToJobs(-1)
+	if got := unset.stats().Destination.Limit; got != 0 {
+		t.Fatalf("destination limit = %d, want 0", got)
+	}
+}
+
+func TestQueuedRequestRespectsContextCancellation(t *testing.T) {
+	inner := newBlockingTransport(http.StatusCreated)
+	defer close(inner.release)
+	tracker := testTracker(t, 1)
+	rt := wrapConcurrency(inner, RoleDestination, tracker)
+
+	// Occupy the only slot.
+	go func() {
+		resp, err := rt.RoundTrip(request(t, context.Background(), http.MethodPut, "https://registry.test/v2/foo/blobs/uploads/1"))
+		if err == nil {
+			resp.Body.Close()
+		}
+	}()
+	<-inner.entered
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var queued atomic.Bool
+	errCh := make(chan error, 1)
+	go func() {
+		queued.Store(true)
+		_, err := rt.RoundTrip(request(t, ctx, http.MethodPut, "https://registry.test/v2/foo/blobs/uploads/2"))
+		errCh <- err
+	}()
+	waitFor(t, "the second request to queue", func() bool {
+		return queued.Load() && tracker.stats().Destination.Blocked > 0
+	})
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Fatalf("queued request error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("cancelling the context did not unblock the queued request")
+	}
+	stats := tracker.stats()
+	if stats.Destination.Total != 1 {
+		t.Fatalf("destination total = %d, want 1 (a cancelled request never went out)", stats.Destination.Total)
+	}
+	if stats.Destination.InFlight != 1 {
+		t.Fatalf("destination in-flight = %d, want 1 (the cancelled request must not leak a slot)", stats.Destination.InFlight)
+	}
+}
+
+func TestSlotIsReleasedOnTransportError(t *testing.T) {
+	tracker := testTracker(t, 1)
+	rt := wrapConcurrency(roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return nil, io.ErrUnexpectedEOF
+	}), RoleDestination, tracker)
+
+	if _, err := rt.RoundTrip(request(t, context.Background(), http.MethodPut, "https://registry.test/v2/")); err == nil {
+		t.Fatalf("expected the inner error to be returned")
+	}
+	if got := tracker.stats().Destination.InFlight; got != 0 {
+		t.Fatalf("in-flight after a failed round trip = %d, want 0", got)
+	}
+}
+
+func TestRolePoolSelection(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodHead, "", http.MethodPut} {
+		if got := RoleDestination.pool(method); got != poolDestination {
+			t.Errorf("RoleDestination.pool(%q) = %v, want destination", method, got)
+		}
+		if got := RoleSource.pool(method); got != poolSource {
+			t.Errorf("RoleSource.pool(%q) = %v, want source", method, got)
+		}
+	}
+	for _, method := range []string{http.MethodGet, http.MethodHead, ""} {
+		if got := RoleAuto.pool(method); got != poolSource {
+			t.Errorf("RoleAuto.pool(%q) = %v, want source", method, got)
+		}
+	}
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		if got := RoleAuto.pool(method); got != poolDestination {
+			t.Errorf("RoleAuto.pool(%q) = %v, want destination", method, got)
+		}
+	}
+}
+
+func TestRequestTargetDropsQueryString(t *testing.T) {
+	req := request(t, context.Background(), http.MethodGet, "https://registry.test/v2/foo/blobs/sha256:aa?X-Amz-Signature=secret")
+	if got, want := requestTarget(req.URL), "https://registry.test/v2/foo/blobs/sha256:aa"; got != want {
+		t.Fatalf("requestTarget = %q, want %q", got, want)
+	}
+	if got := requestTarget(nil); got != "" {
+		t.Fatalf("requestTarget(nil) = %q, want empty", got)
+	}
+}
+
+func TestMaxConcurrentRequestsEnv(t *testing.T) {
+	tests := []struct {
+		value    string
+		want     int
+		wantFrom bool
+	}{
+		{value: "", want: 0, wantFrom: false},
+		{value: "16", want: 16, wantFrom: true},
+		{value: " 8 ", want: 8, wantFrom: true},
+		{value: "0", want: 0, wantFrom: true},
+		{value: "-4", want: 0, wantFrom: true},
+		{value: "lots", want: 0, wantFrom: false},
+	}
+	for _, tc := range tests {
+		t.Setenv(EnvMaxConcurrentRequests, tc.value)
+		got, gotFrom := maxConcurrentRequestsEnv()
+		if got != tc.want || gotFrom != tc.wantFrom {
+			t.Errorf("maxConcurrentRequestsEnv(%q) = %d, %v; want %d, %v", tc.value, got, gotFrom, tc.want, tc.wantFrom)
+		}
+	}
+}
+
+func TestConcurrencyLogModeEnv(t *testing.T) {
+	tests := []struct {
+		value string
+		want  logMode
+	}{
+		{value: "", want: logOff},
+		{value: "off", want: logOff},
+		{value: "0", want: logOff},
+		{value: "false", want: logOff},
+		{value: "summary", want: logSummary},
+		{value: "SUMMARY", want: logSummary},
+		{value: "1", want: logRequests},
+		{value: "true", want: logRequests},
+		{value: "requests", want: logRequests},
+		{value: "typo", want: logRequests},
+	}
+	for _, tc := range tests {
+		t.Setenv(EnvLogConcurrency, tc.value)
+		if got := concurrencyLogMode(); got != tc.want {
+			t.Errorf("concurrencyLogMode(%q) = %v, want %v", tc.value, got, tc.want)
+		}
+	}
+}
+
+func TestSummary(t *testing.T) {
+	if got := newConcurrencyTracker(0, false, logOff, io.Discard).summary(); got != "" {
+		t.Fatalf("summary with logging off = %q, want empty", got)
+	}
+
+	tracker := newConcurrencyTracker(2, true, logSummary, io.Discard)
+	if got := tracker.summary(); got != "" {
+		t.Fatalf("summary without any request = %q, want empty", got)
+	}
+
+	destination := wrapConcurrency(respondingTransport(http.StatusCreated, ""), RoleDestination, tracker)
+	drain(t, destination, http.MethodPut, "https://registry.test/v2/foo/manifests/latest", 3)
+	source := wrapConcurrency(respondingTransport(http.StatusOK, "blob"), RoleSource, tracker)
+	drain(t, source, http.MethodGet, "https://base.test/v2/foo/blobs/sha256:aa", 1)
+
+	got := tracker.summary()
+	for _, want := range []string{"registry requests:", "3 to destination (peak", "/2 concurrent", "1 from sources (peak 1 concurrent)"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("summary = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+func TestLoggingEveryRequest(t *testing.T) {
+	var out strings.Builder
+	tracker := newConcurrencyTracker(4, true, logRequests, &out)
+	rt := wrapConcurrency(respondingTransport(http.StatusCreated, ""), RoleDestination, tracker)
+
+	resp, err := rt.RoundTrip(request(t, context.Background(), http.MethodPut, "https://registry.test/v2/foo/blobs/uploads/1?state=secret"))
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	resp.Body.Close()
+
+	line := out.String()
+	for _, want := range []string{"img registry:", "destination in-flight=1/4", "peak=1", "total=1", "PUT https://registry.test/v2/foo/blobs/uploads/1"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("log line = %q, want it to contain %q", line, want)
+		}
+	}
+	if strings.Contains(line, "secret") {
+		t.Fatalf("log line leaks the query string: %q", line)
+	}
+}

--- a/img_tool/pkg/registryopts/registryopts.go
+++ b/img_tool/pkg/registryopts/registryopts.go
@@ -2,7 +2,8 @@
 // the img tool enforces for every registry operation: multi-keychain
 // authentication, a patient retry backoff, a transport routed through the
 // oci-distribution-gateway (when one is configured) that honors a registry's
-// Retry-After header, and a default concurrency.
+// Retry-After header and accounts for how many requests are in flight, and a
+// default concurrency.
 //
 // Callers assemble options through a small builder so the enforced defaults live
 // in one place while still allowing per-call additions and overrides:
@@ -124,6 +125,12 @@ func NameOptions(opts ...name.Option) []name.Option {
 // of concurrent registry requests modest so operations are less likely to trip
 // server-side rate limits (HTTP 429). Commands may override it (for example
 // `img deploy` defaults to GOMAXPROCS); users override it with --jobs.
+//
+// On its own, jobs is a per-fan-out limit rather than a total: go-cr applies it
+// again inside every push (once for a manifest's children, once more for an
+// image's layers), so the requests actually in flight are the product of the
+// nested limits. Commands pass their jobs value to [LimitConcurrencyToJobs] to
+// make it the total for the destination registry.
 const DefaultJobs = 4
 
 const (
@@ -221,15 +228,31 @@ func (o *Options) Remote() []remote.Option {
 }
 
 // Transport builds the base transport for the given gateway mode: gateway
-// routing (when configured) wrapped to honor Retry-After. Commands that share
-// one transport across several pushers (e.g. `img deploy`) can build it once
-// here and pass it to [Options.WithTransport].
+// routing (when configured), instrumented for concurrency and wrapped to honor
+// Retry-After. Commands that share one transport across several pushers (e.g.
+// `img deploy`) can build it once here and pass it to [Options.WithTransport].
 func Transport(mode gateway.Mode) (http.RoundTripper, error) {
 	base, err := gateway.WrapTransport(BaseTransport(), mode)
 	if err != nil {
 		return nil, err
 	}
-	return WrapRetryAfter(base), nil
+	role := RoleSource
+	if mode == gateway.ModePush {
+		role = RoleDestination
+	}
+	// Concurrency accounting sits below Retry-After pacing (so a rate-limit wait
+	// does not occupy a slot) and above the gateway (so requests are logged
+	// against the registry they address, not the gateway).
+	return WrapRetryAfter(WrapConcurrency(base, role)), nil
+}
+
+// DirectTransport builds a transport that talks to registries without gateway
+// routing: concurrency accounting plus Retry-After pacing over [BaseTransport].
+// Server-side components that must reach the registry themselves (the BES syncer,
+// the OCI ref-graph sync) use it instead of [Transport]. It carries both
+// directions, so its requests are attributed by method ([RoleAuto]).
+func DirectTransport() http.RoundTripper {
+	return WrapRetryAfter(WrapConcurrency(BaseTransport(), RoleAuto))
 }
 
 // BaseTransport returns the transport every registry request starts from:

--- a/img_tool/pkg/registryopts/registryopts_test.go
+++ b/img_tool/pkg/registryopts/registryopts_test.go
@@ -98,8 +98,22 @@ func TestTransportBuilds(t *testing.T) {
 	if rt == nil {
 		t.Fatalf("Transport returned nil")
 	}
-	if _, ok := rt.(*retryAfterTransport); !ok {
+	paced, ok := rt.(*retryAfterTransport)
+	if !ok {
 		t.Fatalf("Transport = %T, want *retryAfterTransport", rt)
+	}
+	// Concurrency accounting sits directly below the Retry-After pacing, so a
+	// rate-limit wait does not occupy a slot.
+	if _, ok := paced.inner.(*concurrencyTransport); !ok {
+		t.Fatalf("Transport inner = %T, want *concurrencyTransport", paced.inner)
+	}
+
+	direct, ok := DirectTransport().(*retryAfterTransport)
+	if !ok {
+		t.Fatalf("DirectTransport = %T, want *retryAfterTransport", DirectTransport())
+	}
+	if _, ok := direct.inner.(*concurrencyTransport); !ok {
+		t.Fatalf("DirectTransport inner = %T, want *concurrencyTransport", direct.inner)
 	}
 }
 

--- a/img_tool/pkg/serve/bes/syncer/syncer.go
+++ b/img_tool/pkg/serve/bes/syncer/syncer.go
@@ -219,7 +219,7 @@ func (s *Syncer) commitRegistryTag(ctx context.Context, op api.IndexedRegistryTa
 		return fmt.Errorf("invalid repository %s: %w", baseReference, err)
 	}
 	remoteOpts := registryopts.Default().
-		WithTransport(registryopts.WrapRetryAfter(registryopts.BaseTransport())).
+		WithTransport(registryopts.DirectTransport()).
 		With(remote.WithContext(ctx)).
 		Remote()
 
@@ -269,7 +269,7 @@ func (s *Syncer) commitOne(ctx context.Context, pushOp api.IndexedPushDeployOper
 	}
 
 	remoteOpts := registryopts.Default().
-		WithTransport(registryopts.WrapRetryAfter(registryopts.BaseTransport())).
+		WithTransport(registryopts.DirectTransport()).
 		With(remote.WithContext(ctx)).
 		Remote()
 
@@ -1125,7 +1125,7 @@ func (l *remoteStreamingLayer) Compressed() (io.ReadCloser, error) {
 			attempts = append(attempts, fmt.Sprintf("%s/%s: %v", source.Registry, source.Repository, err))
 			continue
 		}
-		layer, err := remote.Layer(ref, registryopts.Default().WithTransport(registryopts.WrapRetryAfter(registryopts.BaseTransport())).Remote()...)
+		layer, err := remote.Layer(ref, registryopts.Default().WithTransport(registryopts.DirectTransport()).Remote()...)
 		if err != nil {
 			attempts = append(attempts, fmt.Sprintf("%s: %v", ref, err))
 			continue


### PR DESCRIPTION

--jobs was a per-fan-out limit, not a total. rules_img's PushAll limits
concurrent Push calls to jobs, and go-containerregistry then applies jobs
again inside every push -- once for a manifest's children, once more for an
image's layers -- so the requests actually in flight are the product of the
nested limits. In the persistent worker (the Bazel default) that product is
multiplied again by the number of work requests handled at once. Pushing 3
four-platform, six-layer images with --jobs 16 peaked at 47 concurrent
requests against a live registry.

Add a concurrency middleware in registryopts and wire it into every
transport the package builds, which is the one point all registry requests
pass through exactly once. Commands that own a --jobs flag (img deploy in
both its one-shot and worker paths, and img push manifest) pass it to
LimitConcurrencyToJobs, so jobs becomes the ceiling on requests in flight to
the destination registry. The nested errgroups still generate the work; it
queues at the transport instead of hitting the wire. The same push now peaks
at exactly 16.

Traffic is split into two pools by transport role. The destination pool
covers the push transport -- uploads plus the existence checks that precede
them -- and is what --jobs bounds. The source pool covers base-image reads,
img pull and referrer lookups; it is counted but never throttled, since
throttling it would only slow data on its way into the img tool. Keeping
downloads unbounded also makes the limit deadlock-free: the destination pool
releases its slot when the round trip returns (an upload's request body is
streamed during the round trip, so that is the whole upload), so a
destination request never holds a slot while another one has to finish, and
a layer streamed out of a source registry opens its read before the upload
that consumes it.

The limit is resizable in place, so commands may apply it after transports
are built. Two environment variables come along for debugging:

  IMG_REGISTRY_MAX_CONCURRENT_REQUESTS  override the destination limit
  IMG_REGISTRY_LOG_CONCURRENCY          requests | summary | off

"requests" logs every request as it is admitted with its in-flight and peak
counts, "summary" prints one line at the end; img --verbose implies
"requests". Counting itself is always on.

