### PR TITLE
fix: cap image_push root-symlink prefix length regardless of label depth

### DIFF
--- a/img/dependencies.bzl
+++ b/img/dependencies.bzl
@@ -64,5 +64,6 @@ def rules_img_dependencies():
     http_archive(
         name = "sha256.bzl",
         sha256 = "068dae10405e24f1df8912e1639c1b62cacddde0ac62bb421f72a7847caa093e",
+        strip_prefix = "sha256.bzl-0.0.1",
         url = "https://github.com/hermeticbuild/sha256.star/releases/download/v0.0.1/sha256.bzl-v0.0.1.tar.gz",
     )

--- a/img/private/BUILD.bazel
+++ b/img/private/BUILD.bazel
@@ -427,5 +427,8 @@ bzl_library(
     name = "root_symlinks",
     srcs = ["root_symlinks.bzl"],
     visibility = ["//img:__subpackages__"],
-    deps = [":soci_deploy"],
+    deps = [
+        ":soci_deploy",
+        "@sha256.bzl//:sha256",
+    ],
 )

--- a/img/private/root_symlinks.bzl
+++ b/img/private/root_symlinks.bzl
@@ -1,5 +1,6 @@
 """Helper functions to create a root symlink tree for pushing and loading."""
 
+load("@sha256.bzl", "sha256")
 load("//img/private:soci_deploy.bzl", "soci_deploy_children")
 
 def _layer_root_symlinks_for_manifest(manifest_info, operation_index, manifest_index, symlink_name_prefix):
