### PR TITLE
make cross-compiled binaries and artifact index entries reproducible

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,6 +14,27 @@ common --incompatible_autoload_externally=+@rules_python
 # enable prebuilt protoc toolchain
 common --@protobuf//bazel/toolchains:prefer_prebuilt_protoc=true
 
+# Strip debug information from binaries.
+# docs: https://bazel.build/reference/command-line-reference#flag--strip
+build --strip=always
+
+common --enable_platform_specific_config
+
+# Rewrite output paths in action command lines to a configuration-independent
+# `bazel-out/<mnemonic>` form. Without this, the output directory name embeds the
+# legacy `--cpu` value, which defaults to the *host* CPU even for a target that
+# transitions to another platform. Anything that bakes an output path into an
+# artifact -- the Go compiler records source paths of generated files for stack
+# traces -- then produces different bytes on a macOS host than on a Linux host
+# for the very same target.
+#
+# Only enabled on the platforms where path mapping works; Windows hosts keep the
+# unmapped paths, so binaries cross-compiled there still differ from the ones CI
+# publishes.
+# docs: https://bazel.build/reference/command-line-reference#flag--experimental_output_paths
+common:macos --experimental_output_paths=strip
+common:linux --experimental_output_paths=strip
+
 common --override_module=rules_img_tool=%workspace%/img_tool
 common --override_module=rules_img_internal_tools=%workspace%/modules/rules_img_internal_tools
 common --override_module=rules_img_private=%workspace%/modules/rules_img_private

--- a/img_tool/cmd/manifest/manifest.go
+++ b/img_tool/cmd/manifest/manifest.go
@@ -285,13 +285,23 @@ func ManifestProcess(_ context.Context, args []string) {
 		Digest:       digest.NewDigestFromBytes(digest.SHA256, manifestSHA256[:]),
 		Size:         int64(len(manifestRaw)),
 		ArtifactType: artifactType,
-		Platform: &specv1.Platform{
+		Annotations:  manifest.Annotations,
+	}
+
+	// Only a container image gets platform information. An artifact -- an ORAS
+	// artifact with an empty config, a Helm chart, ... -- has no platform of its
+	// own, and --os/--architecture default to the platform the manifest happens to
+	// be built for. Advertising that in an image index is both wrong (a runtime
+	// may pick the artifact as the image for that platform) and non-reproducible,
+	// because the default depends on the host that ran the build.
+	if api.IsImageConfigMediaType(configMediaType) {
+		descriptor.Platform = &specv1.Platform{
 			Architecture: architecture,
 			OS:           operatingSystem,
 			Variant:      variant,
-		},
-		Annotations: manifest.Annotations,
+		}
 	}
+
 	descriptorRaw, err := json.Marshal(descriptor)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to marshal manifest descriptor: %v\n", err)

