### PR TITLE
chore(services): stamp image creation time from build timestamp

### DIFF
--- a/.github/workflows/push_services.yaml
+++ b/.github/workflows/push_services.yaml
@@ -64,4 +64,4 @@ jobs:
         SIGSTORE_ID_TOKEN="$(jq -er .value <<<"${OIDC_TOKEN_JSON}")"
         export SIGSTORE_ID_TOKEN
         # shellcheck disable=SC2086
-        bazelisk run --config=cosign //:push -- ${TAGS}
+        bazelisk run --config=cosign --stamp //:push -- ${TAGS}

--- a/modules/rules_img_services/.bazelrc
+++ b/modules/rules_img_services/.bazelrc
@@ -7,6 +7,7 @@ import %workspace%/.bazelrc.common
 common --@rules_img//img/settings:destination_registry=ghcr.io
 common --@rules_img//img/settings:compress=zstd
 common --@rules_img//img/settings:compression_level=4
+common --@rules_img//img/settings:stamp_created=enabled
 common --@rules_img//img/settings:additional_image_labels_file=//services:image_labels
 common --@rules_go//go/config:pure
 


### PR DESCRIPTION
Opt in to the new stamp_created setting so service images get their `created` field set to the build timestamp on every deploy build.