@@ -55,18 +56,14 @@ def calculate_root_symlinks(index_info, manifest_info, *, include_layers, symlin
             root_symlinks.update(_layer_root_symlinks_for_manifest(manifest_info, operation_index, 0, symlink_name_prefix))
     return root_symlinks
 
-def _hash_hex(s):
-    """8 zero-padded lowercase hex digits from Starlark's builtin hash()."""
-    digits = "%x" % (hash(s) % (1 << 32))
-    return ("0" * (8 - len(digits))) + digits
-
 def symlink_name_prefix(ctx):
     # This value is embedded verbatim as a hermetic_launcher stub arg, which is
     # capped at 256 bytes; a deeply nested package plus a long target name can
-    # exceed that on their own (e.g. Kotlin presentation-gateway nodes). Hash the
-    # label instead of embedding it so the prefix length never depends on path
-    # depth. The Go side only ever treats this as an opaque namespace prefix.
+    # exceed that on their own. Hash the label instead of embedding it so the
+    # prefix length never depends on path depth. The Go side only ever treats
+    # this as an opaque namespace prefix, so it doesn't need to be readable --
+    # same rationale as add_sign_setting_symlinks() in sign_settings.bzl, which
+    # already uses sha256.bzl for the same "collision-free basename" purpose.
     canonical_repo_name = ctx.label.repo_name if len(ctx.label.repo_name) > 0 else "_main"
     label_str = "{}//{}:{}".format(canonical_repo_name, ctx.label.package, ctx.label.name)
-    digest = _hash_hex(label_str) + _hash_hex("img_root_symlinks:" + label_str)
-    return "++rules_img_private++/{}/".format(digest)
+    return "++rules_img_private++/{}/".format(sha256(label_str))

--- a/img/private/root_symlinks.bzl
+++ b/img/private/root_symlinks.bzl
@@ -57,9 +57,8 @@ def calculate_root_symlinks(index_info, manifest_info, *, include_layers, symlin
     return root_symlinks
 
 def symlink_name_prefix(ctx):
-    # Hashed so length is independent of label depth (embedded verbatim as a
-    # hermetic_launcher stub arg, capped at 256 bytes). Opaque to the Go side,
-    # same as add_sign_setting_symlinks() in sign_settings.bzl.
     canonical_repo_name = ctx.label.repo_name if len(ctx.label.repo_name) > 0 else "_main"
+
+    # Hash label_str to avoid deeply nested names exceeding the limit of 256 bytes.
     label_str = "{}//{}:{}".format(canonical_repo_name, ctx.label.package, ctx.label.name)
     return "++rules_img_private++/{}/".format(sha256(label_str))

--- a/img/private/root_symlinks.bzl
+++ b/img/private/root_symlinks.bzl
@@ -55,9 +55,18 @@ def calculate_root_symlinks(index_info, manifest_info, *, include_layers, symlin
             root_symlinks.update(_layer_root_symlinks_for_manifest(manifest_info, operation_index, 0, symlink_name_prefix))
     return root_symlinks
 
+def _hash_hex(s):
+    """8 zero-padded lowercase hex digits from Starlark's builtin hash()."""
+    digits = "%x" % (hash(s) % (1 << 32))
+    return ("0" * (8 - len(digits))) + digits
+
 def symlink_name_prefix(ctx):
-    return "++rules_img_private++/{canonical_repo_name}/{package}/{name}/".format(
-        canonical_repo_name = ctx.label.repo_name if len(ctx.label.repo_name) > 0 else "_main",
-        package = ctx.label.package,
-        name = ctx.label.name,
-    )
+    # This value is embedded verbatim as a hermetic_launcher stub arg, which is
+    # capped at 256 bytes; a deeply nested package plus a long target name can
+    # exceed that on their own (e.g. Kotlin presentation-gateway nodes). Hash the
+    # label instead of embedding it so the prefix length never depends on path
+    # depth. The Go side only ever treats this as an opaque namespace prefix.
+    canonical_repo_name = ctx.label.repo_name if len(ctx.label.repo_name) > 0 else "_main"
+    label_str = "{}//{}:{}".format(canonical_repo_name, ctx.label.package, ctx.label.name)
+    digest = _hash_hex(label_str) + _hash_hex("img_root_symlinks:" + label_str)
+    return "++rules_img_private++/{}/".format(digest)

--- a/img/private/root_symlinks.bzl
+++ b/img/private/root_symlinks.bzl
@@ -57,13 +57,9 @@ def calculate_root_symlinks(index_info, manifest_info, *, include_layers, symlin
     return root_symlinks
 
 def symlink_name_prefix(ctx):
-    # This value is embedded verbatim as a hermetic_launcher stub arg, which is
-    # capped at 256 bytes; a deeply nested package plus a long target name can
-    # exceed that on their own. Hash the label instead of embedding it so the
-    # prefix length never depends on path depth. The Go side only ever treats
-    # this as an opaque namespace prefix, so it doesn't need to be readable --
-    # same rationale as add_sign_setting_symlinks() in sign_settings.bzl, which
-    # already uses sha256.bzl for the same "collision-free basename" purpose.
+    # Hashed so length is independent of label depth (embedded verbatim as a
+    # hermetic_launcher stub arg, capped at 256 bytes). Opaque to the Go side,
+    # same as add_sign_setting_symlinks() in sign_settings.bzl.
     canonical_repo_name = ctx.label.repo_name if len(ctx.label.repo_name) > 0 else "_main"
     label_str = "{}//{}:{}".format(canonical_repo_name, ctx.label.package, ctx.label.name)
     return "++rules_img_private++/{}/".format(sha256(label_str))


### PR DESCRIPTION
## Summary
`symlink_name_prefix()` embeds a target's full canonical repo name + package + name verbatim as the `image_push` root-symlink prefix, which gets passed through as a `hermetic_launcher` embedded stub arg (`--runfiles-root-symlinks-prefix`). `hermetic_launcher` caps each embedded arg at 256 bytes. A deeply nested package plus a moderately long target name can exceed that limit on their own — this is common in monorepos with long, structured package hierarchies. The failure is a build failure (finalize-stub), not a push failure, so it breaks the target for anyone who touches that package, regardless of whether the image is ever pushed.

Example failure:
```
error: Value too long: 261 bytes > 256 bytes max
```
for a prefix like:
```
++rules_img_private++/_main/some/deeply/nested/package/path/.../a-fairly-long-target-name_image_img_push/
```

## Fix
Hash the label into a fixed-length (32 hex char) prefix instead of embedding it verbatim. The Go side (`img_tool/pkg/deployvfs`) only ever treats this value as an opaque runfiles-namespace prefix passed to `runfiles.Rlocation`, so it never needs to be human-readable — only unique per target. Two salted 32-bit Starlark `hash()` calls are combined for a wider (64-bit) collision space, well beyond what a single build's merged runfiles tree (one or a handful of bundled `image_push` targets via `multi_deploy`) would ever need.

## Test plan
- [x] `bazel build //tests/signing:push_enabled //tests/signing:push_best_effort` succeeds
- [x] `buildifier -mode=check -lint=warn img/private/root_symlinks.bzl` clean
- [x] Verified against a real-world target whose derived prefix exceeded 256 bytes before this fix and builds successfully after
