### PR TITLE
fix(signer): release the signer plugins as prebuilt-only modules

### DIFF
--- a/.bcr/modules/rules_img_signer_notation/presubmit.yml
+++ b/.bcr/modules/rules_img_signer_notation/presubmit.yml
@@ -9,4 +9,4 @@ bcr_test_module:
       platform: ${{ platform }}
       bazel: ${{ bazel }}
       test_targets:
-        - "//..."
+        - "//:all"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -38,25 +38,46 @@ filegroup(
     visibility = ["//img/private/release:__subpackages__"],
 )
 
-# Source files for the signer plugin modules, packaged into the offline BCR so
-# `img deploy` signing can be exercised end-to-end (see //e2e/sbom). These are
-# their own Bazel modules (own MODULE.bazel); their packages are listed in
-# --deleted_packages so the root module can glob their source without building
-# them here. The bazel-* convenience symlinks (created when a module is built
-# standalone) are excluded via .bazelignore.
+# Source files of the signer plugin modules, packaged into their release archives
+# and into the offline BCR the e2e tests consume (see //e2e/sbom). Allowlists: a
+# released plugin resolves to a prebuilt binary, so its archive must contain no Go
+# sources and no BUILD file loading @rules_go/@gazelle — a published module has
+# only its own bazel_deps to resolve labels from.
+#
+# Every entry must be a glob pattern with allow_empty = True: this BUILD file also
+# ships in the rules_img release archive, which has no modules/ directory. The
+# completeness check lives in source_bundle(required_files) instead.
+# buildifier: disable=constant-glob
 filegroup(
     name = "signer_cosign_source_files",
     srcs = glob(
-        ["modules/rules_img_signer_cosign/**"],
+        [
+            "modules/rules_img_signer_cosign/BUILD.bazel",
+            "modules/rules_img_signer_cosign/MODULE.bazel",
+            "modules/rules_img_signer_cosign/README.md",
+            "modules/rules_img_signer_cosign/prebuilt_lockfile.json",
+            "modules/rules_img_signer_cosign/cli/**",
+            "modules/rules_img_signer_cosign/cosign/**",
+            "modules/rules_img_signer_cosign/prebuilt/**",
+        ],
         allow_empty = True,
     ),
     visibility = ["//img/private/release:__subpackages__"],
 )
 
