### PR TITLE
feat(gateway): keep the blob existence cache current from reads, pushes and deletes

### DIFF
--- a/img_tool/cmd/oci-distribution-gateway/README.md
+++ b/img_tool/cmd/oci-distribution-gateway/README.md
@@ -197,11 +197,11 @@ on and add an egress NetworkPolicy naming your registries.
 
 ## Blob existence cache
 
-A serving gateway memoizes one thing: the answer `200` to
-`HEAD /v2/<name>/blobs/<digest>`, the "is this layer already pushed?" probe every
-push begins with. On a build farm that request dominates registry traffic — a fleet
-re-pushing the same base image asks the same question thousands of times, and each
-answer is a round trip a client waits on.
+A serving gateway memoizes one fact: **this blob is in this repository**. It is the
+answer `200` to `HEAD /v2/<name>/blobs/<digest>`, the "is this layer already pushed?"
+probe every push begins with. On a build farm that request dominates registry
+traffic — a fleet re-pushing the same base image asks the same question thousands of
+times, and each answer is a round trip a client waits on.
 
 It is on by default, remembering a blob for six hours within 64 MiB of memory:
 
@@ -221,7 +221,7 @@ question, and gets asked. Resolution happens first, so a request naming `docker.
 and one naming `index.docker.io` share entries (they are the same upstream) while
 `registry.example.com` and `registry.example.com:5000` do not.
 
-Only a plain `200` is remembered:
+Of the answers a probe can get, only a plain `200` is remembered:
 
 - **A `404` is not cached.** A blob that is absent now can be pushed a second
   later, so remembering "not there" would tell clients to re-upload content that
@@ -241,15 +241,42 @@ happened to send is replayed to another client hours later, and every cached hit
 logged with `(cached)` so the decision log still accounts for every request.
 
 **Authorization is not cached.** The policy is consulted on every request, before
-the cache is; a reload that revokes access takes effect on the next probe even
-though its answer is sitting in memory.
+the cache is; a reload that revokes access takes effect on the next probe even though
+its answer is sitting in memory.
+
+### What fills and empties it
+
+A probe is not the only request that settles whether a blob is in a repository, and
+every request that does keeps the cache current:
+
+| Request | Effect |
+| --- | --- |
+| `HEAD .../blobs/<digest>` answered `200` | remembered |
+| `GET .../blobs/<digest>` answered `200`, with a `Docker-Content-Digest` naming that blob | remembered, with the size it served |
+| `PUT .../blobs/uploads/<ref>?digest=<digest>` answered `201` | remembered: the upload committed |
+| `POST .../blobs/uploads/?digest=<digest>` answered `201` | remembered: the whole blob arrived in one request |
+| `POST .../blobs/uploads/?mount=<digest>&from=<repo>` answered `201` | remembered: the mount was honoured |
+| `DELETE .../blobs/<digest>` forwarded | forgotten, whatever the registry answers |
+
+Only the response that *finishes* an upload counts — a `202` means a session was
+opened or a chunk accepted, and a client told that a half-uploaded blob is already
+there would skip an upload it still owes. A delete is read pessimistically the other
+way: a `5xx` or a timeout leaves the gateway unable to tell whether the blob survived,
+and dropping an entry only ever costs one probe. Those drops are counted under
+`..._evictions_total{oci_gateway_cache_eviction_reason="deleted"}`.
+
+An entry admitted by a commit or a mount carries no `Content-Length` — neither request
+sees the blob's bytes — so a probe it answers omits the header rather than inventing a
+size, exactly as it does for a registry that reports no length.
 
 ### Sizing the TTL
 
-The TTL is the one thing between a client and a wrong answer. A blob cannot
-change, but a registry can **garbage-collect** one — and a push client that
-believes a collected layer is still there will skip re-uploading it and commit a
-manifest referring to a blob that is gone.
+The TTL is what stands between a client and the wrong answer the gateway cannot see
+coming. A blob cannot change, but a registry can **garbage-collect** one behind the
+gateway's back — and a push client that believes a collected layer is still there will
+skip re-uploading it and commit a manifest referring to a blob that is gone. (A blob
+deleted *through* the gateway needs no such window; it is dropped when the delete goes
+past.)
 
 Set the TTL well inside the window in which your registry could collect a blob:
 the grace period of its GC, the untagged-blob retention of your Artifactory or ECR
@@ -803,7 +830,7 @@ so it is the one that counts registry traffic:
 | `oci.gateway.blob_existence_cache.lookups` | `oci_gateway_blob_existence_cache_lookups_total` | counter | Cacheable blob probes by whether the cache answered them (`oci.result`) |
 | `oci.gateway.blob_existence_cache.entries` | `oci_gateway_blob_existence_cache_entries` | gauge | Blobs the cache holds. Over `..._capacity`, how full it is |
 | `oci.gateway.blob_existence_cache.capacity` | `oci_gateway_blob_existence_cache_capacity` | gauge | Blobs it has room for. Fixed: the memory is preallocated |
-| `oci.gateway.blob_existence_cache.evictions` | `oci_gateway_blob_existence_cache_evictions_total` | counter | Entries dropped, by `oci.gateway.cache.eviction.reason` (`capacity`/`expired`) |
+| `oci.gateway.blob_existence_cache.evictions` | `oci_gateway_blob_existence_cache_evictions_total` | counter | Entries dropped, by `oci.gateway.cache.eviction.reason` (`capacity`/`expired`/`deleted`) |
 | `oci.gateway.errors` | `oci_gateway_errors_total` | counter | Failures by `error.type` and registry |
 | `oci.gateway.upstream.duration` | `oci_gateway_upstream_duration_seconds` | histogram (s) | Time until the registry returned response headers |
 | `oci.gateway.upstream.auth_handshakes` | `oci_gateway_upstream_auth_handshakes_total` | counter | Ping + token exchanges (cached per repository and scope) |

--- a/img_tool/cmd/oci-distribution-gateway/main.go
+++ b/img_tool/cmd/oci-distribution-gateway/main.go
@@ -24,8 +24,9 @@
 //
 // A serving gateway also memoizes the blob existence checks a push begins with, so
 // that a fleet asking whether the same layer is already upstream pays for one round
-// trip rather than thousands. See --blob-existence-cache-ttl and the "Blob
-// existence cache" section of the README.
+// trip rather than thousands. Reads and pushes it forwards keep that memo current,
+// and a blob delete takes an entry back. See --blob-existence-cache-ttl and the
+// "Blob existence cache" section of the README.
 //
 // A bare invocation with no subcommand means serving mode, so existing
 // deployments keep working unchanged.

--- a/img_tool/cmd/oci-distribution-gateway/serve.go
+++ b/img_tool/cmd/oci-distribution-gateway/serve.go
@@ -70,7 +70,7 @@ func (f *serveFlags) register(flagSet *flag.FlagSet) {
 	flagSet.BoolVar(&f.denyPrivateUpstreams, "deny-private-upstreams", false, "Refuse upstream registries that resolve to a loopback, link-local, or private address. Recommended for a gateway shared between workloads; leave off when your registry is reachable only through an in-cluster (private) address.")
 
 	f.blobCacheMaxMemory = defaultBlobCacheMemory
-	flagSet.DurationVar(&f.blobCacheTTL, "blob-existence-cache-ttl", 6*time.Hour, "How long the gateway may assume a blob it has already seen is still in its repository, answering repeat HEAD probes for it without a round trip. 0 disables the cache. Keep it well inside the window in which your registry could garbage-collect a blob: a client that trusts a stale hit skips re-uploading a layer that is gone.")
+	flagSet.DurationVar(&f.blobCacheTTL, "blob-existence-cache-ttl", 6*time.Hour, "How long the gateway may assume a blob it has seen -- probed for, or pushed through it -- is still in its repository, answering HEAD probes for it without a round trip. 0 disables the cache. Keep it well inside the window in which your registry could garbage-collect a blob: a client that trusts a stale hit skips re-uploading a layer that is gone.")
 	flagSet.Var(&f.blobCacheMaxMemory, "blob-existence-cache-max-memory", "Memory the blob existence cache may use, e.g. 64MiB. It is allocated in full at startup and never grows; when it is full the least recently used blob makes room. 0 disables the cache.")
 
 	flagSet.StringVar(&f.tlsCertFile, "tls-cert-file", "", "PEM certificate (leaf plus any intermediates) to serve TLS with. Enables HTTP/2 via ALPN. Re-read when the file changes and on SIGHUP.")

--- a/img_tool/pkg/serve/gateway/classify.go
+++ b/img_tool/pkg/serve/gateway/classify.go
@@ -101,10 +101,12 @@ type request struct {
 	// forwarded: the gateway could otherwise authorize a different mount source
 	// than the one the upstream acts on.
 	malformedQuery bool
-	// digest is the blob digest a blob existence check asked about, and is set
-	// only for that operation and only when the reference really is a digest. It
-	// is the part of the blob existence cache's key that identifies the content;
-	// leaving it empty is how every other request opts out of the cache.
+	// digest is the blob digest this request is about: the one an existence check
+	// asks after, the one a read returns, the one an upload puts in the repository
+	// when it succeeds, or the one a delete takes away. It is set only for those
+	// requests, and only when the reference really is a digest. It is the part of the
+	// blob existence cache's key that identifies the content; leaving it empty is how
+	// every other request opts out of the cache.
 	digest string
 }
 
@@ -142,38 +144,56 @@ func classify(r *http.Request) (request, bool) {
 			route = routeUploadSession
 		}
 		req := request{repo: m[1], req: reqBlobWrite, kind: "blob upload", op: opNameBlobUpload, route: route, write: true}
-		// A cross-repo mount (POST ...?mount=<digest>&from=<repo>) copies an
-		// existing blob from another repository instead of re-uploading it; the
-		// source repository must be readable. Parse the query strictly and
-		// authorize exactly what will be forwarded upstream. Reject anything
-		// ambiguous: url.ParseQuery errors on (and drops) ';'-joined pairs that a
-		// lenient upstream might still act on, and duplicate mount/from values
-		// could let us authorize one source while the upstream mounts another.
-		if method == http.MethodPost {
+		// A POST opens a session (or finishes an upload outright) and a PUT closes
+		// one; those are the two steps whose query says which blob is being
+		// uploaded, and the only ones the gateway parses.
+		if method == http.MethodPost || method == http.MethodPut {
 			q, err := url.ParseQuery(r.URL.RawQuery)
-			switch {
-			case err != nil || len(q["mount"]) > 1 || len(q["from"]) > 1:
-				req.malformedQuery = true
-			case len(q["mount"]) == 1 && len(q["from"]) == 1:
-				req.mountFrom = q.Get("from")
+			// A cross-repo mount (POST ...?mount=<digest>&from=<repo>) copies an
+			// existing blob from another repository instead of re-uploading it; the
+			// source repository must be readable. Parse the query strictly and
+			// authorize exactly what will be forwarded upstream. Reject anything
+			// ambiguous: url.ParseQuery errors on (and drops) ';'-joined pairs that a
+			// lenient upstream might still act on, and duplicate mount/from values
+			// could let us authorize one source while the upstream mounts another.
+			if method == http.MethodPost {
+				switch {
+				case err != nil || len(q["mount"]) > 1 || len(q["from"]) > 1:
+					req.malformedQuery = true
+				case len(q["mount"]) == 1 && len(q["from"]) == 1:
+					req.mountFrom = q.Get("from")
+				}
+			}
+			// An ambiguous query is not read for a digest either: a request the
+			// gateway and the upstream could read differently must teach the cache
+			// nothing.
+			if err == nil && !req.malformedQuery {
+				req.digest = committedDigest(method, q)
 			}
 		}
 		return req, true
 	}
 	if m := blobRe.FindStringSubmatch(path); m != nil {
+		// Carry the reference as a digest only when it is one, so that the blob
+		// existence cache is never keyed on a reference no registry could answer
+		// for. Three requests turn on it: the HEAD that asks whether the blob is
+		// there, the GET that proves it is by returning it, and the DELETE that
+		// takes it away.
+		digest := ""
+		if digestRe.MatchString(m[blobRefGroup]) {
+			digest = m[blobRefGroup]
+		}
 		switch method {
 		case http.MethodGet:
-			return request{repo: m[1], req: reqBlobRead, kind: "blob read", op: opNameBlobRead, route: routeBlob}, true
+			return request{repo: m[1], req: reqBlobRead, kind: "blob read", op: opNameBlobRead, route: routeBlob, digest: digest}, true
 		case http.MethodHead:
-			req := request{repo: m[1], req: reqBlobReadOrWrite, kind: "blob existence check", op: opNameBlobHead, route: routeBlob}
-			// Carry the digest only when the reference is one, so that the blob
-			// existence cache is never keyed on a reference no registry could
-			// answer for.
-			if digestRe.MatchString(m[blobRefGroup]) {
-				req.digest = m[blobRefGroup]
-			}
-			return req, true
-		default: // DELETE and anything else that mutates.
+			return request{repo: m[1], req: reqBlobReadOrWrite, kind: "blob existence check", op: opNameBlobHead, route: routeBlob, digest: digest}, true
+		case http.MethodDelete:
+			// A delete is a blob write like any other to the policy and the metrics;
+			// the digest is carried because it is the one request whose success makes
+			// a cache entry false.
+			return request{repo: m[1], req: reqBlobWrite, kind: "blob write", op: opNameBlobWrite, route: routeBlob, write: true, digest: digest}, true
+		default: // Anything else that mutates.
 			return request{repo: m[1], req: reqBlobWrite, kind: "blob write", op: opNameBlobWrite, route: routeBlob, write: true}, true
 		}
 	}
@@ -188,4 +208,39 @@ func classify(r *http.Request) (request, bool) {
 		}
 	}
 	return request{op: opNameUnknown}, false
+}
+
+// committedDigest returns the blob digest a POST or PUT to an upload endpoint puts
+// in the repository if the registry answers 201 Created, or "" when the request
+// commits nothing.
+//
+// Three request shapes finish an upload, and each names its blob in the query:
+//
+//   - PUT /v2/<name>/blobs/uploads/<ref>?digest=<digest> closes the session the
+//     content was streamed to. This is what a go-containerregistry push sends.
+//   - POST /v2/<name>/blobs/uploads/?digest=<digest> carries the whole blob in the
+//     one request.
+//   - POST /v2/<name>/blobs/uploads/?mount=<digest>&from=<repo> copies a blob that
+//     is already in the registry, transferring no content at all.
+//
+// Every other step of a session — opening it, appending a chunk, querying its
+// status, cancelling it — commits nothing, and neither does a query that names two
+// blobs: the gateway will not guess which one an upstream acted on, and the price
+// of guessing wrong is telling a client that a blob is present when it is not.
+func committedDigest(method string, q url.Values) string {
+	var reference string
+	switch {
+	case method == http.MethodPost && len(q["mount"]) == 1 && len(q["from"]) == 1 && len(q["digest"]) == 0:
+		reference = q["mount"][0]
+	case len(q["digest"]) == 1 && len(q["mount"]) == 0:
+		reference = q["digest"][0]
+	default:
+		return ""
+	}
+	// Hold the cache to a real digest, exactly as an existence check is: a
+	// reference that is not one names nothing immutable.
+	if !digestRe.MatchString(reference) {
+		return ""
+	}
+	return reference
 }

--- a/img_tool/pkg/serve/gateway/classify_test.go
+++ b/img_tool/pkg/serve/gateway/classify_test.go
@@ -92,10 +92,84 @@ func TestClassifyMount(t *testing.T) {
 	}
 }
 
-// TestClassifyBlobDigest covers the field the blob existence cache keys on. It is
-// set only for a blob existence check, and only when the reference really is a
-// digest — the repository grammar has capture groups of its own, so reading the
-// reference out of the wrong submatch is the mistake to guard against.
+// TestClassifyCommittedDigest covers the other way the cache key is found: the
+// digest a blob upload puts in the repository when the registry commits it. Only
+// the request that finishes an upload names one, and an ambiguous query names none
+// — the gateway must not guess which of two blobs an upstream acted on.
+func TestClassifyCommittedDigest(t *testing.T) {
+	const sha256Digest = "sha256:6b0f2e1a4c3d5e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f7"
+	for _, tc := range []struct {
+		name       string
+		method     string
+		path       string
+		wantDigest string
+	}{
+		// The three request shapes that finish an upload.
+		{"session commit", http.MethodPut, "/v2/app/blobs/uploads/uuid-123?digest=" + sha256Digest, sha256Digest},
+		{"session commit with opaque state", http.MethodPut, "/v2/app/blobs/uploads/uuid-123?_state=abc%3D&digest=" + sha256Digest, sha256Digest},
+		{"monolithic upload", http.MethodPost, "/v2/app/blobs/uploads/?digest=" + sha256Digest, sha256Digest},
+		{"cross-repo mount", http.MethodPost, "/v2/app/blobs/uploads/?mount=" + sha256Digest + "&from=other/app", sha256Digest},
+		// Steps that commit nothing.
+		{"session start", http.MethodPost, "/v2/app/blobs/uploads/", ""},
+		{"chunk", http.MethodPatch, "/v2/app/blobs/uploads/uuid-123?digest=" + sha256Digest, ""},
+		{"status query", http.MethodGet, "/v2/app/blobs/uploads/uuid-123?digest=" + sha256Digest, ""},
+		{"cancellation", http.MethodDelete, "/v2/app/blobs/uploads/uuid-123?digest=" + sha256Digest, ""},
+		// A mount without a source is not a mount, and a reference that is not a
+		// digest names nothing immutable.
+		{"mount without from", http.MethodPost, "/v2/app/blobs/uploads/?mount=" + sha256Digest, ""},
+		{"digest that is not one", http.MethodPut, "/v2/app/blobs/uploads/uuid-123?digest=sha256:abc", ""},
+		{"empty digest", http.MethodPut, "/v2/app/blobs/uploads/uuid-123?digest=", ""},
+		// Queries naming two blobs, or naming one in two ways.
+		{"duplicate digest", http.MethodPut, "/v2/app/blobs/uploads/uuid-123?digest=" + sha256Digest + "&digest=" + sha256Digest, ""},
+		{"mount and digest", http.MethodPost, "/v2/app/blobs/uploads/?mount=" + sha256Digest + "&from=other/app&digest=" + sha256Digest, ""},
+		{"duplicate mount", http.MethodPost, "/v2/app/blobs/uploads/?mount=" + sha256Digest + "&mount=x&from=other/app", ""},
+		{"mount on a commit", http.MethodPut, "/v2/app/blobs/uploads/uuid-123?digest=" + sha256Digest + "&mount=" + sha256Digest, ""},
+		// A query the gateway and a lenient upstream could read differently: the
+		// ';' is dropped here and might be honoured there.
+		{"semicolon separator", http.MethodPut, "/v2/app/blobs/uploads/uuid-123?_state=a;digest=" + sha256Digest, ""},
+		// A manifest is not a blob, whatever its reference: the cache must never
+		// hold one.
+		{"manifest write by digest", http.MethodPut, "/v2/app/manifests/" + sha256Digest, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := classify(req(tc.method, tc.path))
+			if !ok {
+				t.Fatalf("classify ok = false, want true")
+			}
+			if got.digest != tc.wantDigest {
+				t.Errorf("digest = %q, want %q", got.digest, tc.wantDigest)
+			}
+		})
+	}
+}
+
+// TestClassifyMountStaysStrictOnCommits guards the blast radius of parsing a PUT's
+// query: reading it must teach the cache nothing new about mounts, and must not
+// turn a request the gateway used to forward into one it rejects.
+func TestClassifyMountStaysStrictOnCommits(t *testing.T) {
+	for _, path := range []string{
+		"/v2/app/blobs/uploads/uuid-123?mount=sha256:abc&from=other/app",
+		"/v2/app/blobs/uploads/uuid-123?from=a&from=b",
+		"/v2/app/blobs/uploads/uuid-123?_state=a;b",
+	} {
+		got, ok := classify(req(http.MethodPut, path))
+		if !ok {
+			t.Fatalf("classify(PUT %q) ok = false, want true", path)
+		}
+		if got.mountFrom != "" {
+			t.Errorf("classify(PUT %q) mountFrom = %q, want it read on a POST only", path, got.mountFrom)
+		}
+		if got.malformedQuery {
+			t.Errorf("classify(PUT %q) is now rejected as malformed, which it was not before", path)
+		}
+	}
+}
+
+// TestClassifyBlobDigest covers the field the blob existence cache keys on when it
+// is read off the path: the blob a HEAD asks after, the blob a GET returns, and the
+// blob a DELETE takes away. It is set only when the reference really is a digest —
+// the repository grammar has capture groups of its own, so reading the reference out
+// of the wrong submatch is the mistake to guard against.
 func TestClassifyBlobDigest(t *testing.T) {
 	const sha256Digest = "sha256:6b0f2e1a4c3d5e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f7"
 	for _, tc := range []struct {
@@ -109,16 +183,22 @@ func TestClassifyBlobDigest(t *testing.T) {
 		{"repository with separators", http.MethodHead, "/v2/a.b__c-d/blobs/" + sha256Digest, sha256Digest},
 		{"sha512", http.MethodHead, "/v2/app/blobs/sha512:" + strings.Repeat("ab", 64), "sha512:" + strings.Repeat("ab", 64)},
 		{"multipart algorithm", http.MethodHead, "/v2/app/blobs/multihash+base58:" + strings.Repeat("c", 46), "multihash+base58:" + strings.Repeat("c", 46)},
+		// A read names the blob it returns, and a delete the one whose entry it
+		// unmakes.
+		{"blob get", http.MethodGet, "/v2/app/blobs/" + sha256Digest, sha256Digest},
+		{"blob delete", http.MethodDelete, "/v2/app/blobs/" + sha256Digest, sha256Digest},
 		// Not a digest, so nothing immutable is named.
 		{"tag", http.MethodHead, "/v2/app/blobs/latest", ""},
+		{"get by tag", http.MethodGet, "/v2/app/blobs/latest", ""},
+		{"delete by tag", http.MethodDelete, "/v2/app/blobs/latest", ""},
 		{"too short to be a digest", http.MethodHead, "/v2/app/blobs/sha256:abc", ""},
 		{"too long to be a digest", http.MethodHead, "/v2/app/blobs/sha256:" + strings.Repeat("a", 129), ""},
 		{"no algorithm", http.MethodHead, "/v2/app/blobs/" + strings.Repeat("a", 64), ""},
 		{"uppercase algorithm", http.MethodHead, "/v2/app/blobs/SHA256:" + strings.Repeat("a", 64), ""},
-		// Only the existence check is cacheable; a read or a delete is not.
-		{"blob get", http.MethodGet, "/v2/app/blobs/" + sha256Digest, ""},
-		{"blob delete", http.MethodDelete, "/v2/app/blobs/" + sha256Digest, ""},
+		// A manifest is never in the cache, whatever its reference.
 		{"manifest head", http.MethodHead, "/v2/app/manifests/" + sha256Digest, ""},
+		{"manifest get", http.MethodGet, "/v2/app/manifests/" + sha256Digest, ""},
+		{"manifest delete", http.MethodDelete, "/v2/app/manifests/" + sha256Digest, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got, ok := classify(req(tc.method, tc.path))

--- a/img_tool/pkg/serve/gateway/existencecache.go
+++ b/img_tool/pkg/serve/gateway/existencecache.go
@@ -10,8 +10,8 @@ import (
 	"unsafe"
 )
 
-// This file implements the blob existence cache: a memo of the successful
-// answers to HEAD /v2/<name>/blobs/<digest>.
+// This file implements the blob existence cache: a memo of the fact that a blob
+// is in a repository, which is the answer 200 to HEAD /v2/<name>/blobs/<digest>.
 //
 // That one request dominates a build farm's registry traffic. Every push begins
 // by probing whether each layer is already upstream, so a fleet re-pushing the
@@ -19,8 +19,20 @@ import (
 // costs a round trip the client waits on. The answer is also the most cacheable
 // one in the protocol: a blob is immutable and content-addressed, so "this
 // digest is present in this repository" cannot become true-then-false-then-true
-// — it can only stop being true, when the registry garbage-collects the blob.
-// That single failure mode is what the TTL bounds.
+// — it can only stop being true, when the blob leaves the repository. That
+// single failure mode is what the TTL bounds, for the one way it happens out of
+// sight: a registry garbage-collecting the blob. The other way — a client
+// deleting it — travels through the gateway, which drops the entry there and
+// then (see Handler.forgetDeletedBlob).
+//
+// A probe is not the only request that establishes the fact, and the others fill
+// the cache from the side the fleet is already paying for: a read the registry
+// serves under the digest asked for, and an upload it carries through to a
+// commit. Whichever client loses the race to push a layer has then already
+// answered every probe that follows, so the fleet pays for neither the re-upload
+// nor the first probe. The commit response is the earliest point at which that is
+// true, and gateway.go is careful to admit nothing before it (see
+// Handler.rememberBlob).
 //
 // Manifests and tags are deliberately *not* cached. A tag is mutable by
 // definition, and a manifest HEAD is how a client discovers that a tag now
@@ -173,6 +185,7 @@ type cacheShard struct {
 	live            atomic.Int64
 	evictedCapacity atomic.Int64
 	evictedExpired  atomic.Int64
+	evictedDeleted  atomic.Int64
 }
 
 // newBlobExistenceCache builds a cache that treats a blob it has seen as present
@@ -313,6 +326,29 @@ func (c *blobExistenceCache) store(registry, repository, digest string, contentL
 	s.live.Add(1)
 }
 
+// forget drops the entry for a blob, so that the next probe for it asks the
+// registry again. Forgetting a key the cache does not hold does nothing.
+//
+// Other than an entry evicted to make room for another blob, this is the only way
+// one goes before its TTL. The cache's one failure mode is holding a blob that has
+// since gone, and a delete travelling through the gateway is the one moment it can
+// know that happened.
+func (c *blobExistenceCache) forget(registry, repository, digest string) {
+	if c == nil {
+		return
+	}
+	hash := c.hash(registry, repository, digest)
+	s := &c.shards[hash>>c.shardShift]
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if idx := s.find(hash, registry, repository, digest); idx >= 0 {
+		s.drop(idx)
+		s.evictedDeleted.Add(1)
+	}
+}
+
 // hash mixes the three parts of a key without concatenating them, so a lookup
 // allocates nothing.
 func (c *blobExistenceCache) hash(registry, repository, digest string) uint64 {
@@ -350,9 +386,11 @@ type cacheStats struct {
 	// capacity is the number of entries the memory bound allows.
 	capacity int64
 	// evictedCapacity counts entries dropped to make room, evictedExpired those
-	// dropped because their TTL had passed.
+	// dropped because their TTL had passed, and evictedDeleted those dropped
+	// because a blob delete travelled through the gateway.
 	evictedCapacity int64
 	evictedExpired  int64
+	evictedDeleted  int64
 }
 
 func (c *blobExistenceCache) stats() cacheStats {
@@ -365,6 +403,7 @@ func (c *blobExistenceCache) stats() cacheStats {
 		st.entries += s.live.Load()
 		st.evictedCapacity += s.evictedCapacity.Load()
 		st.evictedExpired += s.evictedExpired.Load()
+		st.evictedDeleted += s.evictedDeleted.Load()
 	}
 	return st
 }

--- a/img_tool/pkg/serve/gateway/existencecache_serve_test.go
+++ b/img_tool/pkg/serve/gateway/existencecache_serve_test.go
@@ -3,8 +3,12 @@ package gateway
 import (
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -260,6 +264,539 @@ func TestBlobExistenceCacheConditionalAnswerNotStored(t *testing.T) {
 	head(h, testUpstreamHost, testBlobPath, "Range", "bytes=0-1023")
 	if entries := h.blobCache.stats().entries; entries != 0 {
 		t.Fatalf("cache holds %d entries after a ranged probe, want 0", entries)
+	}
+}
+
+// The read side: handing over a blob is a stronger statement than answering a probe
+// about it, as long as the registry says which blob it handed over.
+
+// readUpstream serves a blob read with a scripted status, digest header and body, and
+// counts what reaches it.
+type readUpstream struct {
+	status int
+	// digest is sent as Docker-Content-Digest, when not empty.
+	digest string
+	body   string
+	reads  int
+	heads  int
+}
+
+func (u *readUpstream) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.URL.Path == "/v2/" || r.URL.Path == "/v2" {
+		return upstreamResponse(http.StatusOK, nil, ""), nil
+	}
+	header := http.Header{}
+	if u.digest != "" {
+		header.Set("Docker-Content-Digest", u.digest)
+	}
+	switch r.Method {
+	case http.MethodHead:
+		u.heads++
+		// A length that is not the read's, so a cached probe says which of the two
+		// answers it came from.
+		header.Set("Content-Length", "12345")
+		return upstreamResponse(http.StatusOK, header, ""), nil
+	default:
+		u.reads++
+		header.Set("Content-Length", strconv.Itoa(len(u.body)))
+		return upstreamResponse(u.status, header, u.body), nil
+	}
+}
+
+// TestBlobExistenceCacheAdmitsServedBlobs: a fleet that pulls a layer today is one
+// that will ask whether it needs to push it tomorrow, and the pull already answered
+// that question.
+func TestBlobExistenceCacheAdmitsServedBlobs(t *testing.T) {
+	up := &readUpstream{status: http.StatusOK, digest: testCacheDigest, body: "layer bytes"}
+	h, _ := newCachingHandler(t, allowHostPolicy(t, testUpstreamHost, "blob:read"), up, time.Hour)
+
+	if got := serve(h, http.MethodGet, testUpstreamHost, testBlobPath, "").Code; got != http.StatusOK {
+		t.Fatalf("read status = %d, want 200", got)
+	}
+	probe := head(h, testUpstreamHost, testBlobPath)
+	if probe.StatusCode != http.StatusOK {
+		t.Errorf("probe after the read = %d, want 200", probe.StatusCode)
+	}
+	if up.heads != 0 {
+		t.Errorf("upstream saw %d probes, want the read to have answered them", up.heads)
+	}
+	// The blob's size is the one the read carried, not the registry's word for it.
+	if got := probe.Header.Get("Content-Length"); got != "11" {
+		t.Errorf("cached Content-Length = %q, want %q", got, "11")
+	}
+}
+
+// TestBlobExistenceCacheNeedsTheDigestOnARead is where a read is held to a stricter
+// standard than a commit. The gateway streams a blob body through without hashing
+// it, and a read can be redirected to storage that serves whatever it is pointed at,
+// so only the registry naming what it served makes the answer evidence.
+func TestBlobExistenceCacheNeedsTheDigestOnARead(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		status   int
+		digest   string
+		cached   bool
+		wantHead int
+	}{
+		{"digest confirms the blob", http.StatusOK, testCacheDigest, true, 0},
+		{"no digest header", http.StatusOK, "", false, 1},
+		{"digest names another blob", http.StatusOK, "sha256:" + strings.Repeat("a", 64), false, 1},
+		// A range request is answered with a slice of the blob, and its
+		// Content-Length is the slice's.
+		{"partial content", http.StatusPartialContent, testCacheDigest, false, 1},
+		{"not found", http.StatusNotFound, "", false, 1},
+		{"upstream error", http.StatusInternalServerError, testCacheDigest, false, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			up := &readUpstream{status: tc.status, digest: tc.digest, body: "layer bytes"}
+			h, _ := newCachingHandler(t, allowHostPolicy(t, testUpstreamHost, "blob:read"), up, time.Hour)
+
+			serve(h, http.MethodGet, testUpstreamHost, testBlobPath, "")
+			entries := h.blobCache.stats().entries
+			if want := int64(0); !tc.cached && entries != want {
+				t.Errorf("cache holds %d entries after the read, want %d", entries, want)
+			}
+			if tc.cached && entries != 1 {
+				t.Errorf("cache holds %d entries after the read, want 1", entries)
+			}
+			head(h, testUpstreamHost, testBlobPath)
+			if up.heads != tc.wantHead {
+				t.Errorf("upstream saw %d probes, want %d", up.heads, tc.wantHead)
+			}
+		})
+	}
+}
+
+// TestBlobExistenceCacheIgnoresReadsOfMutableReferences: a read is only evidence
+// about content that is named by its digest.
+func TestBlobExistenceCacheIgnoresReadsOfMutableReferences(t *testing.T) {
+	for _, path := range []string{
+		"/v2/app/blobs/latest",
+		"/v2/app/manifests/latest",
+		"/v2/app/manifests/" + testCacheDigest,
+	} {
+		up := &readUpstream{status: http.StatusOK, digest: testCacheDigest, body: "bytes"}
+		h, _ := newCachingHandler(t, AllowAll(), up, time.Hour)
+
+		serve(h, http.MethodGet, testUpstreamHost, path, "")
+		if entries := h.blobCache.stats().entries; entries != 0 {
+			t.Errorf("reading %q left %d entries in the cache, want 0", path, entries)
+		}
+	}
+}
+
+// The push side of the cache. A client that finished uploading a layer has told the
+// gateway the answer to every probe for that layer which follows, so the upload fills
+// the cache exactly as a probe of its own would have.
+
+// uploadPath is the session an upload commit closes. Its reference is opaque to
+// the gateway, which learns which blob was committed from the query.
+const uploadPath = "/v2/app/blobs/uploads/uuid-123"
+
+// pushPolicy allows both blob operations on the test upstream: a push needs the
+// write, and a cross-repo mount needs read on the repository it mounts from.
+func pushPolicy(t *testing.T) *CompiledPolicy {
+	t.Helper()
+	return allowHostPolicy(t, testUpstreamHost, "blob:read", "blob:write")
+}
+
+// TestBlobExistenceCacheAdmitsCommittedUploads covers the three requests that
+// finish an upload: the commit of a streamed session, a whole blob in one POST, and
+// a cross-repo mount.
+func TestBlobExistenceCacheAdmitsCommittedUploads(t *testing.T) {
+	for _, tc := range []struct{ name, method, target, body string }{
+		{"session commit", http.MethodPut, uploadPath + "?digest=" + testCacheDigest, ""},
+		{"monolithic upload", http.MethodPost, "/v2/app/blobs/uploads/?digest=" + testCacheDigest, "layer bytes"},
+		{"cross-repo mount", http.MethodPost, "/v2/app/blobs/uploads/?mount=" + testCacheDigest + "&from=other/app", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			up := &blobUpstream{status: http.StatusCreated}
+			h, _ := newCachingHandler(t, pushPolicy(t), up, time.Hour)
+
+			if got := serve(h, tc.method, testUpstreamHost, tc.target, tc.body).Code; got != http.StatusCreated {
+				t.Fatalf("upload status = %d, want 201", got)
+			}
+			probe := head(h, testUpstreamHost, testBlobPath)
+			if probe.StatusCode != http.StatusOK {
+				t.Errorf("probe after the upload = %d, want 200", probe.StatusCode)
+			}
+			if got := up.count(http.MethodHead, testBlobPath); got != 0 {
+				t.Errorf("upstream saw %d probes, want the push to have answered them", got)
+			}
+			if got := probe.Header.Get("Docker-Content-Digest"); got != testCacheDigest {
+				t.Errorf("replayed Docker-Content-Digest = %q, want %q", got, testCacheDigest)
+			}
+		})
+	}
+}
+
+// TestBlobExistenceCacheIgnoresUnfinishedUploads is the "not too early" property,
+// and the one that decides whether this feature is safe at all. Until the commit
+// succeeds there is no blob, and a client told otherwise would skip an upload it
+// still owes and then commit a manifest referring to nothing.
+func TestBlobExistenceCacheIgnoresUnfinishedUploads(t *testing.T) {
+	for _, tc := range []struct {
+		name, method, target, body string
+		status                     int
+	}{
+		{"session opened", http.MethodPost, "/v2/app/blobs/uploads/", "", http.StatusAccepted},
+		{"session opened for a named blob", http.MethodPost, "/v2/app/blobs/uploads/?digest=" + testCacheDigest, "", http.StatusAccepted},
+		{"chunk accepted", http.MethodPatch, uploadPath, "layer bytes", http.StatusAccepted},
+		// A registry that will not mount opens a session instead, and answers 202.
+		{"mount declined", http.MethodPost, "/v2/app/blobs/uploads/?mount=" + testCacheDigest + "&from=other/app", "", http.StatusAccepted},
+		{"commit accepted but not created", http.MethodPut, uploadPath + "?digest=" + testCacheDigest, "", http.StatusAccepted},
+		{"commit rejected", http.MethodPut, uploadPath + "?digest=" + testCacheDigest, "", http.StatusBadRequest},
+		{"commit failed upstream", http.MethodPut, uploadPath + "?digest=" + testCacheDigest, "", http.StatusInternalServerError},
+		{"commit unauthorized", http.MethodPut, uploadPath + "?digest=" + testCacheDigest, "", http.StatusUnauthorized},
+		{"session cancelled", http.MethodDelete, uploadPath, "", http.StatusNoContent},
+		// A manifest is created with a 201 too, and is the one thing the cache must
+		// never hold, whatever its reference.
+		{"manifest created", http.MethodPut, "/v2/app/manifests/" + testCacheDigest, `{"schemaVersion":2}`, http.StatusCreated},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			up := &blobUpstream{status: tc.status}
+			h, _ := newCachingHandler(t, allowHostPolicy(t, testUpstreamHost,
+				"blob:read", "blob:write", "manifest:write"), up, time.Hour)
+
+			serve(h, tc.method, testUpstreamHost, tc.target, tc.body)
+			if entries := h.blobCache.stats().entries; entries != 0 {
+				t.Errorf("cache holds %d entries after %s -> %d, want 0", entries, tc.name, tc.status)
+			}
+			if got := head(h, testUpstreamHost, testBlobPath); got.StatusCode != tc.status {
+				t.Errorf("probe status = %d, want the upstream's %d: it must not have been answered from the cache", got.StatusCode, tc.status)
+			}
+			if got := up.count(http.MethodHead, testBlobPath); got != 1 {
+				t.Errorf("upstream saw %d probes, want 1", got)
+			}
+		})
+	}
+}
+
+// TestBlobExistenceCacheMountTeachesNothingAboutTheSource keeps a mount to what it
+// proves. The blob is now in the repository that asked for it; whether the registry
+// really found it in the repository named by from — rather than in storage it
+// shares between repositories — is the registry's business, not something the
+// gateway may answer for.
+func TestBlobExistenceCacheMountTeachesNothingAboutTheSource(t *testing.T) {
+	const sourcePath = "/v2/other/app/blobs/" + testCacheDigest
+	up := &blobUpstream{status: http.StatusCreated}
+	h, _ := newCachingHandler(t, pushPolicy(t), up, time.Hour)
+
+	serve(h, http.MethodPost, testUpstreamHost, "/v2/app/blobs/uploads/?mount="+testCacheDigest+"&from=other/app", "")
+
+	head(h, testUpstreamHost, sourcePath)
+	if got := up.count(http.MethodHead, sourcePath); got != 1 {
+		t.Errorf("the mount source was answered from the cache (%d upstream probes, want 1)", got)
+	}
+}
+
+// TestBlobExistenceCacheKeepsTheRegistrysDigest refuses the one case where the
+// gateway's reading of an upload and the registry's disagree. Docker-Content-Digest
+// is the registry's own account of what it created; when it names another blob,
+// remembering either would be a guess.
+func TestBlobExistenceCacheKeepsTheRegistrysDigest(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		reported string
+		want     int64
+	}{
+		{"registry confirms the digest", testCacheDigest, 1},
+		{"registry reports nothing", "", 1},
+		{"registry names another blob", "sha256:" + strings.Repeat("a", 64), 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			up := upstreamFunc(func(r *http.Request) (*http.Response, error) {
+				header := http.Header{}
+				if tc.reported != "" {
+					header.Set("Docker-Content-Digest", tc.reported)
+				}
+				return upstreamResponse(http.StatusCreated, header, ""), nil
+			})
+			h, _ := newCachingHandler(t, pushPolicy(t), up, time.Hour)
+
+			serve(h, http.MethodPut, testUpstreamHost, uploadPath+"?digest="+testCacheDigest, "")
+			if got := h.blobCache.stats().entries; got != tc.want {
+				t.Errorf("cache holds %d entries, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBlobExistenceCacheLengthOfAPushedBlob covers what a probe answered from a
+// pushed entry reports as the blob's size. One request carries the whole blob and so
+// proves its size; a session commit and a mount carry no content, and a probe then
+// omits Content-Length rather than inventing one.
+func TestBlobExistenceCacheLengthOfAPushedBlob(t *testing.T) {
+	for _, tc := range []struct{ name, method, target, body, wantLength string }{
+		{"monolithic upload is the whole blob", http.MethodPost, "/v2/app/blobs/uploads/?digest=" + testCacheDigest, "layer bytes", "11"},
+		{"a session commit carries none of it", http.MethodPut, uploadPath + "?digest=" + testCacheDigest, "", ""},
+		{"a mount transfers nothing", http.MethodPost, "/v2/app/blobs/uploads/?mount=" + testCacheDigest + "&from=other/app", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// A registry declares Content-Length: 0 on the 201, for its own empty
+			// body. That is the number a cached probe must never report as the size of
+			// the blob.
+			up := &blobUpstream{status: http.StatusCreated, contentLength: "0"}
+			h, _ := newCachingHandler(t, pushPolicy(t), up, time.Hour)
+
+			serve(h, tc.method, testUpstreamHost, tc.target, tc.body)
+			probe := head(h, testUpstreamHost, testBlobPath)
+			if probe.StatusCode != http.StatusOK {
+				t.Fatalf("probe after the upload = %d, want 200 from the cache", probe.StatusCode)
+			}
+			if got := probe.Header.Get("Content-Length"); got != tc.wantLength {
+				t.Errorf("cached Content-Length = %q, want %q", got, tc.wantLength)
+			}
+		})
+	}
+}
+
+// TestBlobExistenceCachePushedEntryExpires: an entry a push admitted lives under
+// the same TTL as one a probe admitted. It is the same failure it guards against —
+// a garbage-collected blob — and the push is no better evidence hours later.
+func TestBlobExistenceCachePushedEntryExpires(t *testing.T) {
+	const ttl = 6 * time.Hour
+	up := &blobUpstream{status: http.StatusCreated}
+	h, clock := newCachingHandler(t, pushPolicy(t), up, ttl)
+
+	serve(h, http.MethodPut, testUpstreamHost, uploadPath+"?digest="+testCacheDigest, "")
+	clock.advance(ttl - time.Second)
+	head(h, testUpstreamHost, testBlobPath)
+	if got := up.count(http.MethodHead, testBlobPath); got != 0 {
+		t.Fatalf("upstream saw %d probes before the TTL was up, want 0", got)
+	}
+	clock.advance(2 * time.Second)
+	head(h, testUpstreamHost, testBlobPath)
+	if got := up.count(http.MethodHead, testBlobPath); got != 1 {
+		t.Errorf("upstream saw %d probes after the TTL passed, want 1", got)
+	}
+}
+
+// TestBlobExistenceCachePushedEntryStillAsksThePolicy: an entry admitted by a push
+// is subject to the same rule as any other, so a reload that revokes access takes
+// effect on the next probe even though the answer to it is sitting in memory.
+func TestBlobExistenceCachePushedEntryStillAsksThePolicy(t *testing.T) {
+	up := &blobUpstream{status: http.StatusCreated}
+	h, _ := newCachingHandler(t, pushPolicy(t), up, time.Hour)
+
+	if got := serve(h, http.MethodPut, testUpstreamHost, uploadPath+"?digest="+testCacheDigest, "").Code; got != http.StatusCreated {
+		t.Fatalf("upload status = %d, want 201", got)
+	}
+	h.policy.Store(&CompiledPolicy{})
+	if got := head(h, testUpstreamHost, testBlobPath).StatusCode; got != http.StatusForbidden {
+		t.Errorf("probe status after the policy stopped allowing the repository = %d, want 403", got)
+	}
+}
+
+// The other direction: a blob a client deletes through the gateway is a blob the
+// cache must stop claiming is there, without waiting out its TTL.
+
+// deleteUpstream answers an existence check with 200 and a delete with a scripted
+// outcome, so a test can tell a probe that was forwarded from one that was replayed.
+type deleteUpstream struct {
+	status int
+	// err, when set, is returned instead of a response: a delete whose answer never
+	// arrives.
+	err     error
+	heads   int
+	deletes int
+}
+
+func (u *deleteUpstream) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.URL.Path == "/v2/" || r.URL.Path == "/v2" {
+		return upstreamResponse(http.StatusOK, nil, ""), nil
+	}
+	switch r.Method {
+	case http.MethodHead:
+		u.heads++
+		header := http.Header{}
+		header.Set("Content-Length", "12345")
+		return upstreamResponse(http.StatusOK, header, ""), nil
+	case http.MethodDelete:
+		u.deletes++
+		if u.err != nil {
+			return nil, u.err
+		}
+		return upstreamResponse(u.status, nil, ""), nil
+	default:
+		return upstreamResponse(http.StatusMethodNotAllowed, nil, ""), nil
+	}
+}
+
+// deletePolicy allows the probe and the delete, which is a blob write.
+func deletePolicy(t *testing.T) *CompiledPolicy {
+	t.Helper()
+	return allowHostPolicy(t, testUpstreamHost, "blob:read", "blob:write")
+}
+
+// TestBlobExistenceCacheForgetsDeletedBlobs is the cache's own correction. A blob
+// the registry garbage-collects disappears unseen, which is what the TTL is for; a
+// delete travels through the gateway, so that entry need not outlive it.
+//
+// The upstream's answer is deliberately not consulted, and the table says why: only
+// a refusal leaves the blob certainly in place, while a 5xx or a 404 (which is also
+// how a registry with deletes disabled answers) leaves the gateway unable to tell.
+// Dropping the entry costs one probe; keeping a false one costs a client the layer it
+// decided not to re-upload.
+func TestBlobExistenceCacheForgetsDeletedBlobs(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+	}{
+		{"accepted", http.StatusAccepted},
+		{"ok", http.StatusOK},
+		{"no content", http.StatusNoContent},
+		{"not found", http.StatusNotFound},
+		{"upstream error", http.StatusInternalServerError},
+		{"refused", http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			up := &deleteUpstream{status: tc.status}
+			h, _ := newCachingHandler(t, deletePolicy(t), up, time.Hour)
+
+			// Warm the cache, and check it is warm.
+			head(h, testUpstreamHost, testBlobPath)
+			head(h, testUpstreamHost, testBlobPath)
+			if up.heads != 1 {
+				t.Fatalf("upstream saw %d probes while warming, want 1", up.heads)
+			}
+
+			serve(h, http.MethodDelete, testUpstreamHost, testBlobPath, "")
+			if entries := h.blobCache.stats().entries; entries != 0 {
+				t.Errorf("cache holds %d entries after a delete answered %d, want 0", entries, tc.status)
+			}
+			if got := head(h, testUpstreamHost, testBlobPath).StatusCode; got != http.StatusOK {
+				t.Errorf("probe after the delete = %d, want 200", got)
+			}
+			if up.heads != 2 {
+				t.Errorf("upstream saw %d probes, want the one after the delete to have been forwarded", up.heads)
+			}
+		})
+	}
+}
+
+// TestBlobExistenceCacheForgetsADeleteWithNoAnswer covers the delete whose outcome
+// the gateway never learns. The registry may have carried it out regardless, so the
+// entry goes.
+func TestBlobExistenceCacheForgetsADeleteWithNoAnswer(t *testing.T) {
+	up := &deleteUpstream{err: &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}}
+	h, _ := newCachingHandler(t, deletePolicy(t), up, time.Hour)
+
+	head(h, testUpstreamHost, testBlobPath)
+	if got := serve(h, http.MethodDelete, testUpstreamHost, testBlobPath, "").Code; got != http.StatusBadGateway {
+		t.Fatalf("delete status = %d, want 502", got)
+	}
+	if entries := h.blobCache.stats().entries; entries != 0 {
+		t.Errorf("cache holds %d entries after a delete that got no answer, want 0", entries)
+	}
+}
+
+// TestBlobExistenceCacheForgetsOnlyTheDeletedBlob: an invalidation is not a flush.
+func TestBlobExistenceCacheForgetsOnlyTheDeletedBlob(t *testing.T) {
+	const otherDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	up := &deleteUpstream{status: http.StatusAccepted}
+	h, _ := newCachingHandler(t, AllowAll(), up, time.Hour)
+
+	// Three entries: the blob about to be deleted, the same digest in another
+	// repository, and another digest in the same one.
+	head(h, testUpstreamHost, testBlobPath)
+	head(h, testUpstreamHost, "/v2/other/blobs/"+testCacheDigest)
+	head(h, testUpstreamHost, "/v2/app/blobs/"+otherDigest)
+	if entries := h.blobCache.stats().entries; entries != 3 {
+		t.Fatalf("cache holds %d entries after warming, want 3", entries)
+	}
+
+	serve(h, http.MethodDelete, testUpstreamHost, testBlobPath, "")
+
+	if entries := h.blobCache.stats().entries; entries != 2 {
+		t.Errorf("cache holds %d entries after one delete, want 2", entries)
+	}
+	before := up.heads
+	head(h, testUpstreamHost, "/v2/other/blobs/"+testCacheDigest)
+	head(h, testUpstreamHost, "/v2/app/blobs/"+otherDigest)
+	if up.heads != before {
+		t.Errorf("upstream saw %d further probes, want the other two blobs still answered from the cache", up.heads-before)
+	}
+}
+
+// TestBlobExistenceCacheKeptByRequestsThatDeleteNoBlob covers the requests that look
+// like a blob delete without being one. Dropping an entry is never a wrong answer,
+// only a wasted probe, but a session cancellation happens on every abandoned upload
+// and must not evict the layer the fleet is asking about.
+func TestBlobExistenceCacheKeptByRequestsThatDeleteNoBlob(t *testing.T) {
+	for _, tc := range []struct{ name, method, target string }{
+		{"upload session cancelled", http.MethodDelete, "/v2/app/blobs/uploads/uuid-123"},
+		{"manifest deleted", http.MethodDelete, "/v2/app/manifests/" + testCacheDigest},
+		{"blob deleted by a reference that is not a digest", http.MethodDelete, "/v2/app/blobs/latest"},
+		{"blob read", http.MethodGet, testBlobPath},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			up := &deleteUpstream{status: http.StatusAccepted}
+			h, _ := newCachingHandler(t, AllowAll(), up, time.Hour)
+
+			head(h, testUpstreamHost, testBlobPath)
+			serve(h, tc.method, testUpstreamHost, tc.target, "")
+			if entries := h.blobCache.stats().entries; entries != 1 {
+				t.Errorf("cache holds %d entries after %s, want the blob's entry kept", entries, tc.name)
+			}
+			if got := head(h, testUpstreamHost, testBlobPath).StatusCode; got != http.StatusOK {
+				t.Fatalf("probe status = %d, want 200", got)
+			}
+			if up.heads != 1 {
+				t.Errorf("upstream saw %d probes, want the second answered from the cache", up.heads)
+			}
+		})
+	}
+}
+
+// TestBlobExistenceCacheKeptByADeniedDelete is the security half: a client the policy
+// turns away has not reached the registry, so it has learned nothing and changed
+// nothing — including in the cache.
+func TestBlobExistenceCacheKeptByADeniedDelete(t *testing.T) {
+	up := &deleteUpstream{status: http.StatusAccepted}
+	h, _ := newCachingHandler(t, allowHostPolicy(t, testUpstreamHost, "blob:read"), up, time.Hour)
+
+	head(h, testUpstreamHost, testBlobPath)
+	if got := serve(h, http.MethodDelete, testUpstreamHost, testBlobPath, "").Code; got != http.StatusForbidden {
+		t.Fatalf("delete status = %d, want 403", got)
+	}
+	if up.deletes != 0 {
+		t.Fatalf("a denied delete reached the upstream %d times", up.deletes)
+	}
+	if entries := h.blobCache.stats().entries; entries != 1 {
+		t.Errorf("cache holds %d entries after a denied delete, want the entry kept", entries)
+	}
+}
+
+// TestBlobExistenceCacheDeleteEvictionMetric: an entry dropped by a delete is
+// reported under its own reason, so an operator can see invalidations happening
+// rather than reading them as capacity pressure.
+func TestBlobExistenceCacheDeleteEvictionMetric(t *testing.T) {
+	up := upstreamFunc(func(r *http.Request) (*http.Response, error) {
+		header := http.Header{}
+		header.Set("Content-Length", "1")
+		return upstreamResponse(http.StatusOK, header, ""), nil
+	})
+	h, collect := newMetricsHandler(t, deletePolicy(t), up, WithBlobExistenceCache(time.Hour, 256*entryCost))
+
+	head(h, testUpstreamHost, testBlobPath)
+	serve(h, http.MethodDelete, testUpstreamHost, testBlobPath, "")
+	// A second delete for a blob the cache no longer holds is not counted twice.
+	serve(h, http.MethodDelete, testUpstreamHost, testBlobPath, "")
+	rm := collect()
+
+	if got := counterValue(t, rm, "oci.gateway.blob_existence_cache.evictions",
+		attrEvictionReason.String(evictedForDelete)); got != 1 {
+		t.Errorf("delete evictions = %d, want 1", got)
+	}
+	for _, reason := range []string{evictedForCapacity, evictedForExpiry} {
+		if got := counterValue(t, rm, "oci.gateway.blob_existence_cache.evictions",
+			attrEvictionReason.String(reason)); got != 0 {
+			t.Errorf("%s evictions = %d, want 0", reason, got)
+		}
+	}
+	if got := gaugeValue(t, rm, "oci.gateway.blob_existence_cache.entries"); got != 0 {
+		t.Errorf("cache entries = %d, want 0", got)
 	}
 }
 

--- a/img_tool/pkg/serve/gateway/existencecache_test.go
+++ b/img_tool/pkg/serve/gateway/existencecache_test.go
@@ -101,6 +101,48 @@ func TestBlobCacheKeyIsAllThreeParts(t *testing.T) {
 	}
 }
 
+// TestBlobCacheForget covers the one thing that unmakes an entry before its TTL:
+// the blob left the repository, and the cache was told.
+func TestBlobCacheForget(t *testing.T) {
+	c, _ := newTestCache(t, time.Hour, 64)
+
+	// Forgetting what the cache never held is not an error and costs nothing.
+	c.forget(testCacheRegistry, testCacheRepository, testCacheDigest)
+	if stats := c.stats(); stats.entries != 0 || stats.evictedDeleted != 0 {
+		t.Fatalf("forgetting an absent key: entries = %d, deleted evictions = %d; want 0 and 0", stats.entries, stats.evictedDeleted)
+	}
+
+	c.store(testCacheRegistry, testCacheRepository, testCacheDigest, 4096)
+	c.store(testCacheRegistry, testCacheRepository, blobDigest(1), 8192)
+	c.forget(testCacheRegistry, testCacheRepository, testCacheDigest)
+
+	if _, ok := c.lookup(testCacheRegistry, testCacheRepository, testCacheDigest); ok {
+		t.Error("a forgotten blob is still reported as present")
+	}
+	// Only that one key: forgetting is not a flush.
+	if _, ok := c.lookup(testCacheRegistry, testCacheRepository, blobDigest(1)); !ok {
+		t.Error("forgetting one blob dropped another")
+	}
+	if stats := c.stats(); stats.entries != 1 || stats.evictedDeleted != 1 {
+		t.Errorf("after forgetting one of two: entries = %d, deleted evictions = %d; want 1 and 1", stats.entries, stats.evictedDeleted)
+	}
+	// The slot went back into circulation rather than leaking, and the blob can be
+	// stored again — a delete is not a tombstone.
+	checkIntegrity(t, c)
+	c.store(testCacheRegistry, testCacheRepository, testCacheDigest, 4096)
+	if length, ok := c.lookup(testCacheRegistry, testCacheRepository, testCacheDigest); !ok || length != 4096 {
+		t.Errorf("re-storing a forgotten blob: length = %d, ok = %v; want 4096 and true", length, ok)
+	}
+	checkIntegrity(t, c)
+}
+
+// TestBlobCacheForgetOnDisabledCache: a nil cache tolerates every method, which is
+// what keeps the handler free of a second code path for the cache being off.
+func TestBlobCacheForgetOnDisabledCache(t *testing.T) {
+	var c *blobExistenceCache
+	c.forget(testCacheRegistry, testCacheRepository, testCacheDigest)
+}
+
 // TestBlobCacheHashCollisionMisses forces two keys to share a hash, which is the
 // case the stored key bytes exist to settle.
 func TestBlobCacheHashCollisionMisses(t *testing.T) {

--- a/img_tool/pkg/serve/gateway/gateway.go
+++ b/img_tool/pkg/serve/gateway/gateway.go
@@ -16,8 +16,10 @@
 //
 // Successful blob existence checks can be memoized with
 // [WithBlobExistenceCache], which is what keeps a build farm's repeated "is this
-// layer already pushed?" probes from each costing an upstream round trip (see
-// existencecache.go).
+// layer already pushed?" probes from each costing an upstream round trip. Every
+// other request that settles whether a blob is in a repository keeps that memo
+// current: a read that serves the blob and an upload that commits it admit an entry,
+// and a delete takes one away (see existencecache.go).
 package gateway
 
 import (
@@ -165,16 +167,24 @@ func WithPeerAuth(auth *PeerAuth) Option {
 // thousands. Entries are keyed by upstream registry, repository, and digest, and
 // held for ttl.
 //
+// A blob read that the registry serves under the digest asked for is admitted too,
+// as is an upload that the gateway forwards to a successful commit: the registry has
+// just hashed that content against the digest, so a probe a moment later would answer
+// 200 and the client that pushed spares every other client the first probe. Only the
+// response that completes an upload counts, never the session it is the end of. A
+// blob delete forwarded the other way drops the entry again.
+//
 // maxBytes bounds the cache's memory, which is allocated in full at startup and
 // never grows; once it is full, the least recently used entry makes room for a
 // new one. A ttl or maxBytes that is not positive disables the cache, as does a
 // maxBytes below [MinBlobExistenceCacheBytes].
 //
-// ttl is the only thing standing between a client and a stale answer: a blob
-// cannot change, but a registry can garbage-collect one, and a push client that
-// believes a collected layer is still there will skip re-uploading it and commit
-// a manifest referring to nothing. Keep ttl well inside the window in which the
-// registry could collect a blob.
+// ttl is what stands between a client and the one stale answer the gateway cannot
+// see coming: a blob cannot change, but a registry can garbage-collect one behind
+// the gateway's back, and a push client that believes a collected layer is still
+// there will skip re-uploading it and commit a manifest referring to nothing. Keep
+// ttl well inside the window in which the registry could collect a blob. A blob a
+// client deletes through the gateway needs no such window — that entry goes at once.
 //
 // Manifests and tags are never cached: both are mutable, and a HEAD on one is
 // exactly how a client finds out that it changed.
@@ -442,6 +452,128 @@ func (h *Handler) cacheableBlobHead(r *http.Request, cls request) bool {
 	return true
 }
 
+// cacheableBlobRead reports whether a request is a read of a digest-referenced
+// blob, the answer to which can say the blob is there.
+func (h *Handler) cacheableBlobRead(cls request) bool {
+	return h.blobCache != nil && cls.op == opNameBlobRead && cls.digest != ""
+}
+
+// cacheableBlobUpload reports whether a request is one whose success puts a blob in
+// the repository under a digest the cache can be keyed on. [classify] carries the
+// digest for exactly those requests and no others (see [committedDigest]).
+func (h *Handler) cacheableBlobUpload(cls request) bool {
+	return h.blobCache != nil && cls.op == opNameBlobUpload && cls.digest != ""
+}
+
+// rememberBlob admits a blob to the existence cache when the response the gateway
+// just received is proof that the blob is in the repository. Three responses are:
+//
+//   - 200 to an existence check: the answer the cache exists to replay.
+//   - 200 to a blob read that the registry says is the blob asked for. Handing over
+//     the content is a stronger statement than answering a probe, and a fleet that
+//     pulls a layer today is one that will ask whether it needs to push it tomorrow.
+//   - 201 Created to the request that finishes an upload, which is the registry
+//     stating that it hashed the content it received, matched it against the
+//     digest, and stored it. A HEAD sent a moment later would answer 200, so the
+//     client that did the pushing warms the cache for everyone else instead of the
+//     next fleet member paying for a probe of its own.
+//
+// Nothing earlier in an upload counts. A 202 means only that a session was opened
+// or a chunk was accepted; until the commit succeeds there is no blob, and a client
+// told otherwise would skip an upload it still owes. Any status other than the one
+// each case names leaves the cache untouched — including the 206 that answers a
+// ranged read, whose Content-Length is a slice of the blob rather than its size.
+//
+// [Handler.forgetDeletedBlob] is the other direction.
+func (h *Handler) rememberBlob(r *http.Request, repo name.Repository, cls request, resp *http.Response) {
+	var length int64
+	switch {
+	case h.cacheableBlobHead(r, cls) && resp.StatusCode == http.StatusOK:
+		length = blobLength(resp)
+	case h.cacheableBlobRead(cls) && resp.StatusCode == http.StatusOK && servedDigest(resp, cls.digest):
+		length = blobLength(resp)
+	case h.cacheableBlobUpload(cls) && resp.StatusCode == http.StatusCreated && confirmsDigest(resp, cls.digest):
+		length = uploadedLength(r, cls)
+	default:
+		return
+	}
+	h.blobCache.store(repo.RegistryStr(), repo.RepositoryStr(), cls.digest, length)
+}
+
+// confirmsDigest reports whether the registry's own account of what it created
+// agrees with the digest the request asked it to create.
+//
+// Docker-Content-Digest is not required on a 201 and, when a registry does send
+// one, it is all but always the digest already in the request. A registry that
+// names a different blob is one whose reading of the request is not the gateway's,
+// which is the one case where remembering either answer would be a guess.
+func confirmsDigest(resp *http.Response, digest string) bool {
+	reported := resp.Header.Get("Docker-Content-Digest")
+	return reported == "" || reported == digest
+}
+
+// servedDigest reports whether the registry said, in so many words, that the body it
+// is answering a blob read with is the blob that was asked for.
+//
+// Here the header is required, not merely respected — the asymmetry with
+// [confirmsDigest] is the point. A commit is proof on its own, because the registry
+// hashed the content before answering; a read is only proof if the registry names
+// what it served, since the gateway streams the body through without hashing it and
+// a blob read may be redirected to storage that serves whatever it is pointed at. An
+// answer without the header is forwarded to the client and forgotten.
+func servedDigest(resp *http.Response, digest string) bool {
+	return resp.Header.Get("Docker-Content-Digest") == digest
+}
+
+// uploadedLength is the size of a blob whose upload just committed, when this one
+// request is proof of the size, and -1 (unknown) otherwise.
+//
+// The request whose body is the whole blob is a monolithic POST upload: the
+// registry's 201 says it hashed exactly those bytes into the digest that was asked
+// for. A session commit proves nothing about the size — the PUT that closes a
+// session usually carries no body at all, the content having gone upstream in PATCH
+// requests the gateway does not correlate with the commit — and a cross-repo mount
+// transfers no bytes in the first place.
+//
+// The *response's* Content-Length is not the blob's and must not be read as it: a
+// registry sets it to 0 on the 201, whose body is empty.
+//
+// An entry whose length is unknown is still worth keeping, since the existence
+// answer is what a push client is blocked on, and a HEAD answered from one simply
+// omits Content-Length — the same reply the cache already gives for a registry that
+// reports no length.
+func uploadedLength(r *http.Request, cls request) int64 {
+	if r.Method != http.MethodPost || cls.mountFrom != "" || r.ContentLength < 0 {
+		return -1
+	}
+	return r.ContentLength
+}
+
+// forgetDeletedBlob drops the cache entry for a blob a client asked the upstream to
+// delete. It is the counterpart of [Handler.rememberBlob], and the only thing that
+// unmakes an entry before its TTL runs out.
+//
+// The upstream's answer is deliberately not consulted, and this is called even when
+// no answer arrived. The 202 that a delete usually earns (some registries answer 200
+// or 204) means the entry is now false; a 5xx, a timeout, or a client that hung up
+// means the gateway does not know whether it is; a refusal means the blob is still
+// there. Only the last of those makes dropping the entry unnecessary, and dropping it
+// costs one existence check the next time somebody asks. Keeping a false one costs a
+// push client the layer it decided not to re-upload, and then a manifest that
+// references a blob which is gone — so a delete that passed through here is read
+// pessimistically.
+//
+// Dropping after the round trip rather than before it is what keeps a probe arriving
+// mid-delete from writing the entry straight back: the upstream answers such a probe
+// from the state before the delete.
+func (h *Handler) forgetDeletedBlob(repo name.Repository, cls request) {
+	// classify carries a digest on a blob write for a DELETE and nothing else.
+	if h.blobCache == nil || cls.op != opNameBlobWrite || cls.digest == "" {
+		return
+	}
+	h.blobCache.forget(repo.RegistryStr(), repo.RepositoryStr(), cls.digest)
+}
+
 // uncacheableHeaders make a response depend on more than whether the blob exists,
 // so a request carrying one is passed through untouched and its answer is not
 // stored: the upstream would answer it with a 206 or a 304, and the cache only
@@ -534,6 +666,10 @@ func (h *Handler) forward(obs *observation, w http.ResponseWriter, r *http.Reque
 	started := time.Now()
 	resp, err := client.Do(outReq)
 	if err != nil {
+		// A delete whose answer never came back may have taken effect all the same,
+		// and an entry for a blob that is gone is the one wrong answer this cache can
+		// give.
+		h.forgetDeletedBlob(repo, cls)
 		h.writeError(obs, w, r, http.StatusBadGateway, "UNKNOWN", transportErrorType(err),
 			fmt.Sprintf("forwarding to upstream %s: %v", repo.RegistryStr(), err))
 		return
@@ -541,12 +677,11 @@ func (h *Handler) forward(obs *observation, w http.ResponseWriter, r *http.Reque
 	defer resp.Body.Close()
 	obs.upstreamResponse(r.Context(), cls, resp.StatusCode, time.Since(started))
 
-	// Remember a blob the registry confirmed, so the next probe for it costs no
-	// round trip. Only a plain 200 is stored: that is the one answer that means
-	// "this blob is present", and it is the only one the cache replays.
-	if resp.StatusCode == http.StatusOK && h.cacheableBlobHead(r, cls) {
-		h.blobCache.store(repo.RegistryStr(), repo.RepositoryStr(), cls.digest, blobLength(resp))
-	}
+	// Bring the blob existence cache in line with what the registry just did: the
+	// 200 that says a blob is there and the 201 that says it was just put there
+	// admit an entry, and a delete takes one away.
+	h.rememberBlob(r, repo, cls, resp)
+	h.forgetDeletedBlob(repo, cls)
 
 	copyResponseHeader(w.Header(), resp.Header, repo)
 	w.WriteHeader(resp.StatusCode)

--- a/img_tool/pkg/serve/gateway/metrics.go
+++ b/img_tool/pkg/serve/gateway/metrics.go
@@ -57,8 +57,8 @@ const (
 	// "certificate", "ca", or "token".
 	attrMaterial = attribute.Key("oci.gateway.material")
 	// attrEvictionReason says why a cache entry was dropped: "capacity" (it was
-	// the least recently used entry when room was needed) or "expired" (its TTL
-	// had passed).
+	// the least recently used entry when room was needed), "expired" (its TTL
+	// had passed), or "deleted" (a delete for that blob went through the gateway).
 	attrEvictionReason = attribute.Key("oci.gateway.cache.eviction.reason")
 	// attrPeer is the peer gateway a forwarder relays to. It is constant for the
 	// life of the process, so it costs no cardinality; it is attached anyway so a
@@ -82,6 +82,7 @@ const (
 	// Values of [attrEvictionReason].
 	evictedForCapacity = "capacity"
 	evictedForExpiry   = "expired"
+	evictedForDelete   = "deleted"
 )
 
 const (
@@ -298,6 +299,7 @@ func (b *instruments) observe(sources gaugeSources) {
 		o.ObserveInt64(capacity, stats.capacity)
 		o.ObserveInt64(evictions, stats.evictedCapacity, metric.WithAttributes(attrEvictionReason.String(evictedForCapacity)))
 		o.ObserveInt64(evictions, stats.evictedExpired, metric.WithAttributes(attrEvictionReason.String(evictedForExpiry)))
+		o.ObserveInt64(evictions, stats.evictedDeleted, metric.WithAttributes(attrEvictionReason.String(evictedForDelete)))
 		return nil
 	}, entries, capacity, evictions)
 	b.track(err)


### PR DESCRIPTION
The gateway's blob existence cache memoizes one fact — *this blob is in this repository* — and until now learned it one way: a client asked, the registry answered `200`. Three other requests settle the very same fact as they pass through the gateway. This teaches the cache to learn from all of them, and to unlearn when a blob is deleted.

| Request | Effect |
| --- | --- |
| `HEAD .../blobs/<digest>` answered `200` | remembered (unchanged) |
| `GET .../blobs/<digest>` answered `200`, with a `Docker-Content-Digest` naming that blob | remembered, with the size it served |
| `PUT .../blobs/uploads/<ref>?digest=<digest>` answered `201` | remembered: the upload committed |
| `POST .../blobs/uploads/?digest=<digest>` answered `201` | remembered: the whole blob arrived in one request |
| `POST .../blobs/uploads/?mount=<digest>&from=<repo>` answered `201` | remembered: the mount was honoured |
| `DELETE .../blobs/<digest>` forwarded | forgotten, whatever the registry answers |

The machine that wins the race to push a layer now answers the probe for every machine behind it, so a fleet pays for neither the second upload nor the first probe — and a blob deleted through the gateway stops being claimed at once instead of at the end of its TTL.

## Being careful about what counts

**A read is held to a stricter standard than a commit.** The registry must name what it served in `Docker-Content-Digest`. A commit is proof on its own — the registry hashed the content before answering — but the gateway streams a read's body through without hashing it, and a blob read may be redirected to storage that serves whatever it is pointed at. Without the header the answer is forwarded and forgotten. A `206` is not a read of the blob either: its `Content-Length` is a slice of it.

**Nothing earlier than a commit counts, which is the failure that matters here.** A `202` means only that a session was opened or a chunk accepted; a client told that a half-uploaded blob is present would skip an upload it still owes and then commit a manifest referring to nothing. So a session start, a `PATCH`, a status query, a cancellation, a failed commit, and a mount the registry declined all leave the cache untouched. Three narrower limits fall out of the same caution: an ambiguous query (two `digest` values, or a `;` this gateway drops and a lenient registry might honour) is read for no digest at all; a `201` whose `Docker-Content-Digest` names a different blob stores nothing; and a mount teaches nothing about the repository in its `from`, since whether the registry really found the content there or in storage it shares between repositories is not the gateway's to answer.

**A delete is read pessimistically**, and the entry goes even when no answer arrives. A `5xx`, a timeout, or a client that hung up leaves the gateway unable to tell whether the blob survived, and a `404` is both "no such blob" and how a registry with deletions disabled refuses. Dropping an entry costs one existence check; keeping a false one costs a push client the layer it decided not to re-upload. It stays an invalidation of one blob rather than a flush: only a `DELETE` of a blob by digest counts, so an upload session cancellation (which happens on every abandoned push), a manifest delete, and a delete addressed by anything but a digest leave the cache alone — as does a delete the policy denies, which never reaches the registry at all. Dropping *after* the round trip rather than before it keeps a probe arriving mid-delete from writing the entry straight back.

Nothing about authorization changes: the policy is still consulted on every request before the cache is, and a delete carries its digest under the same operation token and policy requirement a blob write has always had.

## Content-Length

An entry admitted by a session commit or a mount holds no length — neither request sees the blob's bytes — so a probe it answers omits the header rather than inventing a size, the same reply the cache already gives for a registry that reports no length. In particular the *response's* `Content-Length` is not the blob's: a registry sets it to `0` on the `201`, for its own empty body. A read and a monolithic upload do carry the whole blob, so those entries have its size.

## Metrics

Entries dropped by a delete are reported under a new `oci.gateway.cache.eviction.reason` value, `deleted`, so an operator can tell invalidation apart from the capacity pressure sharing that counter.