### PR TITLE
feat(gateway): serve cache replication on a listener of its own

### DIFF
--- a/img_tool/cmd/oci-distribution-gateway/BUILD.bazel
+++ b/img_tool/cmd/oci-distribution-gateway/BUILD.bazel
@@ -11,12 +11,14 @@ load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 # test dependency to deps below by hand — gazelle will not do it for you.
 # gazelle:exclude helpers_test.go
 # gazelle:exclude main_test.go
+# gazelle:exclude peerlistener_test.go
 
 go_library(
     name = "oci-distribution-gateway_lib",
     srcs = [
         "forward.go",
         "main.go",
+        "peerlistener.go",
         "serve.go",
     ],
     importpath = "github.com/bazel-contrib/rules_img/img_tool/cmd/oci-distribution-gateway",
@@ -47,6 +49,7 @@ go_test(
     srcs = [
         "helpers_test.go",
         "main_test.go",
+        "peerlistener_test.go",
     ],
     embed = [":oci-distribution-gateway_lib"],
     # keep

--- a/img_tool/cmd/oci-distribution-gateway/README.md
+++ b/img_tool/cmd/oci-distribution-gateway/README.md
@@ -78,6 +78,10 @@ until it is done, or until its warm-up budget runs out.
 | `--allowed-serviceaccount <s>` | any for the audience | `system:serviceaccount:<ns>:<name>`. Repeatable |
 | `--dangerously-allow-plaintext-h2c` | `false` | Accept prior-knowledge h2c on the plaintext listener |
 | `--dangerously-allow-unauthenticated-clients` | `false` | Serve a network-reachable address with no client authentication |
+| `--peer-address <host>`, `--peer-port <n>` | `--address`, — | A [second listener](#a-second-listener-for-peers) carrying only cache replication between instances, so peers are authenticated differently from clients. `--peer-port` enables it |
+| `--peer-tls-cert-file`, `--peer-tls-key-file` | `--tls-cert-file`/`--tls-key-file` | TLS keypair of the peer listener. Hot-reloaded |
+| `--peer-client-ca-file <path>` | `--client-ca-file` | CAs whose client certificates the peer listener accepts. This is what lets instances speak mTLS while clients do not. Hot-reloaded |
+| `--dangerously-allow-unauthenticated-peer-listener` | `false` | Run the peer listener with no client authentication |
 
 ### `forward`
 
@@ -270,6 +274,65 @@ Client certificate identities are re-checked on **every request**, not just per
 connection, so removing one from `--allowed-client-id` takes effect at once even on
 an established connection. There is no CRL or OCSP, so that allow-list *is* the
 revocation mechanism for certificates; use short-lived leaves.
+
+### A second listener for peers
+
+A listener either asks its clients for a certificate or it does not. So a
+deployment that wants **anonymous plaintext for its build clients and mTLS between
+its own instances** cannot express that on one socket. `--peer-port` gives the
+instance-to-instance traffic — the [blob existence cache
+replication](blob-existence-cache.md#replicating-the-cache-between-instances) —
+a listener of its own, with its own TLS material and its own client
+authentication:
+
+```bash
+oci-distribution-gateway serve --policy-file /etc/img/policy.yaml \
+  --address 0.0.0.0 --port 8080 \
+  --dangerously-allow-unauthenticated-clients \
+  --peer-port 8443 \
+  --peer-tls-cert-file /tls/tls.crt --peer-tls-key-file /tls/tls.key \
+  --peer-client-ca-file /tls/ca.crt \
+  --allowed-cache-peer-id oci-distribution-gateway.img-gateway.svc \
+  --blob-existence-cache-peer-service oci-distribution-gateway
+```
+
+Enabling it **moves** the endpoints rather than duplicating them: from then on the
+client listener answers `/_rules_img/cache/` with `404`, and the peer listener is
+the only place they exist. That is the point of the split, not a side effect —
+inserting a cache entry is a write into this instance's view of what is upstream,
+and an anonymous client that could claim a blob exists would make push clients skip
+an upload they still owe.
+
+The peer listener is a closed surface: the two replication endpoints and
+`/healthz`, and `404` for everything else. None of the registry protocol is
+reachable there, so a peer credential cannot be spent on an upstream registry.
+Probe it on its own port — `/healthz` answers before authentication there too, and
+each listener reports the readiness of its own socket.
+
+What it inherits, so the common cases stay short:
+
+| Flag | Falls back to |
+|---|---|
+| `--peer-address` | `--address` |
+| `--peer-tls-cert-file` / `--peer-tls-key-file` | `--tls-cert-file` / `--tls-key-file` |
+| `--peer-client-ca-file` | `--client-ca-file` |
+| the peer identity allow-list | `--allowed-cache-peer-id` (the peers are this listener's only clients, so who may connect and who may write to the cache are the same question) |
+
+`--peer-port` is never inherited and never defaulted: it is the port a
+**discovered** peer is dialled on, so every instance of a deployment has to serve
+it on the same one. Replication follows the peer listener in every other respect
+too — its TLS decides whether the hop is `https`, so a gateway that is plaintext to
+its clients and TLS to its peers replicates over TLS, with no
+`--dangerously-allow-plaintext-cache-peer` needed.
+
+With this in play the Service needs both ports, and the peer one should be
+reachable only from the gateway's own namespace:
+
+```yaml
+ports:
+  - {name: gateway, port: 8080, targetPort: gateway}
+  - {name: peer,    port: 8443, targetPort: peer}
+```
 
 ## Two-hop deployment
 

--- a/img_tool/cmd/oci-distribution-gateway/blob-existence-cache.md
+++ b/img_tool/cmd/oci-distribution-gateway/blob-existence-cache.md
@@ -198,12 +198,18 @@ warning at startup saying so. A forwarding sidecar deployment is exactly the cas
 where it is *not* true, and a forwarder refuses to relay `/_rules_img/` paths for
 the same reason.
 
+When the clients of that listener are anonymous, an allow-list has nothing to match
+on and the endpoints should not be there at all. Give replication a listener of its
+own with `--peer-port`, which moves them off the client listener entirely and lets
+the peers authenticate with mTLS while the clients do not — see
+[A second listener for peers](README.md#a-second-listener-for-peers).
+
 The credential this gateway presents to its peers defaults to its **serving
 identity**: with one Deployment, one keypair and one CA, every instance already
 holds a certificate its peers accept (`--client-ca-file`) and a bundle that
-verifies theirs, so replication needs no material of its own. Pass
-`--blob-existence-cache-peer-token-file` instead if your peers authenticate by
-token.
+verifies theirs, so replication needs no material of its own. With a peer listener
+it is that listener's keypair and CA instead. Pass
+`--blob-existence-cache-peer-token-file` if your peers authenticate by token.
 
 ### Discovering peers in Kubernetes
 
@@ -214,7 +220,8 @@ scale-up, a scale-down, a rolling update and a lost node with no restart and no
 configuration to keep in sync. It needs:
 
 - an explicit `--port`, since a discovered peer is reached at its endpoint address
-  on the port this instance itself serves,
+  on the port this instance itself serves replication on (`--peer-port` when
+  replication has [a listener of its own](README.md#a-second-listener-for-peers)),
 - `--blob-existence-cache-peer-server-name`, because a certificate issued for the
   Service name does not cover the pod IPs that are dialled,
 - and RBAC, which no built-in role grants:

--- a/img_tool/cmd/oci-distribution-gateway/helpers_test.go
+++ b/img_tool/cmd/oci-distribution-gateway/helpers_test.go
@@ -1,11 +1,19 @@
 package main
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/serve/gateway"
 )
@@ -34,11 +42,52 @@ func newEmptyPeerTLS(t *testing.T) *gateway.PeerTLS {
 
 func writeTempFile(t *testing.T, name, contents string) string {
 	t.Helper()
-	path := filepath.Join(t.TempDir(), name)
-	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+	return writeTempFileIn(t, t.TempDir(), name, []byte(contents))
+}
+
+// writeTempFileIn writes into a directory the caller chose, for a test that needs
+// several files side by side.
+func writeTempFileIn(t *testing.T, dir, name string, contents []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
 		t.Fatalf("writing %s: %v", path, err)
 	}
 	return path
+}
+
+// testKeypair mints a throwaway self-signed server certificate and returns it as
+// PEM, together with the key and a CA bundle that verifies it (itself, since it is
+// self-signed). It exists so a test can hand the peer listener real TLS material
+// without a fixture to rotate.
+func testKeypair(t *testing.T) (certPEM, keyPEM, caPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "oci-distribution-gateway.test"},
+		DNSNames:              []string{"oci-distribution-gateway.test"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshalling key: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, certPEM
 }
 
 // testTCPAddr builds a *net.TCPAddr without resolving anything.

--- a/img_tool/cmd/oci-distribution-gateway/main.go
+++ b/img_tool/cmd/oci-distribution-gateway/main.go
@@ -283,6 +283,15 @@ func (f *metricsFlags) setup(ctx context.Context, serviceName string) (*telemetr
 	return metrics, metricsServer, flush
 }
 
+// gatewayListener is one HTTP server of a gateway process: the server itself, the
+// call that starts it (Serve or ServeTLS, depending on whether it speaks TLS), and
+// the address to report.
+type gatewayListener struct {
+	server *http.Server
+	serve  func() error
+	addr   net.Addr
+}
+
 // gatewayServer bundles what a gateway process serves so both modes start and
 // stop it the same way.
 type gatewayServer struct {
@@ -292,6 +301,9 @@ type gatewayServer struct {
 	serve func() error
 	// addr is reported in the startup banner.
 	addr net.Addr
+	// peer is the second listener carrying cache replication between instances, or
+	// nil when the gateway serves it on the main listener (or not at all).
+	peer *gatewayListener
 	// metrics is the Prometheus endpoint, or nil when it is not enabled.
 	metrics *http.Server
 	// shutdownTimeout bounds how long in-flight transfers get to finish.
@@ -306,10 +318,14 @@ type gatewayServer struct {
 func (g *gatewayServer) run() {
 	shutdown := make(chan os.Signal, 1)
 	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)
-	serveErr := make(chan error, 1)
+	serveErr := make(chan error, 2)
 	go func() { serveErr <- g.serve() }()
 
 	fmt.Fprintf(os.Stderr, "%s on %s\n", g.banner, g.addr)
+	if g.peer != nil {
+		go func() { serveErr <- g.peer.serve() }()
+		fmt.Fprintf(os.Stderr, "%s for cache replication peers on %s\n", g.banner, g.peer.addr)
+	}
 
 	select {
 	case err := <-serveErr:
@@ -322,6 +338,13 @@ func (g *gatewayServer) run() {
 		defer cancel()
 		if err := g.server.Shutdown(shutdownCtx); err != nil {
 			log.Printf("graceful shutdown error: %v", err)
+		}
+		if g.peer != nil {
+			// After the traffic it exists to support: a fact learned while the last
+			// requests drain is still worth telling the fleet.
+			if err := g.peer.server.Shutdown(shutdownCtx); err != nil {
+				log.Printf("peer listener shutdown error: %v", err)
+			}
 		}
 		if g.metrics != nil {
 			// After the gateway itself: the last requests should still be counted,

--- a/img_tool/cmd/oci-distribution-gateway/main_test.go
+++ b/img_tool/cmd/oci-distribution-gateway/main_test.go
@@ -237,7 +237,7 @@ func TestCacheReplicationFlagValidation(t *testing.T) {
 			f.cachePeers = repeatedFlag{"https://gw-1:8443"}
 			f.unixSocket = "/run/gw.sock"
 		}),
-		want: "not --unix-socket",
+		want: "instead of --unix-socket",
 	}, {
 		name:  "a plaintext peer without the escape hatch",
 		flags: withCache(func(f *serveFlags) { f.cachePeers = repeatedFlag{"http://gw-1:8443"} }),
@@ -279,12 +279,13 @@ func TestCacheReplicationFlagValidation(t *testing.T) {
 		flags: withCache(func(f *serveFlags) {
 			f.cachePeerService = "img-gateway/gw"
 		}),
-		want: "serves plaintext",
+		want: "serves replication over plaintext",
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			// serverTLS is nil throughout: these are the checks that do not depend on
-			// the TLS material, and a nil one is a gateway serving plaintext.
-			replication, err := tc.flags.cacheReplication(nil)
+			// the TLS material, and a nil one is a gateway serving plaintext. So is
+			// the peer listener, which these cases do not use.
+			replication, err := tc.flags.cacheReplication(nil, nil)
 			switch {
 			case tc.want == "" && err != nil:
 				t.Fatalf("cacheReplication() = %v, want it to pass", err)

--- a/img_tool/cmd/oci-distribution-gateway/peerlistener.go
+++ b/img_tool/cmd/oci-distribution-gateway/peerlistener.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/serve/gateway"
+)
+
+// This file implements the *peer listener*: a second socket carrying nothing but
+// the blob existence cache replication the instances of a serving deployment do
+// between themselves.
+//
+// One listener cannot serve two transports. TLS decides per listener whether a
+// client certificate is requested at all, so a deployment whose build clients
+// speak plaintext HTTP with no credential and whose instances authenticate each
+// other with mTLS has no single socket that can be both. Splitting them is what
+// makes that combination expressible: --address/--port stays exactly as it was,
+// and --peer-address/--peer-port gets its own TLS material and its own client
+// authentication.
+//
+// The split is not only about transports. The replication endpoints are a write
+// path into this instance's cache, and a false "this blob is there" makes a push
+// client skip an upload it still owes — so on a gateway whose clients are
+// anonymous, those endpoints must not be on the clients' listener at all. Enabling
+// the peer listener therefore *moves* them: the client listener answers
+// /_rules_img/cache/ with 404 from then on (see
+// [gateway.Handler.SeparateReplicationHandler]).
+
+// peerListener is the resolved configuration of the second listener, or nil when
+// it is not enabled.
+type peerListener struct {
+	address string
+	port    int
+
+	// tls is the listener's own TLS material. It is also what this instance
+	// presents to its peers as a client, so a symmetric deployment needs one
+	// keypair and one CA and nothing else.
+	tls *gateway.PeerTLS
+	// auth authenticates the peers, or nil when the operator declared the listener
+	// safe without it.
+	auth *gateway.PeerAuth
+}
+
+// enabled reports whether the peer listener is configured. It is written to
+// tolerate a nil receiver so callers need no second code path.
+func (p *peerListener) enabled() bool { return p != nil }
+
+// servesTLS reports whether the peer listener serves TLS, which is also the
+// scheme its peers are reached on.
+func (p *peerListener) servesTLS() bool {
+	return p != nil && p.tls != nil && p.tls.HasCertificate()
+}
+
+// peerListenerRequested reports whether any flag asks for a peer listener. It is
+// separate from building one so that a flag combination that cannot work is an
+// error rather than a listener that quietly does not appear.
+func (f *serveFlags) peerListenerRequested() bool {
+	return f.peerAddress != "" || f.peerPort != 0 ||
+		f.peerTLSCertFile != "" || f.peerTLSKeyFile != "" || f.peerClientCAFile != "" ||
+		f.allowUnauthenticatedPeerListener
+}
+
+// validatePeerListener checks the peer listener flags and fills in what they
+// inherit from the client listener. The inheritance is the point: a symmetric
+// deployment that only wants "clients plaintext, peers mTLS" sets --peer-port and
+// --peer-client-ca-file and nothing else.
+func (f *serveFlags) validatePeerListener() error {
+	if !f.peerListenerRequested() {
+		return nil
+	}
+	if f.peerPort == 0 {
+		return errors.New("the peer listener needs an explicit --peer-port: it is the port a discovered peer is reached on, so every instance must serve it on the same one")
+	}
+	if (f.peerTLSCertFile == "") != (f.peerTLSKeyFile == "") {
+		return errors.New("--peer-tls-cert-file and --peer-tls-key-file must be given together")
+	}
+	// Inherit from the client listener where nothing was said. A gateway that
+	// serves TLS to its clients almost always serves the same certificate to its
+	// peers; one that does not can name a different keypair.
+	if f.peerTLSCertFile == "" {
+		f.peerTLSCertFile, f.peerTLSKeyFile = f.tlsCertFile, f.tlsKeyFile
+	}
+	if f.peerClientCAFile == "" {
+		f.peerClientCAFile = f.clientCAFile
+	}
+	if f.peerAddress == "" {
+		f.peerAddress = f.address
+	}
+	if f.peerClientCAFile != "" && f.peerTLSCertFile == "" {
+		return errors.New("--peer-client-ca-file requires a certificate for the peer listener (--peer-tls-cert-file, or --tls-cert-file to reuse the client listener's): a client certificate can only be presented over TLS")
+	}
+	// Two listeners on one address and one port is a bind error at best and, if
+	// SO_REUSEPORT were ever in play, two sockets sharing the traffic at worst.
+	if f.unixSocket == "" && f.peerPort == f.port && f.peerAddress == f.address {
+		return fmt.Errorf("--peer-port %d is the port the client listener already serves on %s; give the peer listener a port of its own", f.peerPort, f.address)
+	}
+	return nil
+}
+
+// buildPeerListener loads the peer listener's TLS material and client
+// authentication. It returns nil when no peer listener was asked for.
+//
+// The peers' allow-list is deliberately the same --allowed-cache-peer-id that
+// gates writing to the cache: with a listener of their own there is no second
+// population to distinguish, and giving it a separate identity flag would only
+// make two places to keep in sync.
+func (f *serveFlags) buildPeerListener(onReload func(material string, err error)) (*peerListener, error) {
+	if !f.peerListenerRequested() {
+		return nil, nil
+	}
+	listener := &peerListener{address: f.peerAddress, port: f.peerPort}
+
+	var err error
+	if f.peerTLSCertFile != "" || f.peerClientCAFile != "" {
+		listener.tls, err = gateway.NewPeerTLS(gateway.PeerTLSOptions{
+			CertFile: f.peerTLSCertFile,
+			KeyFile:  f.peerTLSKeyFile,
+			CAFile:   f.peerClientCAFile,
+			OnReload: onReload,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("loading the peer listener's TLS material: %w", err)
+		}
+	}
+	if f.peerClientCAFile != "" {
+		listener.auth, err = gateway.NewPeerAuth(gateway.PeerAuthOptions{
+			TLS: listener.tls,
+			// The peers are the only clients of this listener, so who may talk to it
+			// and who may write to the cache are one and the same question.
+			AllowedClientIDs: f.allowedCachePeerIDs,
+			OnReload:         onReload,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("configuring authentication on the peer listener: %w", err)
+		}
+	}
+	// The peer listener is a write path into this instance's cache. Refuse to open
+	// an unauthenticated one on a network-reachable address unless the operator
+	// says so: a client that can insert a fact about a blob that is not there makes
+	// push clients skip an upload they still owe.
+	if listener.auth == nil && reachableFromNetwork("", f.peerAddress) && !f.allowUnauthenticatedPeerListener {
+		return nil, fmt.Errorf("refusing to serve the peer listener on %s:%d without authenticating its peers.\n"+
+			"Configure --peer-client-ca-file (with --allowed-cache-peer-id), bind a loopback address,\n"+
+			"or pass --dangerously-allow-unauthenticated-peer-listener if a service mesh authenticates the hop",
+			f.peerAddress, f.peerPort)
+	}
+	return listener, nil
+}
+
+// serve starts the peer listener and returns it, so the caller can shut it down
+// with the rest of the process. handler is what
+// [gateway.Handler.SeparateReplicationHandler] returned.
+func (p *peerListener) serve(handler http.Handler) (*gatewayListener, error) {
+	socket, _, err := listen("", p.address, p.port, 0)
+	if err != nil {
+		return nil, fmt.Errorf("listening for peers on %s:%d: %w", p.address, p.port, err)
+	}
+	server, serveOn := p.server(handler)
+	return &gatewayListener{server: server, serve: func() error { return serveOn(socket) }, addr: socket.Addr()}, nil
+}
+
+// server assembles the peer listener's HTTP server and the call that serves a
+// socket with it — ServeTLS when this listener speaks TLS, Serve when it does not.
+// It is separate from [peerListener.serve] so the assembly can be checked without
+// binding anything.
+func (p *peerListener) server(handler http.Handler) (*http.Server, func(net.Listener) error) {
+	// Replication is a handful of small JSON requests, not blob traffic, so the
+	// bounds here are ordinary. HTTP/2 is offered over ALPN because a donation of
+	// tens of thousands of entries is one long stream and multiplexing it with the
+	// event batches costs nothing; plaintext h2c is deliberately not offered, since
+	// nothing on this listener needs it.
+	server := &http.Server{
+		Handler:           handler,
+		Protocols:         serveProtocols(false, false),
+		HTTP2:             serveHTTP2Config(),
+		ReadHeaderTimeout: 30 * time.Second,
+		ReadTimeout:       5 * time.Minute,
+		WriteTimeout:      5 * time.Minute,
+		IdleTimeout:       5 * time.Minute,
+	}
+	if !p.servesTLS() {
+		return server, server.Serve
+	}
+	clientAuth := tls.NoClientCert
+	var verify func(tls.ConnectionState) error
+	if p.auth != nil {
+		clientAuth = p.auth.ClientAuthType()
+		verify = p.auth.VerifyConnection
+	}
+	server.TLSConfig = p.tls.ServerConfig(clientAuth, verify, nextProtosFor(server.Protocols))
+	// The empty paths are correct: ServeTLS accepts them when the config can
+	// produce a certificate, which ours does through GetCertificate.
+	return server, func(socket net.Listener) error { return server.ServeTLS(socket, "", "") }
+}
+
+// watch keeps the peer listener's on-disk material fresh, mirroring what the
+// client listener does with its own.
+func (p *peerListener) watch(done <-chan struct{}) {
+	if p == nil {
+		return
+	}
+	if p.tls != nil {
+		go p.tls.Watch(done, 0)
+	}
+	if p.auth != nil {
+		go p.auth.Watch(done, 0)
+	}
+}
+
+// reload re-reads the peer listener's material on SIGHUP. A failed reload keeps
+// what is in force, like every other reload here.
+func (p *peerListener) reload() {
+	if p == nil {
+		return
+	}
+	if p.tls != nil {
+		if err := p.tls.Reload(); err != nil {
+			log.Printf("peer listener TLS material reload FAILED, keeping previous material: %v", err)
+		}
+	}
+	if p.auth != nil {
+		if err := p.auth.Reload(); err != nil {
+			log.Printf("peer listener token reload FAILED, keeping previous tokens: %v", err)
+		}
+	}
+}
+
+// summary describes the peer listener for the startup banner.
+func (p *peerListener) summary() string {
+	transport := "plaintext"
+	if p.servesTLS() {
+		transport = "TLS"
+	}
+	auth := "no client authentication"
+	if p.auth != nil {
+		auth = "mtls"
+		if methods := p.auth.Methods(); len(methods) > 0 {
+			auth = methods[0]
+		}
+	}
+	return fmt.Sprintf("%s, %s", transport, auth)
+}

--- a/img_tool/cmd/oci-distribution-gateway/peerlistener_test.go
+++ b/img_tool/cmd/oci-distribution-gateway/peerlistener_test.go
@@ -1,0 +1,507 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// These tests cover the peer listener: the second socket a serving gateway can
+// carry cache replication on, so that its clients and its peers are authenticated
+// differently. The configuration it exists for is "clients plaintext and
+// anonymous, instances mTLS to each other", which no single listener can express.
+
+// TestPeerListenerFlagValidation covers the startup checks. They are fail-closed
+// in the same way the rest of the gateway's are: a combination that could only
+// half-work refuses to start rather than serving with a control that looks
+// configured but is not.
+func TestPeerListenerFlagValidation(t *testing.T) {
+	base := serveFlags{address: "0.0.0.0", port: 8080}
+
+	with := func(mutate func(*serveFlags)) serveFlags {
+		flags := base
+		mutate(&flags)
+		return flags
+	}
+
+	for _, tc := range []struct {
+		name  string
+		flags serveFlags
+		want  string // a substring of the expected error; empty means it must pass
+		// check runs on the resolved flags after a passing validation, so the
+		// inheritance from the client listener is asserted rather than assumed.
+		check func(*testing.T, *serveFlags)
+	}{{
+		name:  "no peer listener asked for",
+		flags: base,
+	}, {
+		// Its port is what a discovered peer is dialled on, so it cannot be the
+		// arbitrary one a zero port would take.
+		name:  "material without a port",
+		flags: with(func(f *serveFlags) { f.peerClientCAFile = "/tls/ca.crt" }),
+		want:  "needs an explicit --peer-port",
+	}, {
+		name: "half a keypair",
+		flags: with(func(f *serveFlags) {
+			f.peerPort = 8443
+			f.peerTLSCertFile = "/tls/tls.crt"
+		}),
+		want: "must be given together",
+	}, {
+		// The configuration this whole listener exists for: anonymous plaintext
+		// clients, mTLS peers. The peer listener's keypair is named explicitly
+		// because the client listener has none to inherit.
+		name: "plaintext clients and mTLS peers",
+		flags: with(func(f *serveFlags) {
+			f.peerPort = 8443
+			f.peerTLSCertFile, f.peerTLSKeyFile = "/tls/tls.crt", "/tls/tls.key"
+			f.peerClientCAFile = "/tls/ca.crt"
+			f.allowUnauthenticatedText = true
+		}),
+		check: func(t *testing.T, f *serveFlags) {
+			if f.peerAddress != f.address {
+				t.Errorf("peer address = %q, want it to default to --address %q", f.peerAddress, f.address)
+			}
+		},
+	}, {
+		// A gateway that already serves TLS to its clients need not say so twice.
+		name: "the keypair is inherited from the client listener",
+		flags: with(func(f *serveFlags) {
+			f.tlsCertFile, f.tlsKeyFile = "/tls/tls.crt", "/tls/tls.key"
+			f.peerPort = 8443
+			f.peerClientCAFile = "/tls/peer-ca.crt"
+		}),
+		check: func(t *testing.T, f *serveFlags) {
+			if f.peerTLSCertFile != "/tls/tls.crt" || f.peerTLSKeyFile != "/tls/tls.key" {
+				t.Errorf("peer keypair = %q/%q, want it inherited from --tls-cert-file", f.peerTLSCertFile, f.peerTLSKeyFile)
+			}
+		},
+	}, {
+		name: "a client CA with no certificate to present it over",
+		flags: with(func(f *serveFlags) {
+			f.peerPort = 8443
+			f.peerClientCAFile = "/tls/ca.crt"
+		}),
+		want: "requires a certificate for the peer listener",
+	}, {
+		name: "both listeners on the same address and port",
+		flags: with(func(f *serveFlags) {
+			f.peerPort = 8080
+			f.allowUnauthenticatedPeerListener = true
+		}),
+		want: "give the peer listener a port of its own",
+	}, {
+		// Same port, different address, is two distinct sockets.
+		name: "the same port on a different address",
+		flags: with(func(f *serveFlags) {
+			f.peerAddress = "127.0.0.1"
+			f.peerPort = 8080
+		}),
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			flags := tc.flags
+			err := flags.validatePeerListener()
+			switch {
+			case tc.want == "" && err != nil:
+				t.Fatalf("validatePeerListener() = %v, want it to pass", err)
+			case tc.want == "":
+				if tc.check != nil {
+					tc.check(t, &flags)
+				}
+			case err == nil:
+				t.Fatalf("validatePeerListener() passed, want an error containing %q", tc.want)
+			case !strings.Contains(err.Error(), tc.want):
+				t.Errorf("validatePeerListener() = %v, want an error containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestPeerListenerRefusesToBeAnonymousOnTheNetwork covers the one check that
+// cannot be made from the flags alone. The peer listener is a write path into this
+// instance's blob existence cache, and a client that inserts a fact about a blob
+// that is not there makes push clients skip an upload they still owe — so an
+// unauthenticated one on a reachable address needs the operator to say so.
+func TestPeerListenerRefusesToBeAnonymousOnTheNetwork(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		address string
+		allow   bool
+		wantErr bool
+	}{
+		{name: "reachable and anonymous", address: "0.0.0.0", wantErr: true},
+		{name: "reachable, anonymous, and declared safe", address: "0.0.0.0", allow: true},
+		{name: "loopback needs no declaration", address: "localhost"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flags := serveFlags{
+				address:                          tc.address,
+				port:                             8080,
+				peerAddress:                      tc.address,
+				peerPort:                         8443,
+				allowUnauthenticatedPeerListener: tc.allow,
+			}
+			if err := flags.validatePeerListener(); err != nil {
+				t.Fatalf("validatePeerListener() = %v", err)
+			}
+			listener, err := flags.buildPeerListener(nil)
+			switch {
+			case tc.wantErr && err == nil:
+				t.Fatalf("buildPeerListener() opened an anonymous listener on %s, want it refused", tc.address)
+			case tc.wantErr:
+				if !strings.Contains(err.Error(), "without authenticating its peers") {
+					t.Errorf("buildPeerListener() = %v, want it to say the peers are unauthenticated", err)
+				}
+			case err != nil:
+				t.Fatalf("buildPeerListener() = %v, want it to pass", err)
+			case !listener.enabled():
+				t.Fatal("buildPeerListener() returned no listener")
+			}
+		})
+	}
+}
+
+// TestPeerListenerServesMTLSWhileClientsGoPlaintext is the end-to-end check of the
+// configuration this listener exists for. It assembles the peer listener's real
+// server and drives real TLS handshakes over it: a peer presenting a certificate
+// from the CA is served, a certificate from anywhere else is refused by the
+// handshake, and one with no certificate still connects (so the health probe is
+// answerable) and is left to the handler to authenticate — while the client
+// listener alongside it is plain HTTP with no credential at all.
+func TestPeerListenerServesMTLSWhileClientsGoPlaintext(t *testing.T) {
+	dir := t.TempDir()
+	certPEM, keyPEM, caPEM := testKeypair(t)
+	flags := serveFlags{
+		address:          "0.0.0.0",
+		port:             8080,
+		peerPort:         8443,
+		peerTLSCertFile:  writeTempFileIn(t, dir, "tls.crt", certPEM),
+		peerTLSKeyFile:   writeTempFileIn(t, dir, "tls.key", keyPEM),
+		peerClientCAFile: writeTempFileIn(t, dir, "ca.crt", caPEM),
+		// The clients: anonymous, plaintext, network-reachable.
+		allowUnauthenticatedText: true,
+	}
+	if err := flags.validatePeerListener(); err != nil {
+		t.Fatalf("validatePeerListener() = %v", err)
+	}
+	peers, err := flags.buildPeerListener(nil)
+	if err != nil {
+		t.Fatalf("buildPeerListener() = %v", err)
+	}
+
+	server, serveOn := peers.server(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "peer\n")
+	}))
+	if server.TLSConfig == nil {
+		t.Fatal("the peer listener assembled no TLS config")
+	}
+	// A client certificate is requested and verified, which is exactly what the
+	// client listener does not do.
+	if got := server.TLSConfig.ClientAuth; got != tls.VerifyClientCertIfGiven {
+		t.Errorf("peer listener ClientAuth = %v, want VerifyClientCertIfGiven", got)
+	}
+
+	socket := newPipeListener()
+	defer socket.Close()
+	go func() { _ = serveOn(socket) }()
+	defer server.Close()
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		t.Fatal("the CA bundle holds no certificates")
+	}
+	pair, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("loading the client keypair: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		certificate []tls.Certificate
+		wantBody    string
+	}{
+		{name: "a peer with a certificate from the CA", certificate: []tls.Certificate{pair}, wantBody: "peer"},
+		// No certificate still completes the handshake — that is what keeps the
+		// health probe answerable — but the handler authenticates the request, which
+		// this bare handler stands in for.
+		{name: "a peer with no certificate", wantBody: "peer"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, err := socket.dial()
+			if err != nil {
+				t.Fatalf("dialling the peer listener: %v", err)
+			}
+			defer conn.Close()
+			client := tls.Client(conn, &tls.Config{
+				RootCAs:      pool,
+				ServerName:   "oci-distribution-gateway.test",
+				Certificates: tc.certificate,
+				MinVersion:   tls.VersionTLS13,
+			})
+			if err := client.Handshake(); err != nil {
+				t.Fatalf("TLS handshake: %v", err)
+			}
+			if err := client.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				t.Fatalf("setting a deadline: %v", err)
+			}
+			if _, err := io.WriteString(client, "GET /healthz HTTP/1.1\r\nHost: peer\r\nConnection: close\r\n\r\n"); err != nil {
+				t.Fatalf("writing the request: %v", err)
+			}
+			response, err := io.ReadAll(client)
+			if err != nil {
+				t.Fatalf("reading the response: %v", err)
+			}
+			if !strings.Contains(string(response), tc.wantBody) {
+				t.Errorf("response = %q, want it to contain %q", response, tc.wantBody)
+			}
+		})
+	}
+
+	// And a peer whose certificate is signed by somebody else is refused by the
+	// handshake, before any request is read.
+	otherCert, otherKey, _ := testKeypair(t)
+	other, err := tls.X509KeyPair(otherCert, otherKey)
+	if err != nil {
+		t.Fatalf("loading the foreign keypair: %v", err)
+	}
+	conn, err := socket.dial()
+	if err != nil {
+		t.Fatalf("dialling the peer listener: %v", err)
+	}
+	defer conn.Close()
+	client := tls.Client(conn, &tls.Config{
+		RootCAs:      pool,
+		ServerName:   "oci-distribution-gateway.test",
+		Certificates: []tls.Certificate{other},
+		MinVersion:   tls.VersionTLS13,
+	})
+	if err := client.Handshake(); err != nil {
+		// TLS 1.3 reports the server's rejection of the client certificate on the
+		// first read rather than in Handshake, so either is the expected outcome.
+		return
+	}
+	_ = client.SetDeadline(time.Now().Add(5 * time.Second))
+	if _, err := io.WriteString(client, "GET /healthz HTTP/1.1\r\nHost: peer\r\nConnection: close\r\n\r\n"); err == nil {
+		if body, err := io.ReadAll(client); err == nil && strings.Contains(string(body), "peer") {
+			t.Error("the peer listener served a client whose certificate the CA did not sign")
+		}
+	}
+}
+
+// TestReplicationFollowsThePeerListener checks the consequence of the split that
+// is easiest to get wrong: with a peer listener, the hop between instances is that
+// listener's — its port is the one a discovered peer is dialled on, and its TLS
+// decides whether the hop is https. The client listener's plaintext must not make
+// the gateway refuse (or downgrade) a replication hop that is in fact encrypted.
+func TestReplicationFollowsThePeerListener(t *testing.T) {
+	// A gateway serving plaintext to its clients, with peer discovery. Without a
+	// peer listener this cannot work: replication would be plaintext too.
+	flags := serveFlags{
+		address:            "0.0.0.0",
+		port:               8080,
+		blobCacheTTL:       time.Hour,
+		blobCacheMaxMemory: defaultBlobCacheMemory,
+		cachePeerService:   "img-gateway/gw",
+	}
+	if _, err := flags.cacheReplication(nil, nil); err == nil || !strings.Contains(err.Error(), "serves replication over plaintext") {
+		t.Fatalf("cacheReplication() without a peer listener = %v, want it to refuse a plaintext hop", err)
+	}
+
+	// The same gateway with a TLS peer listener: the hop is that listener's, so it
+	// is https and it is dialled on --peer-port. Discovery itself needs a pod's
+	// environment, which a test is not — reaching that error is the assertion that
+	// the plaintext and port checks both passed.
+	dir := t.TempDir()
+	certPEM, keyPEM, caPEM := testKeypair(t)
+	flags.peerPort = 8443
+	flags.peerTLSCertFile = writeTempFileIn(t, dir, "tls.crt", certPEM)
+	flags.peerTLSKeyFile = writeTempFileIn(t, dir, "tls.key", keyPEM)
+	flags.peerClientCAFile = writeTempFileIn(t, dir, "ca.crt", caPEM)
+	if err := flags.validatePeerListener(); err != nil {
+		t.Fatalf("validatePeerListener() = %v", err)
+	}
+	peers, err := flags.buildPeerListener(nil)
+	if err != nil {
+		t.Fatalf("buildPeerListener() = %v", err)
+	}
+	if !peers.servesTLS() {
+		t.Fatal("the peer listener does not serve TLS despite a keypair")
+	}
+	if _, err := flags.cacheReplication(nil, peers); err == nil || !strings.Contains(err.Error(), "Kubernetes pod") {
+		t.Fatalf("cacheReplication() with a TLS peer listener = %v, want it past the plaintext and port checks", err)
+	}
+}
+
+// pipeListener is a net.Listener over in-memory connections, so a test can drive
+// a real TLS handshake and a real HTTP server without binding a port (which this
+// repository's tests deliberately never do).
+//
+// The connections buffer rather than being a net.Pipe, and that is load-bearing:
+// net.Pipe is synchronous and unbuffered, so any exchange where both sides write
+// before either reads deadlocks — and a TLS 1.3 server sends its session tickets
+// the moment the handshake completes. A socketpair would do too, but syscall.
+// Socketpair does not exist on Windows, and this package's tests run there.
+// //pkg/serve/gateway has the same helper for the same reason; it is not importable
+// from here, since it lives in that package's own test sources.
+type pipeListener struct {
+	conns   chan net.Conn
+	closing chan struct{}
+	once    sync.Once
+}
+
+func newPipeListener() *pipeListener {
+	return &pipeListener{conns: make(chan net.Conn), closing: make(chan struct{})}
+}
+
+func (l *pipeListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-l.conns:
+		return conn, nil
+	case <-l.closing:
+		return nil, net.ErrClosed
+	}
+}
+
+// dial opens a connection to the listener and hands the far end to Accept.
+func (l *pipeListener) dial() (net.Conn, error) {
+	toServer, toClient := newPipeBuffer(), newPipeBuffer()
+	client := &pipeConn{read: toClient, write: toServer, local: pipeAddr("peer-client"), peer: pipeAddr("peer-listener")}
+	server := &pipeConn{read: toServer, write: toClient, local: pipeAddr("peer-listener"), peer: pipeAddr("peer-client")}
+	select {
+	case l.conns <- server:
+		return client, nil
+	case <-l.closing:
+		client.Close()
+		server.Close()
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *pipeListener) Close() error {
+	l.once.Do(func() { close(l.closing) })
+	return nil
+}
+
+func (l *pipeListener) Addr() net.Addr { return pipeAddr("peer-listener") }
+
+type pipeAddr string
+
+func (pipeAddr) Network() string  { return "pipe" }
+func (a pipeAddr) String() string { return string(a) }
+
+// pipeBuffer is one direction of a pipeConn: an unbounded byte queue that blocks
+// readers until data arrives, the writer closes, or the deadline passes.
+type pipeBuffer struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	buf      bytes.Buffer
+	closed   bool
+	deadline time.Time
+	timer    *time.Timer
+}
+
+func newPipeBuffer() *pipeBuffer {
+	b := &pipeBuffer{}
+	b.cond = sync.NewCond(&b.mu)
+	return b
+}
+
+func (b *pipeBuffer) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for b.buf.Len() == 0 {
+		if b.closed {
+			return 0, io.EOF
+		}
+		if b.expiredLocked() {
+			return 0, os.ErrDeadlineExceeded
+		}
+		b.cond.Wait()
+	}
+	return b.buf.Read(p)
+}
+
+func (b *pipeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return 0, net.ErrClosed
+	}
+	n, err := b.buf.Write(p)
+	b.cond.Broadcast()
+	return n, err
+}
+
+func (b *pipeBuffer) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.closed = true
+	b.cond.Broadcast()
+	return nil
+}
+
+// setDeadline wakes any blocked reader once t has passed.
+func (b *pipeBuffer) setDeadline(t time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.deadline = t
+	if b.timer != nil {
+		b.timer.Stop()
+		b.timer = nil
+	}
+	if t.IsZero() {
+		return
+	}
+	if delay := time.Until(t); delay > 0 {
+		b.timer = time.AfterFunc(delay, func() {
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			b.cond.Broadcast()
+		})
+	}
+	b.cond.Broadcast()
+}
+
+func (b *pipeBuffer) expiredLocked() bool {
+	return !b.deadline.IsZero() && !time.Now().Before(b.deadline)
+}
+
+// pipeConn is one end of an in-memory connection.
+type pipeConn struct {
+	read  *pipeBuffer
+	write *pipeBuffer
+	local pipeAddr
+	peer  pipeAddr
+	once  sync.Once
+}
+
+func (c *pipeConn) Read(p []byte) (int, error)  { return c.read.Read(p) }
+func (c *pipeConn) Write(p []byte) (int, error) { return c.write.Write(p) }
+func (c *pipeConn) LocalAddr() net.Addr         { return c.local }
+func (c *pipeConn) RemoteAddr() net.Addr        { return c.peer }
+
+func (c *pipeConn) Close() error {
+	c.once.Do(func() {
+		// Closing both directions models a TCP close: the peer's reads end too.
+		_ = c.write.Close()
+		_ = c.read.Close()
+	})
+	return nil
+}
+
+func (c *pipeConn) SetDeadline(t time.Time) error {
+	c.read.setDeadline(t)
+	c.write.setDeadline(t)
+	return nil
+}
+
+func (c *pipeConn) SetReadDeadline(t time.Time) error  { c.read.setDeadline(t); return nil }
+func (c *pipeConn) SetWriteDeadline(t time.Time) error { c.write.setDeadline(t); return nil }

--- a/img_tool/cmd/oci-distribution-gateway/serve.go
+++ b/img_tool/cmd/oci-distribution-gateway/serve.go
@@ -60,6 +60,15 @@ type serveFlags struct {
 	allowPlaintextH2C        bool
 	allowUnauthenticatedText bool
 
+	// A second listener for peer (instance-to-instance) traffic, so a deployment
+	// can serve its clients one way and its peers another.
+	peerAddress                      string
+	peerPort                         int
+	peerTLSCertFile                  string
+	peerTLSKeyFile                   string
+	peerClientCAFile                 string
+	allowUnauthenticatedPeerListener bool
+
 	metrics metricsFlags
 }
 
@@ -117,6 +126,13 @@ func (f *serveFlags) register(flagSet *flag.FlagSet) {
 	flagSet.BoolVar(&f.allowPlaintextH2C, "dangerously-allow-plaintext-h2c", false, "Accept prior-knowledge HTTP/2 (h2c) on the plaintext listener. DANGEROUS: sniffing the h2c preface happens before any read deadline is set, so a client that connects and stalls holds a connection indefinitely. Only for a listener reachable solely through a service-mesh sidecar.")
 	flagSet.BoolVar(&f.allowUnauthenticatedText, "dangerously-allow-unauthenticated-clients", false, "Serve a network-reachable address without client authentication. DANGEROUS: this listener holds the upstream registry credentials, and a Kubernetes ClusterIP Service is reachable from every namespace.")
 
+	flagSet.StringVar(&f.peerAddress, "peer-address", "", "Address of a second listener carrying only cache replication between the instances of this deployment, so peers can be authenticated differently from clients -- mTLS between instances while clients connect over plaintext, for example. Setting it (or --peer-port) moves the /_rules_img/cache/ endpoints off the client listener entirely. Defaults to --address once --peer-port is set.")
+	flagSet.IntVar(&f.peerPort, "peer-port", 0, "Port of the peer listener. Required to enable it, and it is also the port a discovered peer is reached on, so every instance must use the same one.")
+	flagSet.StringVar(&f.peerTLSCertFile, "peer-tls-cert-file", "", "PEM certificate the peer listener serves TLS with. Defaults to --tls-cert-file. Re-read when the file changes and on SIGHUP.")
+	flagSet.StringVar(&f.peerTLSKeyFile, "peer-tls-key-file", "", "PEM private key matching --peer-tls-cert-file. Both or neither.")
+	flagSet.StringVar(&f.peerClientCAFile, "peer-client-ca-file", "", "PEM bundle of CAs whose client certificates the peer listener accepts. Setting it enables mTLS there and requires a certificate for that listener. Defaults to --client-ca-file. This is the flag that lets instances speak mTLS to each other while clients do not.")
+	flagSet.BoolVar(&f.allowUnauthenticatedPeerListener, "dangerously-allow-unauthenticated-peer-listener", false, "Run the peer listener with no client authentication. DANGEROUS: anything able to reach it can insert blob existence facts, and a client that believes a false one skips an upload it still owes.")
+
 	f.metrics.register(flagSet)
 }
 
@@ -137,6 +153,7 @@ func newServeFlagSet() (*flag.FlagSet, *serveFlags) {
 				"oci-distribution-gateway serve --unix-socket /run/gw.sock --dangerously-allow-all",
 				"oci-distribution-gateway serve --port 8080 --policy-file /etc/img/policy.json --metrics-exporter prometheus",
 				"oci-distribution-gateway serve --address 0.0.0.0 --port 8443 --policy-file /etc/img/policy.json \\\n      --tls-cert-file /tls/tls.crt --tls-key-file /tls/tls.key \\\n      --client-ca-file /tls/ca.crt --allowed-client-id spiffe://cluster.local/ns/bb/sa/worker",
+				"oci-distribution-gateway serve --address 0.0.0.0 --port 8080 --policy-file /etc/img/policy.json \\\n      --dangerously-allow-unauthenticated-clients \\\n      --peer-port 8443 --peer-tls-cert-file /tls/tls.crt --peer-tls-key-file /tls/tls.key \\\n      --peer-client-ca-file /tls/ca.crt --allowed-cache-peer-id oci-gateway.img-gateway.svc \\\n      --blob-existence-cache-peer-service oci-distribution-gateway",
 			})
 	}
 	return flagSet, flags
@@ -171,6 +188,10 @@ func serveProcess(ctx context.Context, args []string) {
 	}
 	if flags.clientCAFile != "" && flags.tlsCertFile == "" {
 		fmt.Fprintln(os.Stderr, "Error: --client-ca-file requires --tls-cert-file (a client certificate can only be presented over TLS)")
+		os.Exit(1)
+	}
+	if err := flags.validatePeerListener(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 	// A bound too small to hold one blob would leave a cache that stores nothing
@@ -245,6 +266,13 @@ func serveProcess(ctx context.Context, args []string) {
 		}
 	}
 
+	var peers *peerListener
+	peers, err = flags.buildPeerListener(onReload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
 	var peerAuth *gateway.PeerAuth
 	if flags.clientCAFile != "" || len(flags.clientTokenFiles) > 0 || flags.serviceAccountAudience != "" {
 		peerAuth, err = gateway.NewPeerAuth(gateway.PeerAuthOptions{
@@ -284,7 +312,7 @@ func serveProcess(ctx context.Context, args []string) {
 	if peerAuth != nil {
 		handlerOpts = append(handlerOpts, gateway.WithPeerAuth(peerAuth))
 	}
-	replication, err := flags.cacheReplication(serverTLS)
+	replication, err := flags.cacheReplication(serverTLS, peers)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -301,6 +329,25 @@ func serveProcess(ctx context.Context, args []string) {
 	}
 	handler := gateway.New(handlerOpts...)
 	recordReload = handler.RecordMaterialReload
+
+	// Split cache replication off onto its own listener when one is configured. It
+	// has to happen before the client listener opens: from this call on, the client
+	// listener answers the replication endpoints with 404, and a window in which it
+	// still served them would be exactly the anonymous write path into this
+	// instance's cache that the separate listener exists to close.
+	var peerServer *gatewayListener
+	if peers.enabled() {
+		replicationHandler := handler.SeparateReplicationHandler(peers.auth)
+		if replicationHandler == nil {
+			fmt.Fprintln(os.Stderr, "Error: --peer-port configures a listener for cache replication, which is not enabled")
+			os.Exit(1)
+		}
+		peerServer, err = peers.serve(replicationHandler)
+		if err != nil {
+			log.Fatalf("Failed to listen for peers: %v", err)
+		}
+		log.Printf("cache replication served on its own listener (%s)", peers.summary())
+	}
 
 	listener, cleanup, err := listen(flags.unixSocket, flags.address, flags.port, socketMode)
 	if err != nil {
@@ -345,6 +392,7 @@ func serveProcess(ctx context.Context, args []string) {
 	if peerAuth != nil {
 		go peerAuth.Watch(done, 0)
 	}
+	peers.watch(done)
 	// Peer discovery, the warm-up that seeds this instance's cache from a peer, and
 	// the batching of outbound facts. The listener is already open, so a peer's
 	// broadcast is accepted from here on — including while the warm-up runs, which
@@ -371,6 +419,7 @@ func serveProcess(ctx context.Context, args []string) {
 					log.Printf("token reload FAILED, keeping previous tokens: %v", err)
 				}
 			}
+			peers.reload()
 		}
 	}()
 
@@ -378,6 +427,7 @@ func serveProcess(ctx context.Context, args []string) {
 		server:          server,
 		serve:           serve,
 		addr:            listener.Addr(),
+		peer:            peerServer,
 		metrics:         metricsServer,
 		shutdownTimeout: flags.shutdownTimeout,
 		banner:          "oci-distribution-gateway listening",
@@ -392,7 +442,12 @@ func serveProcess(ctx context.Context, args []string) {
 // CA — every instance already holds a certificate its peers accept and a CA bundle
 // that verifies theirs, so replication needs no material of its own. A fleet whose
 // peers authenticate by token instead passes --blob-existence-cache-peer-token-file.
-func (f *serveFlags) cacheReplication(serverTLS *gateway.PeerTLS) (*gateway.CacheReplication, error) {
+//
+// peers, when set, is the second listener replication is served on, and it takes
+// over from the client listener in every respect: its TLS material is what this
+// instance presents to its peers and verifies them with, and its port is the one a
+// discovered peer is dialled on.
+func (f *serveFlags) cacheReplication(serverTLS *gateway.PeerTLS, peers *peerListener) (*gateway.CacheReplication, error) {
 	if len(f.cachePeers) == 0 && f.cachePeerService == "" {
 		// Refuse to ignore a flag that only makes sense with peers: silently doing
 		// nothing with --allowed-cache-peer-id would look like a control that is in
@@ -405,6 +460,7 @@ func (f *serveFlags) cacheReplication(serverTLS *gateway.PeerTLS) (*gateway.Cach
 			{"--blob-existence-cache-peer-token-file", f.cachePeerTokenFile != ""},
 			{"--allowed-cache-peer-id", len(f.allowedCachePeerIDs) > 0},
 			{"--dangerously-allow-plaintext-cache-peer", f.allowPlaintextCachePeer},
+			{"--peer-port", peers.enabled()},
 		} {
 			if orphan.set {
 				return nil, fmt.Errorf("%s configures cache replication, which needs --blob-existence-cache-peer or --blob-existence-cache-peer-service", orphan.flag)
@@ -418,11 +474,18 @@ func (f *serveFlags) cacheReplication(serverTLS *gateway.PeerTLS) (*gateway.Cach
 	if f.blobCacheTTL <= 0 || f.blobCacheMaxMemory <= 0 {
 		return nil, errors.New("cache replication needs the blob existence cache: --blob-existence-cache-ttl and --blob-existence-cache-max-memory must both be above zero")
 	}
-	if f.unixSocket != "" {
-		return nil, errors.New("cache replication needs a TCP listener that peers can reach, not --unix-socket")
+	if f.unixSocket != "" && !peers.enabled() {
+		return nil, errors.New("cache replication needs a TCP listener that peers can reach: give the gateway --address/--port instead of --unix-socket, or serve replication on a peer listener of its own with --peer-port")
 	}
 
-	peers, err := f.cachePeerSource(serverTLS)
+	// The peer listener's material is what talks to peers when there is one: on a
+	// gateway whose clients are anonymous over plaintext, the client listener's
+	// (absent) TLS says nothing about the hop between instances.
+	replicationTLS := serverTLS
+	if peers.enabled() {
+		replicationTLS = peers.tls
+	}
+	peerSource, err := f.cachePeerSource(replicationTLS, peers)
 	if err != nil {
 		return nil, err
 	}
@@ -430,15 +493,15 @@ func (f *serveFlags) cacheReplication(serverTLS *gateway.PeerTLS) (*gateway.Cach
 	if f.cachePeerTokenFile != "" {
 		credential = newTokenReader(f.cachePeerTokenFile).token
 	}
-	if serverTLS == nil && credential == nil {
+	if replicationTLS == nil && credential == nil {
 		log.Printf("WARNING: this gateway presents no credential to its cache replication peers; they must accept anonymous clients for replication to work")
 	}
 	if len(f.allowedCachePeerIDs) == 0 {
 		log.Printf("WARNING: no --allowed-cache-peer-id is set, so every client this gateway authenticates may insert blob existence facts into its cache; a false one makes push clients skip an upload they still owe")
 	}
 	return gateway.NewCacheReplication(gateway.ReplicationConfig{
-		Peers:          peers,
-		Client:         cachePeerClient(serverTLS, f.cachePeerServerName),
+		Peers:          peerSource,
+		Client:         cachePeerClient(replicationTLS, f.cachePeerServerName),
 		Credential:     credential,
 		AllowedPeerIDs: f.allowedCachePeerIDs,
 		BatchSize:      f.cacheBatchSize,
@@ -449,8 +512,10 @@ func (f *serveFlags) cacheReplication(serverTLS *gateway.PeerTLS) (*gateway.Cach
 
 // cachePeerSource resolves the configured peers: either the static list, whose
 // URLs are validated here, or a Kubernetes Service whose endpoints are watched.
-func (f *serveFlags) cachePeerSource(serverTLS *gateway.PeerTLS) (gateway.PeerSource, error) {
-	servingTLS := serverTLS != nil && serverTLS.HasCertificate()
+func (f *serveFlags) cachePeerSource(replicationTLS *gateway.PeerTLS, peers *peerListener) (gateway.PeerSource, error) {
+	// Whether the *replication* hop is encrypted, which on a gateway with a peer
+	// listener is that listener's business and not the client listener's.
+	replicationTLSServed := replicationTLS != nil && replicationTLS.HasCertificate()
 	if f.cachePeerService == "" {
 		for _, peer := range f.cachePeers {
 			if err := f.validateCachePeer(peer); err != nil {
@@ -460,24 +525,29 @@ func (f *serveFlags) cachePeerSource(serverTLS *gateway.PeerTLS) (gateway.PeerSo
 		return gateway.StaticPeers(f.cachePeers), nil
 	}
 	// A discovered peer is a pod of this same Deployment, so it is reached the way
-	// this instance is: the same scheme, and the same container port.
-	if f.port == 0 {
-		return nil, errors.New("--blob-existence-cache-peer-service needs an explicit --port, since a discovered peer is reached on the port this gateway itself serves on")
+	// this instance is: the same scheme, and the same container port — the peer
+	// listener's when there is one, since that is where replication is served.
+	port, portFlag := f.port, "--port"
+	if peers.enabled() {
+		port, portFlag = peers.port, "--peer-port"
+	}
+	if port == 0 {
+		return nil, fmt.Errorf("--blob-existence-cache-peer-service needs an explicit %s, since a discovered peer is reached on the port this gateway itself serves replication on", portFlag)
 	}
 	scheme := "https"
-	if !servingTLS {
+	if !replicationTLSServed {
 		if !f.allowPlaintextCachePeer {
-			return nil, errors.New("this gateway serves plaintext, so replication to its peers would be plaintext too: configure --tls-cert-file, or pass --dangerously-allow-plaintext-cache-peer when a service mesh secures the hop")
+			return nil, errors.New("this gateway serves replication over plaintext, so replication to its peers would be plaintext too: configure --tls-cert-file (or --peer-tls-cert-file for a peer listener), or pass --dangerously-allow-plaintext-cache-peer when a service mesh secures the hop")
 		}
 		scheme = "http"
 	}
-	if servingTLS && f.cachePeerServerName == "" {
+	if replicationTLSServed && f.cachePeerServerName == "" {
 		log.Printf("warning: --blob-existence-cache-peer-service dials pod IPs, which a certificate issued for the Service name does not cover; set --blob-existence-cache-peer-server-name if replication fails to verify its peers")
 	}
 	return gateway.NewKubernetesPeers(gateway.KubernetesPeerOptions{
 		Service: f.cachePeerService,
 		Scheme:  scheme,
-		Port:    f.port,
+		Port:    port,
 	})
 }
 

--- a/img_tool/pkg/serve/gateway/BUILD.bazel
+++ b/img_tool/pkg/serve/gateway/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "peers_test.go",
         "peertls_test.go",
         "policy_test.go",
+        "replication_listener_test.go",
         "replication_serve_test.go",
         "replication_test.go",
         "testcerts_test.go",

--- a/img_tool/pkg/serve/gateway/existencecache_test.go
+++ b/img_tool/pkg/serve/gateway/existencecache_test.go
@@ -18,6 +18,9 @@ const (
 	testCacheRegistry   = "registry.test"
 	testCacheRepository = "team/service/app"
 	testCacheDigest     = "sha256:6b0f2e1a4c3d5e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f7"
+	// testOtherDigest is a second blob, for a test that has to tell one entry from
+	// another rather than only whether the cache has anything in it.
+	testOtherDigest = "sha256:1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f809"
 )
 
 // fakeClock is a manually advanced clock, so the TTL tests neither sleep nor

--- a/img_tool/pkg/serve/gateway/gateway.go
+++ b/img_tool/pkg/serve/gateway/gateway.go
@@ -114,6 +114,12 @@ type Handler struct {
 	// when replication is off, which every one of its methods tolerates.
 	replication *CacheReplication
 
+	// replicationSeparate reports that replication is served on a listener of its
+	// own, so this handler refuses the replication endpoints outright. It is set
+	// by [Handler.SeparateReplicationHandler] during startup, and read on the
+	// request path.
+	replicationSeparate atomic.Bool
+
 	// warming reports that this instance is still seeding its cache from a peer
 	// and should be kept out of the load balancer until it is not — see
 	// [Handler.warmingUp]. warmingUntil is the deadline past which it reports
@@ -345,19 +351,7 @@ func (h *Handler) serve(obs *observation, w http.ResponseWriter, r *http.Request
 	// The health endpoint is answered before authentication so a Kubernetes probe
 	// can reach a listener that requires a credential.
 	if path == healthPath {
-		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		if h.warmingUp() {
-			// Still seeding the blob existence cache from a peer. Serving now would
-			// send this instance's share of the fleet's probes upstream for nothing,
-			// so stay out of the Service until the seeding is done or its budget is
-			// spent (see Handler.warmingUp).
-			w.Header().Set("Retry-After", "1")
-			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = io.WriteString(w, "warming up\n")
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = io.WriteString(w, "ok\n")
+		h.serveHealth(w)
 		return
 	}
 
@@ -377,6 +371,15 @@ func (h *Handler) serve(obs *observation, w http.ResponseWriter, r *http.Request
 	// what it may do to this instance's cache is gated by the identity of the peer
 	// rather than by the policy (see replication.go).
 	if strings.HasPrefix(path, replicationPathPrefix) {
+		if h.replicationSeparate.Load() {
+			// Replication has a listener of its own, which is the only place these
+			// endpoints exist. Answering them here too would put the write path to
+			// this instance's cache back on the surface the separate listener was
+			// configured to take it off.
+			h.writeError(obs, w, r, http.StatusNotFound, "UNSUPPORTED", errUnsupportedEndpoint,
+				"this gateway replicates its blob existence cache on a separate listener")
+			return
+		}
 		h.serveCacheReplication(obs, w, r, path)
 		return
 	}
@@ -488,6 +491,26 @@ func (h *Handler) serve(obs *observation, w http.ResponseWriter, r *http.Request
 	}
 
 	h.forward(obs, w, r, repo, cls)
+}
+
+// serveHealth answers the unauthenticated health endpoint. Both of a gateway's
+// listeners answer it: a Kubernetes probe names a port, and a peer listener that
+// could not say whether it is ready would have to be probed through the client
+// one, which reports the readiness of a different socket.
+func (h *Handler) serveHealth(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	if h.warmingUp() {
+		// Still seeding the blob existence cache from a peer. Serving now would
+		// send this instance's share of the fleet's probes upstream for nothing,
+		// so stay out of the Service until the seeding is done or its budget is
+		// spent (see Handler.warmingUp).
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, "warming up\n")
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, "ok\n")
 }
 
 // serveCachedBlobHead answers a blob existence check from the blob existence

--- a/img_tool/pkg/serve/gateway/replication.go
+++ b/img_tool/pkg/serve/gateway/replication.go
@@ -667,6 +667,73 @@ func principalIdentity(principal string) (string, bool) {
 	return "", false
 }
 
+// SeparateReplicationHandler splits cache replication off onto a listener of its
+// own and returns the [http.Handler] for it, or nil when this gateway does not
+// replicate.
+//
+// It exists for the deployment whose two audiences want two different transports:
+// build clients reaching the gateway over plaintext HTTP with no credential of
+// their own, while the instances of the deployment authenticate each other with
+// mTLS. Those cannot be the same socket — a listener either requires a client
+// certificate or it does not — so the peer traffic gets a second one, with its own
+// TLS material, its own client authentication, and nothing on it but the
+// replication endpoints and the health probe.
+//
+// Once it is called the registry-protocol listener answers /_rules_img/cache/ with
+// 404, so the write path into this instance's blob existence cache exists only on
+// the peer listener. That is the whole point of separating them: an anonymous
+// client that could insert facts could make a push client skip an upload it still
+// owes.
+//
+// peerAuth authenticates the peers. It may be nil, which is only appropriate when
+// the peer listener is unreachable except through something that authenticates it
+// (a service mesh, or a loopback address); the caller is expected to say so out
+// loud.
+func (h *Handler) SeparateReplicationHandler(peerAuth *PeerAuth) http.Handler {
+	if h.replication == nil {
+		return nil
+	}
+	h.replicationSeparate.Store(true)
+	return &replicationHandler{gateway: h, peerAuth: peerAuth}
+}
+
+// replicationHandler serves the replication endpoints (and the health probe) on a
+// listener of their own. It is what [Handler.SeparateReplicationHandler] returns.
+type replicationHandler struct {
+	gateway  *Handler
+	peerAuth *PeerAuth
+}
+
+// ServeHTTP implements [http.Handler]. It is deliberately a closed surface: the
+// health probe, the two replication endpoints, and 404 for everything else. None
+// of the registry protocol is reachable here, so a peer credential cannot be spent
+// on an upstream registry.
+func (rh *replicationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h := rh.gateway
+	obs, w, r := h.metrics.begin(w, r)
+	defer obs.finish(r.Context())
+
+	path := r.URL.EscapedPath()
+	if path == healthPath {
+		h.serveHealth(w)
+		return
+	}
+	if rh.peerAuth != nil {
+		principal, err := rh.peerAuth.Authenticate(r)
+		if err != nil {
+			h.writePeerAuthError(obs, w, r, err)
+			return
+		}
+		obs.principal = principal
+	}
+	if !strings.HasPrefix(path, replicationPathPrefix) {
+		h.writeError(obs, w, r, http.StatusNotFound, "UNSUPPORTED", errUnsupportedEndpoint,
+			"this listener serves blob existence cache replication only")
+		return
+	}
+	h.serveCacheReplication(obs, w, r, path)
+}
+
 // serveCacheReplication answers the two replication endpoints, or explains why it
 // will not.
 //

--- a/img_tool/pkg/serve/gateway/replication_listener_test.go
+++ b/img_tool/pkg/serve/gateway/replication_listener_test.go
@@ -1,0 +1,148 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// These tests cover splitting cache replication onto a listener of its own, which
+// is what lets a deployment authenticate its peers differently from its clients:
+// anonymous plaintext for build clients, mTLS between the instances. The two
+// properties that matter are that the endpoints *move* rather than being
+// duplicated, and that the separate listener exposes nothing but them.
+
+// TestSeparateReplicationMovesTheEndpointsOffTheClientListener is the security
+// property of the split. A gateway whose clients are anonymous must not leave the
+// write path into its blob existence cache on the clients' listener: a client that
+// can insert a fact about a blob that is not there makes push clients skip an
+// upload they still owe.
+func TestSeparateReplicationMovesTheEndpointsOffTheClientListener(t *testing.T) {
+	router := newPeerRouter()
+	fleet := newFleet(t, router, replicaConfig{id: "a", peers: []string{"b"}})
+	handler := fleet["a"].handler
+
+	// Before the split the client listener serves them, which is the single-listener
+	// deployment every existing gateway is.
+	if resp := postEvents(handler, "b", cacheEvent{Registry: testUpstreamHost, Repository: "app", Digest: testCacheDigest}); resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("posting to the client listener before the split = %d, want 204", resp.StatusCode)
+	}
+
+	peerHandler := handler.SeparateReplicationHandler(nil)
+	if peerHandler == nil {
+		t.Fatal("SeparateReplicationHandler returned nil for a replicating gateway")
+	}
+
+	// Afterwards the client listener refuses them...
+	resp := postEvents(handler, "b", cacheEvent{Registry: testUpstreamHost, Repository: "app", Digest: testOtherDigest})
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("posting to the client listener after the split = %d, want 404", resp.StatusCode)
+	}
+	if held(fleet["a"], testOtherDigest) {
+		t.Fatal("the client listener wrote to the cache after replication moved to its own listener")
+	}
+	// ...and the peer listener serves them.
+	if resp := postEventsTo(peerHandler, "b", []cacheEvent{{Registry: testUpstreamHost, Repository: "app", Digest: testOtherDigest}}, nil); resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("posting to the peer listener = %d, want 204", resp.StatusCode)
+	}
+	if !held(fleet["a"], testOtherDigest) {
+		t.Fatal("the peer listener did not write the fact to the cache")
+	}
+}
+
+// TestSeparateReplicationListenerServesNothingElse holds the peer listener to a
+// closed surface. It carries a credential the peers trust, so anything of the
+// registry protocol reachable there would be a way to spend that credential on an
+// upstream registry.
+func TestSeparateReplicationListenerServesNothingElse(t *testing.T) {
+	router := newPeerRouter()
+	fleet := newFleet(t, router, replicaConfig{id: "a", peers: []string{"b"}})
+	peerHandler := fleet["a"].handler.SeparateReplicationHandler(nil)
+
+	for _, path := range []string{
+		"/v2/",
+		"/v2/app/manifests/latest",
+		"/v2/app/blobs/" + testCacheDigest,
+		"/",
+	} {
+		r, _ := http.NewRequest(http.MethodGet, "http://gateway"+path, nil)
+		r.Header.Set("X-rules_img-Original-Host", testUpstreamHost)
+		recorder := httptest.NewRecorder()
+		peerHandler.ServeHTTP(recorder, r)
+		if got := recorder.Code; got != http.StatusNotFound {
+			t.Errorf("GET %s on the peer listener = %d, want 404", path, got)
+		}
+	}
+}
+
+// TestSeparateReplicationListenerAnswersHealth keeps the readiness probe working
+// against the peer listener. A Kubernetes probe names a port, so a peer listener
+// that could not answer would have to be probed through the client one — which
+// reports the readiness of a different socket.
+func TestSeparateReplicationListenerAnswersHealth(t *testing.T) {
+	router := newPeerRouter()
+	fleet := newFleet(t, router, replicaConfig{id: "a", peers: []string{"b"}})
+	peerHandler := fleet["a"].handler.SeparateReplicationHandler(nil)
+
+	r, _ := http.NewRequest(http.MethodGet, "http://gateway"+healthPath, nil)
+	recorder := httptest.NewRecorder()
+	peerHandler.ServeHTTP(recorder, r)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET %s on the peer listener = %d, want 200", healthPath, recorder.Code)
+	}
+	if got := recorder.Body.String(); !strings.Contains(got, "ok") {
+		t.Errorf("health body = %q, want it to say ok", got)
+	}
+}
+
+// TestSeparateReplicationRequiresReplication covers the flag combination that asks
+// for a peer listener on a gateway that does not replicate. Returning nil is what
+// lets the command refuse to start rather than opening a listener with nothing on
+// it.
+func TestSeparateReplicationRequiresReplication(t *testing.T) {
+	handler := newTestHandler(allowHostPolicy(t, testUpstreamHost, "blob:read"), &fakeUpstreamRT{})
+	if peerHandler := handler.SeparateReplicationHandler(nil); peerHandler != nil {
+		t.Fatalf("SeparateReplicationHandler() = %v for a gateway that does not replicate, want nil", peerHandler)
+	}
+}
+
+// TestSeparateReplicationListenerAuthenticatesPeers checks that the peer
+// listener's own authentication is enforced — it is a different PeerAuth from the
+// client listener's, which is the entire point of the split.
+func TestSeparateReplicationListenerAuthenticatesPeers(t *testing.T) {
+	dir := t.TempDir()
+	tokens := writeFile(t, dir, "tokens", []byte("0123456789abcdef0123456789abcdef\n"))
+	auth, err := NewPeerAuth(PeerAuthOptions{TokenFiles: []string{tokens}})
+	if err != nil {
+		t.Fatalf("NewPeerAuth: %v", err)
+	}
+
+	router := newPeerRouter()
+	fleet := newFleet(t, router, replicaConfig{id: "a", peers: []string{"b"}})
+	peerHandler := fleet["a"].handler.SeparateReplicationHandler(auth)
+
+	// No credential: refused before the endpoint is reached.
+	if resp := postEventsTo(peerHandler, "b", []cacheEvent{{Registry: testUpstreamHost, Repository: "app", Digest: testCacheDigest}}, nil); resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("posting with no credential = %d, want 401", resp.StatusCode)
+	}
+	if held(fleet["a"], testCacheDigest) {
+		t.Fatal("an unauthenticated peer wrote to the cache")
+	}
+	// The health probe stays reachable without one, so a readiness probe works.
+	r, _ := http.NewRequest(http.MethodGet, "http://gateway"+healthPath, nil)
+	recorder := httptest.NewRecorder()
+	peerHandler.ServeHTTP(recorder, r)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("health with no credential = %d, want 200", recorder.Code)
+	}
+	// With the token it goes through.
+	resp := postEventsTo(peerHandler, "b", []cacheEvent{{Registry: testUpstreamHost, Repository: "app", Digest: testCacheDigest}},
+		withBearer("0123456789abcdef0123456789abcdef"))
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("posting with the token = %d, want 204", resp.StatusCode)
+	}
+	if !held(fleet["a"], testCacheDigest) {
+		t.Fatal("an authenticated peer's fact did not reach the cache")
+	}
+}

--- a/img_tool/pkg/serve/gateway/replication_serve_test.go
+++ b/img_tool/pkg/serve/gateway/replication_serve_test.go
@@ -19,14 +19,29 @@ import (
 // postEvents sends a batch to an instance's replication endpoint the way a peer
 // would, with the given origin identity, and returns the response.
 func postEvents(h *Handler, origin string, events ...cacheEvent) *http.Response {
+	return postEventsTo(h, origin, events, nil)
+}
+
+// postEventsTo is postEvents against any handler, so the same call works for the
+// client listener and for the separate one a gateway can serve replication on.
+// credential, when set, is presented as a bearer token.
+func postEventsTo(h http.Handler, origin string, events []cacheEvent, credential func(*http.Request)) *http.Response {
 	body, _ := json.Marshal(cacheEventBatch{Events: events})
 	r, _ := http.NewRequest(http.MethodPost, "http://gateway"+replicationEventsPath, strings.NewReader(string(body)))
 	if origin != "" {
 		r.Header.Set(cacheOriginHeader, origin)
 	}
+	if credential != nil {
+		credential(r)
+	}
 	recorder := httptest.NewRecorder()
 	h.ServeHTTP(recorder, r)
 	return recorder.Result()
+}
+
+// withBearer presents a bearer token on a replication request.
+func withBearer(token string) func(*http.Request) {
+	return func(r *http.Request) { r.Header.Set("Authorization", "Bearer "+token) }
 }
 
 // donate fetches a donation from an instance, as a warming peer would.


### PR DESCRIPTION
A serving gateway could not authenticate its clients and its peers differently. TLS decides per listener whether a client certificate is requested at all, so a deployment whose build clients speak plaintext HTTP with no credential of their own, while its instances authenticate each other with mTLS, had no single socket that could be both.

--peer-port gives the instance-to-instance traffic -- the blob existence cache replication -- a second listener, with its own TLS material and its own client authentication. What it does not name it inherits from the client listener (--peer-address from --address, the keypair from --tls-cert-file/--tls-key-file, the CA from --client-ca-file), so the common case is two flags. The port itself is never defaulted: it is the port a discovered peer is dialled on, so every instance of a deployment has to serve it on the same one.

Enabling it moves the endpoints rather than duplicating them. From the call to Handler.SeparateReplicationHandler on, the client listener answers /_rules_img/cache/ with 404 and the peer listener is the only place they exist. That is the point of the split rather than a side effect: inserting a cache entry is a write into this instance's view of what is upstream, and an anonymous client able to claim a blob is there would make push clients skip an upload they still owe. The peer listener is correspondingly a closed surface -- the two replication endpoints and /healthz, 404 for everything else -- so the credential its peers present cannot be spent on an upstream registry.

Replication follows that listener in every other respect too. Its TLS is what decides whether the hop is https, so a gateway that is plaintext to its clients and TLS to its peers replicates over TLS with no --dangerously-allow-plaintext-cache-peer, and its keypair and CA bundle are what this instance presents to its peers and verifies them with. Both listeners answer /healthz before authentication, since a Kubernetes probe names a port and each socket's readiness is its own.

The startup checks are fail-closed like the rest of the gateway's: half a keypair, a client CA with no certificate to present it over, both listeners on one address and port, and an anonymous peer listener on a network-reachable address all refuse to start.