### PR TITLE
perf: use relative symlinks for directory layouts on Bazel >= 7.1

### DIFF
--- a/img/private/BUILD.bazel
+++ b/img/private/BUILD.bazel
@@ -19,10 +19,21 @@ bzl_library(
 )
 
 bzl_library(
+    name = "oci_layout_action",
+    srcs = ["oci_layout_action.bzl"],
+    visibility = ["//img:__subpackages__"],
+    deps = [
+        "//img/private/common:build",
+        "@bazel_features//:features",
+    ],
+)
+
+bzl_library(
     name = "index",
     srcs = ["index.bzl"],
     visibility = ["//img:__subpackages__"],
     deps = [
+        ":oci_layout_action",
         ":push_metadata",
         ":soci_deploy",
         ":stamp",
@@ -150,6 +161,7 @@ bzl_library(
     visibility = ["//img:__subpackages__"],
     deps = [
         ":annotations_util",
+        ":oci_layout_action",
         ":push_metadata",
         ":stamp",
         "//img/private/common:build",
@@ -176,6 +188,7 @@ bzl_library(
     srcs = ["optimize.bzl"],
     visibility = ["//img:__subpackages__"],
     deps = [
+        ":oci_layout_action",
         "//img/private/common:build",
         "//img/private/common:layer_helper",
         "//img/private/common:transitions",

--- a/img/private/index.bzl
+++ b/img/private/index.bzl
@@ -1,6 +1,7 @@
 """Image index rule for composing multi-layer OCI images."""
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("//img/private:oci_layout_action.bzl", "run_oci_layout_action")
 load("//img/private:push_metadata.bzl", "process_deploy_specs")
 load("//img/private:soci_deploy.bzl", "soci_deploy_children")
 load("//img/private:stamp.bzl", "expand_or_write")
@@ -39,7 +40,6 @@ def _build_oci_layout(ctx, format, index_out, manifests):
     args.add("oci-layout")
     args.add("--format", format)
     args.add("--index", index_out.path)
-    args.add("--output", oci_layout_output.path)
     if ctx.attr._oci_layout_settings[OCILayoutSettingsInfo].allow_shallow_oci_layout:
         args.add("--allow-missing-blobs")
 
@@ -59,13 +59,12 @@ def _build_oci_layout(ctx, format, index_out, manifests):
                 inputs.append(layer.metadata)
                 inputs.append(layer.blob)
 
-    img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
-    ctx.actions.run(
+    run_oci_layout_action(
+        ctx,
+        format = format,
+        output = oci_layout_output,
+        args = args,
         inputs = inputs,
-        outputs = [oci_layout_output],
-        executable = img_toolchain_info.tool_exe,
-        arguments = [args],
-        env = {"RULES_IMG": "1"},
         mnemonic = "OCIIndexLayout",
     )
 

--- a/img/private/manifest.bzl
+++ b/img/private/manifest.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//img/private:annotations_util.bzl", "extract_annotations_from_pull_info")
+load("//img/private:oci_layout_action.bzl", "run_oci_layout_action")
 load("//img/private:push_metadata.bzl", "process_deploy_specs")
 load("//img/private:stamp.bzl", "expand_or_write")
 load("//img/private/common:build.bzl", "TOOLCHAIN", "TOOLCHAINS")
@@ -235,7 +236,6 @@ def _build_oci_layout(ctx, format, manifest_out, config_out, layers):
     args.add("--format", format)
     args.add("--manifest", manifest_out.path)
     args.add("--config", config_out.path)
-    args.add("--output", oci_layout_output.path)
     if ctx.attr._oci_layout_settings[OCILayoutSettingsInfo].allow_shallow_oci_layout:
         args.add("--allow-missing-blobs")
 
@@ -248,13 +248,12 @@ def _build_oci_layout(ctx, format, manifest_out, config_out, layers):
             inputs.append(layer.metadata)
             inputs.append(layer.blob)
 
-    img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
-    ctx.actions.run(
+    run_oci_layout_action(
+        ctx,
+        format = format,
+        output = oci_layout_output,
+        args = args,
         inputs = inputs,
-        outputs = [oci_layout_output],
-        executable = img_toolchain_info.tool_exe,
-        arguments = [args],
-        env = {"RULES_IMG": "1"},
         mnemonic = "OCILayout",
     )
 

--- a/img/private/oci_layout_action.bzl
+++ b/img/private/oci_layout_action.bzl
@@ -11,6 +11,10 @@ def run_oci_layout_action(ctx, *, format, output, args, inputs, mnemonic):
     shared-base model.  The img tool produces relative symlinks, which are safe
     under remote execution and runfiles trees.  Tar outputs always embed blobs.
 
+    Symlinks are skipped on Windows exec platforms: Windows hardlinks to reparse
+    points propagate the (now-misplaced) relative target to the new file, turning
+    it into a dangling symlink when downstream tools copy blobs out of the tree.
+
     Args:
         ctx: Rule context.
         format: Output format, either "directory" or "tar".
@@ -19,16 +23,21 @@ def run_oci_layout_action(ctx, *, format, output, args, inputs, mnemonic):
         inputs: List of input files for the action.
         mnemonic: Action mnemonic string.
     """
-    if format == "directory" and bazel_features.rules.permits_treeartifact_uplevel_symlinks:
+    img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
+    tool = img_toolchain_info.tool_exe
+
+    # The img tool is img.exe on Windows exec platforms and img elsewhere.
+    is_windows_exec = tool.basename.endswith(".exe")
+
+    if format == "directory" and not is_windows_exec and bazel_features.rules.permits_treeartifact_uplevel_symlinks:
         args.add("--symlink")
 
     args.add("--output", output.path)
 
-    img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
     ctx.actions.run(
         inputs = inputs,
         outputs = [output],
-        executable = img_toolchain_info.tool_exe,
+        executable = tool,
         arguments = [args],
         env = {"RULES_IMG": "1"},
         mnemonic = mnemonic,

--- a/img/private/oci_layout_action.bzl
+++ b/img/private/oci_layout_action.bzl
@@ -1,0 +1,35 @@
+"""Shared helper to run img oci-layout with optional uplevel symlinks."""
+
+load("@bazel_features//:features.bzl", "bazel_features")
+load("//img/private/common:build.bzl", "TOOLCHAIN")
+
+def run_oci_layout_action(ctx, *, format, output, args, inputs, mnemonic):
+    """Run `img oci-layout`, emitting relative symlinks for directory outputs on Bazel >= 7.1.
+
+    Directory TreeArtifact outputs use --symlink so that shared base-image blobs
+    are symlinked rather than copied into every layout, matching rules_oci's
+    shared-base model.  The img tool produces relative symlinks, which are safe
+    under remote execution and runfiles trees.  Tar outputs always embed blobs.
+
+    Args:
+        ctx: Rule context.
+        format: Output format, either "directory" or "tar".
+        output: The declared output artifact (TreeArtifact or File).
+        args: An ctx.actions.args() object with all flags except --output.
+        inputs: List of input files for the action.
+        mnemonic: Action mnemonic string.
+    """
+    if format == "directory" and bazel_features.rules.permits_treeartifact_uplevel_symlinks:
+        args.add("--symlink")
+
+    args.add("--output", output.path)
+
+    img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
+    ctx.actions.run(
+        inputs = inputs,
+        outputs = [output],
+        executable = img_toolchain_info.tool_exe,
+        arguments = [args],
+        env = {"RULES_IMG": "1"},
+        mnemonic = mnemonic,
+    )

--- a/img/private/optimize.bzl
+++ b/img/private/optimize.bzl
@@ -1,6 +1,7 @@
 """Image optimization rule for rewriting existing image layers."""
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("//img/private:oci_layout_action.bzl", "run_oci_layout_action")
 load("//img/private/common:build.bzl", "TOOLCHAIN", "TOOLCHAINS")
 load("//img/private/common:layer_helper.bzl", "IMAGE_MTREE_ATTRS", "compression_tuning_args", "image_mtree_or_none")
 load("//img/private/common:transitions.bzl", "reset_platform_transition")
@@ -174,7 +175,6 @@ def _build_manifest_oci_layout(ctx, format, manifest):
     args.add("--format", format)
     args.add("--manifest", manifest.manifest.path)
     args.add("--config", manifest.config.path)
-    args.add("--output", oci_layout_output.path)
     if ctx.attr._oci_layout_settings[OCILayoutSettingsInfo].allow_shallow_oci_layout:
         args.add("--allow-missing-blobs")
 
@@ -184,13 +184,12 @@ def _build_manifest_oci_layout(ctx, format, manifest):
         inputs.append(layer.metadata)
         inputs.append(layer.blob)
 
-    img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
-    ctx.actions.run(
+    run_oci_layout_action(
+        ctx,
+        format = format,
+        output = oci_layout_output,
+        args = args,
         inputs = inputs,
-        outputs = [oci_layout_output],
-        executable = img_toolchain_info.tool_exe,
-        arguments = [args],
-        env = {"RULES_IMG": "1"},
         mnemonic = "OCIOptimizedLayout",
     )
 
@@ -208,7 +207,6 @@ def _build_index_oci_layout(ctx, format, index_out, manifests):
     args.add("oci-layout")
     args.add("--format", format)
     args.add("--index", index_out.path)
-    args.add("--output", oci_layout_output.path)
     if ctx.attr._oci_layout_settings[OCILayoutSettingsInfo].allow_shallow_oci_layout:
         args.add("--allow-missing-blobs")
 
@@ -223,13 +221,12 @@ def _build_index_oci_layout(ctx, format, index_out, manifests):
             inputs.append(layer.metadata)
             inputs.append(layer.blob)
 
-    img_toolchain_info = ctx.toolchains[TOOLCHAIN].imgtoolchaininfo
-    ctx.actions.run(
+    run_oci_layout_action(
+        ctx,
+        format = format,
+        output = oci_layout_output,
+        args = args,
         inputs = inputs,
-        outputs = [oci_layout_output],
-        executable = img_toolchain_info.tool_exe,
-        arguments = [args],
-        env = {"RULES_IMG": "1"},
         mnemonic = "OCIOptimizedIndexLayout",
     )
 

--- a/img_tool/pkg/ocilayout/builder_test.go
+++ b/img_tool/pkg/ocilayout/builder_test.go
@@ -290,6 +290,38 @@ func TestOCILayoutDirectoryCleanIndex(t *testing.T) {
 	}
 }
 
+func TestOCILayoutSymlinksAreRelative(t *testing.T) {
+	manifest, manifestData, _, _, layerHex := makeTestManifest()
+	dir := t.TempDir()
+
+	configPath := filepath.Join(dir, "config")
+	os.WriteFile(configPath, []byte(`{"architecture":"amd64","os":"linux"}`), 0o644)
+	layerPath := filepath.Join(dir, "layer")
+	os.WriteFile(layerPath, []byte("fake layer content"), 0o644)
+
+	out := filepath.Join(dir, "layout")
+	mi := ManifestInput{Manifest: manifest, ManifestData: manifestData, Config: BlobFromPath(configPath)}
+	mi.Layers = []LayerInput{{Descriptor: manifest.Layers[0], Blob: BlobFromPath(layerPath), Present: true}}
+
+	if err := New(OCILayout()).WithLinkStrategy(true, false).AddManifest(mi).WriteDir(context.Background(), out); err != nil {
+		t.Fatalf("WriteDir: %v", err)
+	}
+
+	linkPath := filepath.Join(out, "blobs/sha256", layerHex)
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("reading symlink %s: %v", linkPath, err)
+	}
+	if filepath.IsAbs(target) {
+		t.Errorf("symlink target must be relative, got %q", target)
+	}
+	// The relative target must resolve to the original source file.
+	resolved := filepath.Join(filepath.Dir(linkPath), target)
+	if resolved != layerPath {
+		t.Errorf("resolved symlink: got %q want %q", resolved, layerPath)
+	}
+}
+
 func TestSparseLayout(t *testing.T) {
 	manifest, manifestData, _, configHex, layerHex := makeTestManifest()
 	dir := t.TempDir()

--- a/img_tool/pkg/ocilayout/copy.go
+++ b/img_tool/pkg/ocilayout/copy.go
@@ -31,7 +31,15 @@ func copyFile(src, dst string, useSymlinks bool) error {
 		if err != nil {
 			return err
 		}
-		return os.Symlink(absSrc, dst)
+		absDst, err := filepath.Abs(dst)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(filepath.Dir(absDst), absSrc)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(rel, dst)
 	}
 
 	if err := os.Link(src, dst); err == nil {


### PR DESCRIPTION
Directory OCI layout TreeArtifacts were copying/hardlinking layer blobs, so shared base layers were re-materialized per image, inflating output_base and remote cache downloads.

For directory layouts on Bazel >= 7.1, pass --symlink to the img tool and produce relative (not absolute) symlinks in the Go layer, so shared base blobs are referenced rather than copied. Tar layouts still embed blobs.

Closes https://github.com/bazel-contrib/rules_img/issues/677