### PR TITLE
fix(release): find the tool artifact inside the index it is pushed under

### DIFF
--- a/.github/dev-registry.json
+++ b/.github/dev-registry.json
@@ -6,6 +6,7 @@
   "artifact": {
     "registry": "ghcr.io",
     "repository": "bazel-contrib/rules_img/img",
+    "artifact_type": "application/vnd.rules_img.tools.v1",
     "lockfile_title": "prebuilt_lockfile.json"
   }
 }

--- a/.github/workflows/push_services.yaml
+++ b/.github/workflows/push_services.yaml
@@ -102,22 +102,45 @@ jobs:
       uses: ./.github/actions/generate-buildbuddy-bazelrc
       with:
         template-path: .github/workflows/.bazelrc.buildbuddy
-        output-path: buildbuddy.bazelrc
+        output-path: .github/workflows/.bazelrc.buildbuddy.generated
         api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
     - name: Setup Bazel
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
       with:
         bazelisk-cache: true
         repository-cache: true
-        bazelrc: import %workspace%/buildbuddy.bazelrc
+        bazelrc: |
+          import %workspace%/.github/workflows/ci.bazelrc
+          import %workspace%/.github/workflows/.bazelrc.buildbuddy.generated
     - name: Fetch the prebuilt lockfile from the artifact
       shell: bash
       run: |
         artifact="$(jq -r '.artifact.registry + "/" + .artifact.repository' "${CONFIG}")"
+        artifact_type="$(jq -r '.artifact.artifact_type' "${CONFIG}")"
         title="$(jq -r '.artifact.lockfile_title // "prebuilt_lockfile.json"' "${CONFIG}")"
-        digest="$(oras manifest fetch "${artifact}:${VERSION}" \
-          | jq -er --arg title "${title}" \
-            '.layers[] | select(.annotations["org.opencontainers.image.title"] == $title) | .digest')"
+
+        # The tag names an index: the container images and the ORAS artifact are
+        # pushed together, so the layers are one level down.
+        manifest="$(oras manifest fetch "${artifact}:${VERSION}")"
+        if jq -e 'has("manifests")' >/dev/null <<<"${manifest}"; then
+          child="$(jq -r --arg type "${artifact_type}" \
+            '[.manifests[] | select(.artifactType == $type) | .digest] | first // empty' <<<"${manifest}")"
+          if [[ -z "${child}" ]]; then
+            echo "::error::${artifact}:${VERSION} is an index with no ${artifact_type} manifest in it"
+            jq . <<<"${manifest}" >&2
+            exit 1
+          fi
+          manifest="$(oras manifest fetch "${artifact}@${child}")"
+        fi
+
+        digest="$(jq -r --arg title "${title}" \
+          '[.layers[] | select(.annotations["org.opencontainers.image.title"] == $title) | .digest] | first // empty' <<<"${manifest}")"
+        if [[ -z "${digest}" ]]; then
+          echo "::error::${artifact}:${VERSION} has no layer titled ${title}"
+          jq . <<<"${manifest}" >&2
+          exit 1
+        fi
+
         mkdir -p prerelease
         oras blob fetch "${artifact}@${digest}" --output prerelease/prebuilt_lockfile.json
         jq . prerelease/prebuilt_lockfile.json
@@ -167,6 +190,7 @@ jobs:
         git \
           -c user.name='github-actions[bot]' \
           -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+          -c commit.gpgsign=false \
           commit -q -m "publish ${GITHUB_REPOSITORY##*/} ${VERSION}" \
           -m "Built from ${GITHUB_SHA}."
         # Concurrent runs on main are serialized by this workflow's concurrency

--- a/docs/pre-releases.md
+++ b/docs/pre-releases.md
@@ -61,7 +61,10 @@ be replaced if the build that produced it is re-run.
    platform, plus a `prebuilt_lockfile.json` layer naming those layers by digest
    (`//services/img` in `modules/rules_img_services`).
 2. The `publish-dev-registry` job then fetches that lockfile back out of the
-   artifact with the ORAS CLI, and builds the module's source archive with
+   artifact with the ORAS CLI — the tag names an index holding both the container
+   images and the artifact, so it descends into the manifest whose `artifactType`
+   matches before looking for the layer — and builds the module's source archive
+   with
    `--//img/private/release:prebuilt_lockfile_override=//:prebuilt_lockfile.json`
    — the empty lockfile the source tree carries, so the archive is *not* specific
    to the commit.
@@ -105,6 +108,7 @@ The pipeline is driven by `.github/dev-registry.json`:
 | `asset_base_url` | Optional. Where the source archives are served from; defaults to `<registry_url>/assets`. |
 | `metadata_template` | Optional. BCR-style `metadata.json` seeding a module's homepage and maintainers on first publish. Relative to this file. |
 | `artifact.registry`, `artifact.repository` | The ORAS artifact holding the tool binaries. Must agree with what the push job publishes and with the `registry`/`repository` recorded in the lockfile -- the publisher refuses to publish a lockfile that points somewhere else. |
+| `artifact.artifact_type` | `artifactType` of the artifact manifest. The tag it is pushed under names an index that also holds the container images, so this is how the workflow picks the artifact out of it. |
 | `artifact.lockfile_title` | Layer title of the lockfile inside the artifact, and the path it is overlaid at in the module. Defaults to `prebuilt_lockfile.json`. |
 
 Serving the branch is a one-time repository setting: enable GitHub Pages for the

--- a/modules/rules_img_internal_tools/release/devregistry/config.go
+++ b/modules/rules_img_internal_tools/release/devregistry/config.go
@@ -37,8 +37,12 @@ type Config struct {
 // Artifact is the location of the ORAS artifact holding the tool binaries and
 // the lockfile that names them.
 type Artifact struct {
-	Registry      string `json:"registry"`
-	Repository    string `json:"repository"`
+	Registry   string `json:"registry"`
+	Repository string `json:"repository"`
+	// ArtifactType identifies the artifact manifest among the images published
+	// under the same tag. Only the workflow needs it, to find the artifact inside
+	// the index before pulling the lockfile out of it.
+	ArtifactType  string `json:"artifact_type,omitempty"`
 	LockfileTitle string `json:"lockfile_title,omitempty"`
 }
 


### PR DESCRIPTION
The first pre-release publish failed fetching the lockfile out of the ORAS artifact ([run](https://github.com/bazel-contrib/rules_img/actions/runs/31491297270/job/93779510446)): the tag it is pushed under names an index holding the container images *and* the artifact, so the manifest at that tag has no layers to select from, and `jq` gave up on a null.

Descend into the child manifest whose `artifactType` matches before looking for the lockfile layer, and say which layer or manifest was missing when it is not there. The `artifactType` is a field of the channel config, next to the repository it identifies a manifest in.

Two things this had no business getting right by luck, found while rehearsing the rest of the job against the artifact of the failed run: committing on a machine that signs commits by default (a self-hosted runner) would fail, and the BuildBuddy bazelrc followed the pattern for a job that builds a module under `modules/` rather than the one for a job building the root workspace.
