### PR TITLE
feat(services): sign service images with cosign

### DIFF
--- a/.github/workflows/push_services.yaml
+++ b/.github/workflows/push_services.yaml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Login to GHCR
@@ -39,6 +40,9 @@ jobs:
         bazelisk-cache: true
         repository-cache: true
         bazelrc: import %workspace%/buildbuddy.bazelrc
+    - name: Build images
+      working-directory: modules/rules_img_services
+      run: bazelisk build --config=cosign //:push
     - name: Push images to ghcr.io
       working-directory: modules/rules_img_services
       shell: bash
@@ -54,5 +58,10 @@ jobs:
           SHORT_SHA="${GITHUB_SHA:0:7}"
           TAGS="--tag=${VERSION}-${DATE}-${SHORT_SHA}"
         fi
+        OIDC_TOKEN_JSON="$(curl -sSf \
+          -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sigstore")"
+        SIGSTORE_ID_TOKEN="$(jq -er .value <<<"${OIDC_TOKEN_JSON}")"
+        export SIGSTORE_ID_TOKEN
         # shellcheck disable=SC2086
-        bazelisk run //:push -- ${TAGS}
+        bazelisk run --config=cosign //:push -- ${TAGS}

--- a/modules/rules_img_services/.bazelrc
+++ b/modules/rules_img_services/.bazelrc
@@ -10,6 +10,9 @@ common --@rules_img//img/settings:compression_level=4
 common --@rules_img//img/settings:additional_image_labels_file=//services:image_labels
 common --@rules_go//go/config:pure
 
+build:cosign --@rules_img//img/settings:sign=enabled
+build:cosign --@rules_img//img/settings:sign_setting=//services:cosign_keyless
+
 # The images published from this module must be reproducible: the same commit has
 # to yield the same digests no matter which host built it.
 #

--- a/modules/rules_img_services/MODULE.bazel
+++ b/modules/rules_img_services/MODULE.bazel
@@ -4,6 +4,7 @@ bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_go", version = "0.62.0")
 bazel_dep(name = "rules_img", version = "0.3.19")
 bazel_dep(name = "rules_img_private", version = "0.0.1")
+bazel_dep(name = "rules_img_signer_cosign", version = "0.0.1")
 bazel_dep(name = "rules_img_tool", version = "0.3.19")
 
 register_toolchains("@rules_img_tool//toolchain:all")

--- a/modules/rules_img_services/services/BUILD.bazel
+++ b/modules/rules_img_services/services/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_img//img:multi_deploy.bzl", "multi_deploy")
 load("@rules_img//img:push.bzl", "image_push_spec")
+load("@rules_img//img:signing.bzl", "signing_config")
 
 multi_deploy(
     name = "push",
@@ -15,6 +16,16 @@ image_push_spec(
     name = "push_spec",
     repository = "bazel-contrib/rules_img/{{.image_target_name}}",
     visibility = ["//services:__subpackages__"],
+)
+
+signing_config(
+    name = "cosign_keyless",
+    targets = [
+        "roots",
+        "child_manifests",
+    ],
+    tool = "@rules_img_signer_cosign",
+    visibility = ["//visibility:public"],
 )
 
 filegroup(


### PR DESCRIPTION
Adds a keyless cosign signing_config (off by default) and enables it in the ghcr.io push workflow, which mints the GitHub Actions OIDC token the signer plugin exchanges for a Fulcio certificate.