+# buildifier: disable=constant-glob
 filegroup(
     name = "signer_notation_source_files",
     srcs = glob(
-        ["modules/rules_img_signer_notation/**"],
+        [
+            "modules/rules_img_signer_notation/BUILD.bazel",
+            "modules/rules_img_signer_notation/MODULE.bazel",
+            "modules/rules_img_signer_notation/README.md",
+            "modules/rules_img_signer_notation/prebuilt_lockfile.json",
+            "modules/rules_img_signer_notation/cli/**",
+            "modules/rules_img_signer_notation/notation/**",
+            "modules/rules_img_signer_notation/prebuilt/**",
+        ],
         allow_empty = True,
     ),
     visibility = ["//img/private/release:__subpackages__"],
@@ -65,5 +86,6 @@ filegroup(
 exports_files([
     ".bcr/metadata.template.json",
     "modules/rules_img_signer_cosign/MODULE.bazel",
+    "modules/rules_img_signer_notation/MODULE.bazel",
     "prebuilt_lockfile.json",
 ])

--- a/e2e/sbom/BUILD.bazel
+++ b/e2e/sbom/BUILD.bazel
@@ -111,5 +111,7 @@ build_test(
         "//:push_image",
         "//:sbom_layer",
         "//:sbom_manifest",
+        "@rules_img_signer_cosign",
+        "@rules_img_signer_notation",
     ],
 )

--- a/img/private/release/BUILD.bazel
+++ b/img/private/release/BUILD.bazel
@@ -95,10 +95,25 @@ versioned_filename_info(
 # source, so a consumer (the e2e scratch workspace, or a real user of the
 # published module) downloads the prebuilt plugin instead of building it from
 # source. source_bundle also injects a cleaned MODULE.bazel (with the
-# REMOVE_BEFORE_RELEASE sections stripped) so the released module no longer
-# carries the build-from-source gazelle setup that is broken outside this repo.
+# REMOVE_BEFORE_RELEASE sections stripped), so the released module is
+# prebuilt-only: no Go sources, no rules_go, no gazelle.
 # They are versioned independently of rules_img, so pin their BCR versions to
 # match module(version = ...) in each MODULE.bazel.
+
+# Files a released plugin module must contain, relative to its module root.
+# //:signer_*_source_files has to glob with allow_empty = True, so this is what
+# turns a dropped release file into a build failure.
+SIGNER_REQUIRED_FILES = [
+    "BUILD.bazel",
+    "MODULE.bazel",
+    "README.md",
+    "prebuilt_lockfile.json",
+    "cli/BUILD.bazel",
+    "cli/cli.bzl",
+    "prebuilt/BUILD.bazel",
+    "prebuilt/prebuilt.bzl",
+]
+
 version(
     name = "signer_cosign_version",
     tags = ["manual"],
@@ -116,6 +131,7 @@ source_bundle(
     srcs = ["//:signer_cosign_source_files"],
     module_bazel = "//img/private/release/module_bazel_release_prep:cleaned_cosign_module",
     overrides = ["@rules_img_internal_tools//release:signer_cosign_prebuilt"],
+    required_files = SIGNER_REQUIRED_FILES + ["cosign/BUILD.bazel"],
     strip_prefix = "modules/rules_img_signer_cosign/",
     tags = ["manual"],
 )
@@ -132,7 +148,9 @@ pkg_tar(
 source_bundle(
     name = "signer_notation_srcs",
     srcs = ["//:signer_notation_source_files"],
+    module_bazel = "//img/private/release/module_bazel_release_prep:cleaned_notation_module",
     overrides = ["@rules_img_internal_tools//release:signer_notation_prebuilt"],
+    required_files = SIGNER_REQUIRED_FILES + ["notation/BUILD.bazel"],
     strip_prefix = "modules/rules_img_signer_notation/",
     tags = ["manual"],
 )

--- a/img/private/release/defs.bzl
+++ b/img/private/release/defs.bzl
@@ -329,6 +329,15 @@ def _source_bundle_impl(ctx):
         dest_src_map = stripped_dest_src
         attributes = stripped_attributes
 
+    # The srcs come from globs that must tolerate an empty match, so a pattern
+    # that stops matching would silently drop files from the archive.
+    missing = [dest for dest in ctx.attr.required_files if dest not in dest_src_map]
+    if missing:
+        fail("source_bundle {} would package an incomplete module: missing {}".format(
+            ctx.label,
+            ", ".join(missing),
+        ))
+
     return [
         DefaultInfo(files = depset(dest_src_map.values())),
         PackageFilesInfo(attributes = attributes, dest_src_map = dest_src_map),
@@ -345,6 +354,9 @@ source_bundle = rule(
         "module_bazel": attr.label(
             allow_single_file = True,
             doc = "Optional MODULE.bazel to substitute in the bundle (e.g. a release-cleaned version).",
+        ),
+        "required_files": attr.string_list(
+            doc = "Destinations (relative to the packaged module root) that must be present in the bundle.",
         ),
     },
 )

--- a/img/private/release/module_bazel_release_prep/BUILD.bazel
+++ b/img/private/release/module_bazel_release_prep/BUILD.bazel
@@ -17,6 +17,12 @@ clean_module_bazel(
     visibility = ["//img/private/release:__subpackages__"],
 )
 
+clean_module_bazel(
+    name = "cleaned_notation_module",
+    src = "//:modules/rules_img_signer_notation/MODULE.bazel",
+    visibility = ["//img/private/release:__subpackages__"],
+)
+
 bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],

--- a/modules/rules_img_internal_tools/integration_test_runner/integration_test_runner.go
+++ b/modules/rules_img_internal_tools/integration_test_runner/integration_test_runner.go
@@ -24,19 +24,43 @@ var (
 
 const signingEnvMarker = "RULES_IMG_E2E_SIGNING"
 
+// signerModules are the independently released signer plugin modules that the
+// signing-capable e2e workspaces depend on.
+var signerModules = []string{"rules_img_signer_cosign", "rules_img_signer_notation"}
+
 type commandLine struct {
 	name string
 	args []string
 }
 
-func prepareWorkspace(workspaceDir, sourceDir, mainRegistry string) error {
-	localBCR, err := runfiles.Rlocation("_main/img/private/release/bcr.local")
+// offlineReleaseArtifacts locates the offline BCR (every module's release
+// archive plus its extracted source) and the distdir holding the prebuilt
+// binaries the released modules download.
+func offlineReleaseArtifacts() (localBCR string, distdir string, err error) {
+	localBCR, err = runfiles.Rlocation("_main/img/private/release/bcr.local")
 	if err != nil {
-		return fmt.Errorf("failed to find local bcr: %v", err)
+		return "", "", fmt.Errorf("failed to find local bcr: %v", err)
 	}
-	distdir, err := runfiles.Rlocation("_main/img/private/release/airgapped.distdir")
+	distdir, err = runfiles.Rlocation("_main/img/private/release/airgapped.distdir")
 	if err != nil {
-		return fmt.Errorf("failed to find distdir: %v", err)
+		return "", "", fmt.Errorf("failed to find distdir: %v", err)
+	}
+	return localBCR, distdir, nil
+}
+
+// localBCRURL renders a local BCR directory as a --registry file:// URL.
+func localBCRURL(localBCR string) string {
+	path := filepath.ToSlash(localBCR)
+	if runtime.GOOS == "windows" {
+		return "file:///" + path
+	}
+	return "file://" + path
+}
+
+func prepareWorkspace(workspaceDir, sourceDir, mainRegistry string) error {
+	localBCR, distdir, err := offlineReleaseArtifacts()
+	if err != nil {
+		return err
 	}
 	bazelDepOverride, err := runfiles.Rlocation("_main/img/private/release/bcr_local_module_rules_img.bazel_dep")
 	if err != nil {
@@ -152,12 +176,7 @@ func prepareWorkspace(workspaceDir, sourceDir, mainRegistry string) error {
 			return fmt.Errorf("failed to write patched module file: %v", err)
 		}
 	}
-	localBCRUrlPath := filepath.ToSlash(localBCR)
-	if runtime.GOOS == "windows" {
-		localBCRUrlPath = "file:///" + localBCRUrlPath
-	} else {
-		localBCRUrlPath = "file://" + localBCRUrlPath
-	}
+	localBCRUrlPath := localBCRURL(localBCR)
 
 	var bazelrc string
 	if isWorkspaceMode {
@@ -199,14 +218,17 @@ func outputUserRoot() (string, func() error) {
 	}
 }
 
-func startupFlags() ([]string, func() error) {
+// startupFlags returns the Bazel startup flags for a run in a prepared
+// workspace, plus the rc file CI injects to share its remote cache.
+func startupFlags(bazelrcs ...string) ([]string, func() error) {
 	flags := []string{"--nosystem_rc", "--nohome_rc"}
 	root, cleanupRoot := outputUserRoot()
 	if len(root) > 0 {
 		flags = append(flags, "--output_user_root="+root)
 	}
-	flags = append(flags, "--bazelrc="+filepath.Join(".bazelrc"))
-	flags = append(flags, "--bazelrc="+filepath.Join(".bazelrc.generated"))
+	for _, bazelrc := range bazelrcs {
+		flags = append(flags, "--bazelrc="+bazelrc)
+	}
 	if injectedBazelrc := os.Getenv("BAZEL_INTEGRATION_TEST_INJECT_BAZELRC"); injectedBazelrc != "" {
 		flags = append(flags, "--bazelrc="+injectedBazelrc)
 	}
@@ -258,6 +280,17 @@ func runBazelCommands(bazel, workspaceDir string, startup []string) error {
 	// ensure all referenced BUILD files are included in the release tar
 	if err := runBazel(bazel, workspaceDir, startup, nil, "query", "query", "@rules_img//..."); err != nil {
 		return err
+	}
+	// Same check for the released signer plugin modules: they ship prebuilt
+	// binaries and no Go sources, and neither this workspace (in released mode)
+	// nor a real consumer provides rules_go/gazelle.
+	if os.Getenv(signingEnvMarker) == "1" {
+		for _, module := range signerModules {
+			label := "@" + module + "//..."
+			if err := runBazel(bazel, workspaceDir, startup, nil, "query "+module, "query", label); err != nil {
+				return err
+			}
+		}
 	}
 	if err := runBazel(bazel, workspaceDir, startup, nil, "test", append([]string{"test", "//..."}, metadataFlag...)...); err != nil {
 		return err
@@ -360,7 +393,7 @@ func run() int {
 		return 1
 	}
 
-	startup, cleanupRoot := startupFlags()
+	startup, cleanupRoot := startupFlags(".bazelrc", ".bazelrc.generated")
 	defer cleanupRoot()
 
 	// Shut down Bazel at the end to conserve memory.
@@ -373,12 +406,96 @@ func run() int {
 		return 1
 	}
 
+	if err := bcrPresubmitPhase(bazel); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		return 1
+	}
+
 	if err := deployPhase(bazel, workspaceDir, startup, mainReg.hostPort); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		return 1
 	}
 
 	return 0
+}
+
+// bcrPresubmitPhase reproduces the Bazel Central Registry presubmit for each
+// signer plugin module, running it against the released module source extracted
+// into the offline BCR. Every other build in this repository sees the plugin
+// through its in-repo MODULE.bazel (with the rules_go/gazelle setup the release
+// strips) and as a dependency rather than as the root module, so this is the
+// only place a broken release archive shows up before the tag is pushed.
+func bcrPresubmitPhase(bazel string) error {
+	if os.Getenv(signingEnvMarker) != "1" {
+		return nil
+	}
+	localBCR, distdir, err := offlineReleaseArtifacts()
+	if err != nil {
+		return err
+	}
+	for _, module := range signerModules {
+		source, err := releasedModuleSource(localBCR, module)
+		if err != nil {
+			return err
+		}
+		if err := runBCRPresubmit(bazel, module, source, localBCR, distdir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// releasedModuleSource returns the extracted release archive of module inside the
+// offline BCR.
+func releasedModuleSource(localBCR, module string) (string, error) {
+	moduleDir := filepath.Join(localBCR, "contents", module)
+	entries, err := os.ReadDir(moduleDir)
+	if err != nil {
+		return "", fmt.Errorf("listing versions of %s in the offline BCR: %v", module, err)
+	}
+	var versions []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			versions = append(versions, entry.Name())
+		}
+	}
+	if len(versions) != 1 {
+		return "", fmt.Errorf("expected exactly one version of %s in the offline BCR, got %v", module, versions)
+	}
+	return filepath.Join(moduleDir, versions[0], "src"), nil
+}
+
+// runBCRPresubmit copies the released module source out of the (read-only) BCR
+// tree and runs the presubmit's test target in it.
+func runBCRPresubmit(bazel, module, source, localBCR, distdir string) error {
+	workspaceDir, err := os.MkdirTemp("", "bcr-presubmit-")
+	if err != nil {
+		return fmt.Errorf("creating workspace for the %s BCR presubmit: %v", module, err)
+	}
+	defer os.RemoveAll(workspaceDir)
+
+	if err := copyFSWithSymlinks(workspaceDir, source); err != nil {
+		return fmt.Errorf("copying released %s source: %v", module, err)
+	}
+
+	// The distdir serves the prebuilt plugin binary the released module
+	// downloads, so this runs before the GitHub release exists.
+	bazelrc := fmt.Sprintf(`common --registry=%s --registry=https://bcr.bazel.build/
+common --distdir=%s
+`, localBCRURL(localBCR), filepath.ToSlash(distdir))
+	if err := os.WriteFile(filepath.Join(workspaceDir, ".bazelrc.generated"), []byte(bazelrc), 0o644); err != nil {
+		return fmt.Errorf("writing bazelrc for the %s BCR presubmit: %v", module, err)
+	}
+
+	startup, cleanupRoot := startupFlags(".bazelrc.generated")
+	defer cleanupRoot()
+	// Shut down this server before the next one starts, to conserve memory.
+	defer func() {
+		_ = runBazel(bazel, workspaceDir, startup, nil, "shutdown", "shutdown")
+	}()
+
+	// Keep in sync with test_targets in .bcr/modules/<module>/presubmit.yml.
+	return runBazel(bazel, workspaceDir, startup, nil, "bcr presubmit "+module, "test", "//:all")
 }
 
 // deployPhase runs `bazel run //:push` against the local registry, verifies the

--- a/modules/rules_img_signer_cosign/BUILD.bazel
+++ b/modules/rules_img_signer_cosign/BUILD.bazel
@@ -11,10 +11,10 @@ alias(
 
 exports_files(["prebuilt_lockfile.json"])
 
-# Compile the source-built plugin binary under `bazel test //...` so the module's
-# standalone CI check verifies the whole build graph even though it has few
-# go_test targets.
+# The only test target in the released module, and the one the BCR presubmit runs
+# (`//:all`) — so it must go through the alias rather than reference //cmd/cosign
+# directly, which is not part of the release archive.
 build_test(
     name = "build_test",
-    targets = ["//cmd/cosign"],
+    targets = [":rules_img_signer_cosign"],
 )

--- a/modules/rules_img_signer_cosign/MODULE.bazel
+++ b/modules/rules_img_signer_cosign/MODULE.bazel
@@ -6,7 +6,33 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "platforms", version = "1.0.0")
 
+# Resolve the plugin binary: released versions ship a populated
+# prebuilt_lockfile.json and download the prebuilt binary.
+prebuilt = use_extension("//prebuilt:prebuilt.bzl", "prebuilt_signer")
+prebuilt.from_file(
+    basename = "cosign",
+    lockfile = "//:prebuilt_lockfile.json",
+)
+use_repo(prebuilt, "rules_img_signer_cosign_resolved")
+
+# Download the official upstream cosign CLI (kept in sync with the sigstore
+# libraries in go.mod) so integration tests can verify signatures with the real
+# tool. Exposed as @rules_img_signer_cosign//cosign:cosign.
+cosign_cli = use_extension("//cli:cli.bzl", "cosign_cli")
+cosign_cli.from_file(lockfile = "//cli:cosign_cli.lock.json")
+use_repo(
+    cosign_cli,
+    "cosign_cli_darwin_amd64",
+    "cosign_cli_darwin_arm64",
+    "cosign_cli_linux_amd64",
+    "cosign_cli_linux_arm64",
+    "cosign_cli_windows_amd64",
+)
+
 ### REMOVE_BEFORE_RELEASE_START
+
+# Stripped when the release archive is produced: the released module ships
+# prebuilt binaries and no Go sources, so it must not depend on rules_go/gazelle.
 
 bazel_dep(name = "rules_go", version = "0.62.0")
 bazel_dep(name = "gazelle", version = "0.52.2")
@@ -29,6 +55,9 @@ use_repo(
     "org_golang_google_protobuf",
 )
 
+# Used whenever prebuilt_lockfile.json is still the empty list `[]`.
+prebuilt.source(target = "//cmd/cosign")
+
 # NOTE: building this module *from source* requires disabling gazelle proto
 # generation for a couple of sigstore transitive deps whose .proto sources do
 # not build cleanly. gazelle_override is a ROOT-module-only tag, so it cannot be
@@ -46,27 +75,3 @@ use_repo(
 #   )
 
 ### REMOVE_BEFORE_RELEASE_END
-
-# Resolve the plugin binary: prebuilt download for released versions, or the
-# source-built go_binary for any other commit / local / git_override build.
-prebuilt = use_extension("//prebuilt:prebuilt.bzl", "prebuilt_signer")
-prebuilt.from_file(
-    basename = "cosign",
-    lockfile = "//:prebuilt_lockfile.json",
-)
-prebuilt.source(target = "//cmd/cosign")
-use_repo(prebuilt, "rules_img_signer_cosign_resolved")
-
-# Download the official upstream cosign CLI (kept in sync with the sigstore
-# libraries in go.mod) so integration tests can verify signatures with the real
-# tool. Exposed as @rules_img_signer_cosign//cosign:cosign.
-cosign_cli = use_extension("//cli:cli.bzl", "cosign_cli")
-cosign_cli.from_file(lockfile = "//cli:cosign_cli.lock.json")
-use_repo(
-    cosign_cli,
-    "cosign_cli_darwin_amd64",
-    "cosign_cli_darwin_arm64",
-    "cosign_cli_linux_amd64",
-    "cosign_cli_linux_arm64",
-    "cosign_cli_windows_amd64",
-)

--- a/modules/rules_img_signer_cosign/README.md
+++ b/modules/rules_img_signer_cosign/README.md
@@ -34,11 +34,12 @@ signing_config(
 ```
 
 `@rules_img_signer_cosign` resolves to a prebuilt binary for released versions
-(zero configuration), or a source-built `go_binary` otherwise. The `args` list
-holds the plugin flags documented below; `img deploy` invokes the plugin as
-`<tool> sign-oci-artifact <args...>` and passes the ambient process environment
-through to it (so `$COSIGN_PASSWORD`, `$SIGSTORE_ID_TOKEN`, `$SIGSTORE_*`, etc.
-reach the plugin).
+(zero configuration — the published module needs no Go toolchain), or a
+source-built `go_binary` when the module comes from a checkout of the rules_img
+repository. The `args` list holds the plugin flags documented below; `img deploy`
+invokes the plugin as `<tool> sign-oci-artifact <args...>` and passes the ambient
+process environment through to it (so `$COSIGN_PASSWORD`, `$SIGSTORE_ID_TOKEN`,
+`$SIGSTORE_*`, etc. reach the plugin).
 
 ### Common configurations
 
@@ -366,10 +367,17 @@ Deliberately **not** supported, with the reason:
 
 ## Building from source (git_override / local path)
 
+Released versions need none of this: the published archive contains only the
+Starlark needed to download the prebuilt plugin binary — no Go sources, no
+`rules_go`, no `gazelle`, no Go toolchain. Building from source therefore means
+building from a checkout of the [rules_img
+repository](https://github.com/bazel-contrib/rules_img) (`git_override` or a
+local path), not from the BCR archive.
+
 `sigstore-go` pulls proto-heavy transitive dependencies whose `.proto` sources
 do not build cleanly under gazelle's proto generation. Because `gazelle_override`
-is a **root-module-only** tag, a downstream *source* build (e.g. via
-`git_override`) requires adding the following to your **root** `MODULE.bazel`:
+is a **root-module-only** tag, such a source build requires adding the following
+to your **root** `MODULE.bazel`:
 
 ```python
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
@@ -382,5 +390,3 @@ go_deps.gazelle_override(
     path = "github.com/google/certificate-transparency-go",
 )
 ```
-
-Released versions ship a prebuilt binary and need none of this.

--- a/modules/rules_img_signer_cosign/prebuilt/prebuilt.bzl
+++ b/modules/rules_img_signer_cosign/prebuilt/prebuilt.bzl
@@ -5,6 +5,10 @@ This is self-contained: it does not depend on rules_img, so the module can be
 built and released independently. The decision is driven by
 `prebuilt_lockfile.json`, which is an empty list `[]` in source and is overwritten
 with per-platform digests when the release archive is produced.
+
+A released module declares no `source()` tag: its archive contains no Go sources,
+so unsupported platforms report that instead of referencing a `//cmd/...` package
+that is not packaged.
 """
 
 _URL_DEFAULT = "https://github.com/bazel-contrib/rules_img/releases/download/{tag}/{basename}_{os}_{cpu}{dot}{ext}"
@@ -18,6 +22,7 @@ _OS_CONSTRAINT = {
 _CPU_CONSTRAINT = {
     "amd64": "@platforms//cpu:x86_64",
     "arm64": "@platforms//cpu:aarch64",
+    "s390x": "@platforms//cpu:s390x",
 }
 
 def _prebuilt_download_impl(rctx):
@@ -53,9 +58,24 @@ _prebuilt_download = repository_rule(
         "integrity": attr.string(mandatory = True),
         "basename": attr.string(mandatory = True),
         "os": attr.string(values = ["darwin", "linux", "windows"]),
-        "cpu": attr.string(values = ["amd64", "arm64"]),
+        "cpu": attr.string(values = ["amd64", "arm64", "s390x"]),
         "url_templates": attr.string_list(default = [_URL_DEFAULT]),
     },
+)
+
+_ALIAS_TEMPLATE = """\
+alias(
+    name = "binary",
+    actual = {actual},
+    visibility = ["//visibility:public"],
+)
+"""
+
+_NO_MATCH_ERROR = (
+    "no prebuilt {basename} signer plugin binary for this platform. " +
+    "Released versions of the plugin publish binaries for linux (x86_64, arm64, s390x), " +
+    "macOS (x86_64, arm64) and Windows (x86_64, arm64) only. To use it elsewhere, build the " +
+    "plugin from source with a git_override on github.com/bazel-contrib/rules_img."
 )
 
 def _resolved_hub_impl(rctx):
@@ -63,13 +83,7 @@ def _resolved_hub_impl(rctx):
     select_map = json.decode(rctx.attr.select_map)
     if not select_map:
         # No prebuilt for this version: alias straight to the source go_binary.
-        rctx.file("BUILD.bazel", """\
-alias(
-    name = "binary",
-    actual = "{source}",
-    visibility = ["//visibility:public"],
-)
-""".format(source = rctx.attr.source))
+        rctx.file("BUILD.bazel", _ALIAS_TEMPLATE.format(actual = '"{}"'.format(rctx.attr.source)))
         return
 
     config_settings = []
@@ -90,25 +104,31 @@ config_setting(
             cpu_constraint = _CPU_CONSTRAINT[cpu],
         ))
         arms[":is_{}".format(platform_key)] = "@{}//:binary".format(repo)
-    arms["//conditions:default"] = rctx.attr.source
 
-    rctx.file("BUILD.bazel", """\
-{config_settings}
-alias(
-    name = "binary",
-    actual = select({arms}),
-    visibility = ["//visibility:public"],
-)
-""".format(
+    extra_select_args = ""
+    if rctx.attr.source:
+        arms["//conditions:default"] = rctx.attr.source
+    else:
+        extra_select_args = '\n        no_match_error = "{}",'.format(
+            _NO_MATCH_ERROR.format(basename = rctx.attr.basename),
+        )
+
+    rctx.file("BUILD.bazel", "{config_settings}\n{alias}".format(
         config_settings = "\n".join(config_settings),
-        arms = json.encode_indent(arms, prefix = "        ", indent = "    "),
+        alias = _ALIAS_TEMPLATE.format(actual = "select(\n        {arms},{extra}\n    )".format(
+            arms = json.encode_indent(arms, prefix = "        ", indent = "    "),
+            extra = extra_select_args,
+        )),
     ))
 
 _resolved_hub = repository_rule(
     implementation = _resolved_hub_impl,
     attrs = {
         "select_map": attr.string(mandatory = True),
-        "source": attr.string(mandatory = True),
+        "basename": attr.string(mandatory = True),
+        "source": attr.string(
+            doc = "Label of the source-built binary, or empty for a prebuilt-only (released) module.",
+        ),
     },
 )
 
@@ -120,7 +140,7 @@ _from_file = tag_class(attrs = {
 _source = tag_class(attrs = {"target": attr.label(mandatory = True)})
 
 def _impl(ctx):
-    source = None
+    source = ""
     lockfile_entries = []
     basename = None
     url_templates = [_URL_DEFAULT]
@@ -135,8 +155,8 @@ def _impl(ctx):
             url_templates = ff.url_templates
             lockfile_entries = json.decode(ctx.read(ff.lockfile))
 
-    if source == None or hub_name == None:
-        fail("prebuilt_signer requires both a source() and a from_file() tag")
+    if hub_name == None:
+        fail("prebuilt_signer requires a from_file() tag")
 
     select_map = {}
     for item in lockfile_entries:
@@ -156,9 +176,13 @@ def _impl(ctx):
         )
         select_map["{}_{}".format(os, cpu)] = repo
 
+    if not select_map and not source:
+        fail("prebuilt_signer: {} has neither a populated prebuilt lockfile nor a source() tag".format(hub_name))
+
     _resolved_hub(
         name = hub_name,
         select_map = json.encode(select_map),
+        basename = basename,
         source = source,
     )
 

--- a/modules/rules_img_signer_notation/BUILD.bazel
+++ b/modules/rules_img_signer_notation/BUILD.bazel
@@ -11,10 +11,10 @@ alias(
 
 exports_files(["prebuilt_lockfile.json"])
 
-# Compile the source-built plugin binary under `bazel test //...` so the module's
-# standalone CI check verifies the whole build graph even though it has few
-# go_test targets.
+# The only test target in the released module, and the one the BCR presubmit runs
+# (`//:all`) — so it must go through the alias rather than reference //cmd/notation
+# directly, which is not part of the release archive.
 build_test(
     name = "build_test",
-    targets = ["//cmd/notation"],
+    targets = [":rules_img_signer_notation"],
 )

--- a/modules/rules_img_signer_notation/MODULE.bazel
+++ b/modules/rules_img_signer_notation/MODULE.bazel
@@ -5,6 +5,35 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "platforms", version = "1.0.0")
+
+# Resolve the plugin binary: released versions ship a populated
+# prebuilt_lockfile.json and download the prebuilt binary.
+prebuilt = use_extension("//prebuilt:prebuilt.bzl", "prebuilt_signer")
+prebuilt.from_file(
+    basename = "notation",
+    lockfile = "//:prebuilt_lockfile.json",
+)
+use_repo(prebuilt, "rules_img_signer_notation_resolved")
+
+# Download the official upstream notation CLI (kept in sync with the
+# notation-core-go library in go.mod) so integration tests can verify signatures
+# with the real tool. Exposed as @rules_img_signer_notation//notation.
+notation_cli = use_extension("//cli:cli.bzl", "notation_cli")
+notation_cli.from_file(lockfile = "//cli:notation_cli.lock.json")
+use_repo(
+    notation_cli,
+    "notation_cli_darwin_amd64",
+    "notation_cli_darwin_arm64",
+    "notation_cli_linux_amd64",
+    "notation_cli_linux_arm64",
+    "notation_cli_windows_amd64",
+)
+
+### REMOVE_BEFORE_RELEASE_START
+
+# Stripped when the release archive is produced: the released module ships
+# prebuilt binaries and no Go sources, so it must not depend on rules_go/gazelle.
+
 bazel_dep(name = "rules_go", version = "0.62.0")
 bazel_dep(name = "gazelle", version = "0.52.2")
 
@@ -22,26 +51,7 @@ use_repo(
     "com_github_opencontainers_image_spec",
 )
 
-# Resolve the plugin binary: prebuilt download for released versions, or the
-# source-built go_binary for any other commit / local / git_override build.
-prebuilt = use_extension("//prebuilt:prebuilt.bzl", "prebuilt_signer")
-prebuilt.from_file(
-    basename = "notation",
-    lockfile = "//:prebuilt_lockfile.json",
-)
+# Used whenever prebuilt_lockfile.json is still the empty list `[]`.
 prebuilt.source(target = "//cmd/notation")
-use_repo(prebuilt, "rules_img_signer_notation_resolved")
 
-# Download the official upstream notation CLI (kept in sync with the
-# notation-core-go library in go.mod) so integration tests can verify signatures
-# with the real tool. Exposed as @rules_img_signer_notation//notation.
-notation_cli = use_extension("//cli:cli.bzl", "notation_cli")
-notation_cli.from_file(lockfile = "//cli:notation_cli.lock.json")
-use_repo(
-    notation_cli,
-    "notation_cli_darwin_amd64",
-    "notation_cli_darwin_arm64",
-    "notation_cli_linux_amd64",
-    "notation_cli_linux_arm64",
-    "notation_cli_windows_amd64",
-)
+### REMOVE_BEFORE_RELEASE_END

--- a/modules/rules_img_signer_notation/README.md
+++ b/modules/rules_img_signer_notation/README.md
@@ -17,9 +17,12 @@ This is an **independent Bazel module**.
 bazel_dep(name = "rules_img_signer_notation", version = "<version>")
 ```
 
-`@rules_img_signer_notation` resolves to a prebuilt binary for released versions,
-or a source-built `go_binary` for any other commit / local / `git_override`
-build. Source builds of this module work with no extra configuration.
+`@rules_img_signer_notation` resolves to a prebuilt binary for released versions:
+the published archive contains only the Starlark needed to download it — no Go
+sources, no `rules_go`, no `gazelle`, no Go toolchain. Building the plugin from
+source means building from a checkout of the
+[rules_img repository](https://github.com/bazel-contrib/rules_img)
+(`git_override` or a local path), which works with no extra configuration.
 
 ## Usage
 

--- a/modules/rules_img_signer_notation/prebuilt/prebuilt.bzl
+++ b/modules/rules_img_signer_notation/prebuilt/prebuilt.bzl
@@ -5,6 +5,10 @@ This is self-contained: it does not depend on rules_img, so the module can be
 built and released independently. The decision is driven by
 `prebuilt_lockfile.json`, which is an empty list `[]` in source and is overwritten
 with per-platform digests when the release archive is produced.
+
+A released module declares no `source()` tag: its archive contains no Go sources,
+so unsupported platforms report that instead of referencing a `//cmd/...` package
+that is not packaged.
 """
 
 _URL_DEFAULT = "https://github.com/bazel-contrib/rules_img/releases/download/{tag}/{basename}_{os}_{cpu}{dot}{ext}"
@@ -18,6 +22,7 @@ _OS_CONSTRAINT = {
 _CPU_CONSTRAINT = {
     "amd64": "@platforms//cpu:x86_64",
     "arm64": "@platforms//cpu:aarch64",
+    "s390x": "@platforms//cpu:s390x",
 }
 
 def _prebuilt_download_impl(rctx):
@@ -53,9 +58,24 @@ _prebuilt_download = repository_rule(
         "integrity": attr.string(mandatory = True),
         "basename": attr.string(mandatory = True),
         "os": attr.string(values = ["darwin", "linux", "windows"]),
-        "cpu": attr.string(values = ["amd64", "arm64"]),
+        "cpu": attr.string(values = ["amd64", "arm64", "s390x"]),
         "url_templates": attr.string_list(default = [_URL_DEFAULT]),
     },
+)
+
+_ALIAS_TEMPLATE = """\
+alias(
+    name = "binary",
+    actual = {actual},
+    visibility = ["//visibility:public"],
+)
+"""
+
+_NO_MATCH_ERROR = (
+    "no prebuilt {basename} signer plugin binary for this platform. " +
+    "Released versions of the plugin publish binaries for linux (x86_64, arm64, s390x), " +
+    "macOS (x86_64, arm64) and Windows (x86_64, arm64) only. To use it elsewhere, build the " +
+    "plugin from source with a git_override on github.com/bazel-contrib/rules_img."
 )
 
 def _resolved_hub_impl(rctx):
@@ -63,13 +83,7 @@ def _resolved_hub_impl(rctx):
     select_map = json.decode(rctx.attr.select_map)
     if not select_map:
         # No prebuilt for this version: alias straight to the source go_binary.
-        rctx.file("BUILD.bazel", """\
-alias(
-    name = "binary",
-    actual = "{source}",
-    visibility = ["//visibility:public"],
-)
-""".format(source = rctx.attr.source))
+        rctx.file("BUILD.bazel", _ALIAS_TEMPLATE.format(actual = '"{}"'.format(rctx.attr.source)))
         return
 
     config_settings = []
@@ -90,25 +104,31 @@ config_setting(
             cpu_constraint = _CPU_CONSTRAINT[cpu],
         ))
         arms[":is_{}".format(platform_key)] = "@{}//:binary".format(repo)
-    arms["//conditions:default"] = rctx.attr.source
 
-    rctx.file("BUILD.bazel", """\
-{config_settings}
-alias(
-    name = "binary",
-    actual = select({arms}),
-    visibility = ["//visibility:public"],
-)
-""".format(
+    extra_select_args = ""
+    if rctx.attr.source:
+        arms["//conditions:default"] = rctx.attr.source
+    else:
+        extra_select_args = '\n        no_match_error = "{}",'.format(
+            _NO_MATCH_ERROR.format(basename = rctx.attr.basename),
+        )
+
+    rctx.file("BUILD.bazel", "{config_settings}\n{alias}".format(
         config_settings = "\n".join(config_settings),
-        arms = json.encode_indent(arms, prefix = "        ", indent = "    "),
+        alias = _ALIAS_TEMPLATE.format(actual = "select(\n        {arms},{extra}\n    )".format(
+            arms = json.encode_indent(arms, prefix = "        ", indent = "    "),
+            extra = extra_select_args,
+        )),
     ))
 
 _resolved_hub = repository_rule(
     implementation = _resolved_hub_impl,
     attrs = {
         "select_map": attr.string(mandatory = True),
-        "source": attr.string(mandatory = True),
+        "basename": attr.string(mandatory = True),
+        "source": attr.string(
+            doc = "Label of the source-built binary, or empty for a prebuilt-only (released) module.",
+        ),
     },
 )
 
@@ -120,7 +140,7 @@ _from_file = tag_class(attrs = {
 _source = tag_class(attrs = {"target": attr.label(mandatory = True)})
 
 def _impl(ctx):
-    source = None
+    source = ""
     lockfile_entries = []
     basename = None
     url_templates = [_URL_DEFAULT]
@@ -135,8 +155,8 @@ def _impl(ctx):
             url_templates = ff.url_templates
             lockfile_entries = json.decode(ctx.read(ff.lockfile))
 
-    if source == None or hub_name == None:
-        fail("prebuilt_signer requires both a source() and a from_file() tag")
+    if hub_name == None:
+        fail("prebuilt_signer requires a from_file() tag")
 
     select_map = {}
     for item in lockfile_entries:
@@ -156,9 +176,13 @@ def _impl(ctx):
         )
         select_map["{}_{}".format(os, cpu)] = repo
 
+    if not select_map and not source:
+        fail("prebuilt_signer: {} has neither a populated prebuilt lockfile nor a source() tag".format(hub_name))
+
     _resolved_hub(
         name = hub_name,
         select_map = json.encode(select_map),
+        basename = basename,
         source = source,
     )
 


### PR DESCRIPTION
The cosign plugin's BCR presubmit failed because the release archive still
carried the plugin's Go sources: their BUILD files load `@rules_go`, which a
published module cannot resolve.

```
ERROR: error loading package 'cmd/cosign': Unable to find package for
@@[unknown repo 'rules_go' requested from @@]//go:def.bzl ...
and referenced by '//:build_test_0__deps'
```

Package only the Starlark needed to download the prebuilt binary, for both
plugins:

- the release filegroups (`//:signer_*_source_files`) are allowlists — no
  `cmd/`, `pkg/`, `go.mod`, `go.sum`;
- `prebuilt.source()` and the rules_go/gazelle setup moved into the
  `REMOVE_BEFORE_RELEASE` section, which notation did not have at all, so its
  released module pulled in gazelle and built the plugin from source;
- `//:build_test` resolves the plugin through the alias instead of
  `//cmd/<basename>`, keeping `//:all` Go-free while still offering the BCR
  presubmit a test target.

Without a source fallback, a platform we publish no binary for now gets a
`no_match_error` instead of a reference to an unpackaged `//cmd/...` package,
and s390x resolves the binary we already publish.

The e2e tests consume these very archives through the offline BCR, so they now
also load every package of the released modules and re-run the BCR presubmit
against the extracted archive — before a tag exists.

Note that `rules_img_signer_notation` 0.0.1 is already published, so shipping
the prebuilt-only form needs a version bump; `rules_img_signer_cosign` is not
published yet and can keep 0.0.1.