--- a/img_tool/pkg/api/BUILD.bazel
+++ b/img_tool/pkg/api/BUILD.bazel
@@ -19,6 +19,9 @@ go_library(
 
 go_test(
     name = "api_test",
-    srcs = ["deploy_test.go"],
+    srcs = [
+        "api_test.go",
+        "deploy_test.go",
+    ],
     embed = [":api"],
 )

--- a/img_tool/pkg/api/api.go
+++ b/img_tool/pkg/api/api.go
@@ -30,7 +30,29 @@ const (
 
 	// Config media types
 	MediaTypeEmptyJSON = "application/vnd.oci.empty.v1+json"
+
+	// Config media types of a runnable container image. Docker and OCI images use
+	// distinct types for the same thing.
+	MediaTypeOCIImageConfig    = "application/vnd.oci.image.config.v1+json"
+	MediaTypeDockerImageConfig = "application/vnd.docker.container.image.v1+json"
 )
+
+// IsImageConfigMediaType reports whether a config blob of this media type is a
+// container image config, i.e. describes something a runtime can execute. The
+// empty string means "unset", which defaults to the OCI image config.
+//
+// Manifests with any other config media type -- an empty config for an ORAS
+// artifact, a Helm chart config, ... -- are artifacts rather than images. They
+// have no platform of their own, so callers must not attach platform
+// information to them.
+func IsImageConfigMediaType(mediaType string) bool {
+	switch mediaType {
+	case "", MediaTypeOCIImageConfig, MediaTypeDockerImageConfig:
+		return true
+	default:
+		return false
+	}
+}
 
 func (h HashAlgorithm) Len() int {
 	switch h {

--- a/img_tool/pkg/api/api_test.go
+++ b/img_tool/pkg/api/api_test.go
@@ -1,0 +1,43 @@
+package api
+
+import "testing"
+
+func TestIsImageConfigMediaType(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		mediaType string
+		want      bool
+	}{
+		{
+			name:      "unset defaults to the OCI image config",
+			mediaType: "",
+			want:      true,
+		},
+		{
+			name:      "OCI image config",
+			mediaType: MediaTypeOCIImageConfig,
+			want:      true,
+		},
+		{
+			name:      "Docker image config",
+			mediaType: MediaTypeDockerImageConfig,
+			want:      true,
+		},
+		{
+			name:      "empty config of an ORAS artifact",
+			mediaType: MediaTypeEmptyJSON,
+			want:      false,
+		},
+		{
+			name:      "Helm chart config",
+			mediaType: "application/vnd.cncf.helm.config.v1+json",
+			want:      false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsImageConfigMediaType(tc.mediaType); got != tc.want {
+				t.Errorf("IsImageConfigMediaType(%q) = %v, want %v", tc.mediaType, got, tc.want)
+			}
+		})
+	}
+}

--- a/modules/rules_img_private/release_platforms/defs.bzl
+++ b/modules/rules_img_private/release_platforms/defs.bzl
@@ -104,6 +104,15 @@ def _release_platforms_transition_impl(_settings, _attr):
         for platform in PLATFORM_NAMES
     }
 
+# Released binaries must also be built with `--experimental_output_paths=strip`,
+# which this transition cannot set: Bazel rejects `--experimental_*` options as
+# transition outputs. Modules building release binaries have to enable it in their
+# .bazelrc instead, per host platform, since path mapping does not work on Windows.
+# Without it, Bazel's output directory name embeds the legacy `--cpu` value, which
+# stays at its host-derived default even though we transition `--platforms` above,
+# so output paths that end up baked into an artifact -- the Go compiler records the
+# source paths of generated files for stack traces -- differ between a macOS and a
+# Linux build host.
 release_platforms_transition = transition(
     implementation = _release_platforms_transition_impl,
     inputs = [],

--- a/modules/rules_img_services/.bazelrc
+++ b/modules/rules_img_services/.bazelrc
@@ -10,6 +10,29 @@ common --@rules_img//img/settings:compression_level=4
 common --@rules_img//img/settings:additional_image_labels_file=//services:image_labels
 common --@rules_go//go/config:pure
 
+# The images published from this module must be reproducible: the same commit has
+# to yield the same digests no matter which host built it.
+#
+# docs: https://bazel.build/reference/command-line-reference#flag--strip
+build --strip=always
+
+common --enable_platform_specific_config
+
+# Rewrite output paths in action command lines to a configuration-independent
+# `bazel-out/<mnemonic>` form. Without this, the output directory name embeds the
+# legacy `--cpu` value, which defaults to the *host* CPU even for a target that
+# transitions to another platform. Anything that bakes an output path into an
+# artifact -- the Go compiler records source paths of generated files for stack
+# traces -- then produces different bytes on a macOS host than on a Linux host
+# for the very same target.
+#
+# Only enabled on the platforms where path mapping works. Images built on a
+# Windows host keep the unmapped paths and so differ from the published ones,
+# which is acceptable: releases are built on Linux.
+# docs: https://bazel.build/reference/command-line-reference#flag--experimental_output_paths
+common:macos --experimental_output_paths=strip
+common:linux --experimental_output_paths=strip
+
 # Workaround for rules_python no longer being autoloaded by Bazel 9:
 #  https://github.com/bazelbuild/bazel/pull/27593
 #

--- a/tests/img_toolchain/testcases/manifest_artifact_descriptor_has_no_platform.ini
+++ b/tests/img_toolchain/testcases/manifest_artifact_descriptor_has_no_platform.ini
@@ -1,0 +1,23 @@
+[test]
+name = manifest_artifact_descriptor_has_no_platform
+description = Test that the descriptor of a manifest with a non-image config carries no platform
+
+[file]
+name = helm_config.json
+{"name":"test-chart","version":"1.0.0"}
+
+[command]
+subcommand = manifest
+args = --config-media-type=application/vnd.cncf.helm.config.v1+json --config-fragment=helm_config.json --os=darwin --architecture=arm64 --manifest=manifest.json --descriptor=descriptor.json
+expect_exit = 0
+
+[assert]
+file_exists = descriptor.json
+file_valid_json = descriptor.json
+# The manifest describes a Helm chart, not something a runtime can execute, so
+# --os/--architecture must not leak into the descriptor: they default to whatever
+# platform the build happens to target, which would both mislead runtimes
+# selecting from an index and make the index digest depend on the build host.
+file_not_contains = descriptor.json, "platform"
+file_not_contains = descriptor.json, "darwin"
+file_not_contains = descriptor.json, "arm64"

--- a/tests/img_toolchain/testcases/manifest_image_descriptor_has_platform.ini
+++ b/tests/img_toolchain/testcases/manifest_image_descriptor_has_platform.ini
@@ -1,0 +1,16 @@
+[test]
+name = manifest_image_descriptor_has_platform
+description = Test that the descriptor of a regular image manifest still carries its platform
+
+[command]
+subcommand = manifest
+args = --os=darwin --architecture=arm64 --manifest=manifest.json --descriptor=descriptor.json
+expect_exit = 0
+
+[assert]
+file_exists = descriptor.json
+file_valid_json = descriptor.json
+json_field_exists = descriptor.json, platform
+file_contains = descriptor.json, "darwin"
+file_contains = descriptor.json, "arm64"
+file_contains = descriptor.json, "v8"


### PR DESCRIPTION
Cross-compiled binaries were not reproducible across build hosts: the same commit yielded a different `img` binary, and therefore different image digests, depending on whether a Mac or a Linux machine built it. This is why ghcr.io/bazel-contrib/rules_img/img:0.3.19 differs from the image published for the following commit.

Bazel names the output directory after the legacy `--cpu` value, which keeps its host-derived default even when a transition sets `--platforms` to another platform. A linux/amd64 release binary therefore lands under bazel-out/darwin_arm64-opt-ST-<hash>/ on a Mac and bazel-out/k8-opt-ST-<hash>/ on Linux -- same configuration, different path. rules_go trims source paths to the execroot only, so the Go compiler records those paths for its generated .pb.go inputs in the pclntab, and the host's CPU name ends up inside every cross-compiled binary. `--experimental_output_paths=strip` rewrites them to a configuration-independent form. Debug stripping does not help here, since a binary needs its pclntab file names at runtime; `--strip=always` comes along because release artifacts have no use for debug information either.

The transition cannot set the flag itself -- Bazel rejects `--experimental_*` options as transition outputs -- so it lives in the .bazelrc of the modules that build published artifacts, next to the existing hermeticity flags.

Independently, a manifest whose config is not a container image config was advertising a platform in the image index it was added to. An ORAS artifact has no platform of its own, so `img manifest` was falling back to whichever platform the build targeted, which for a manifest without an explicit `platform` attribute is the host. Besides moving the index digest between hosts, that platform is a lie a runtime acts on: the artifact entry claimed linux/amd64, the same platform as the real container image next to it, so a client resolving the index could pick the artifact as the image. Platform information is now attached only to manifests that describe something a runtime can execute.