### PR TITLE
fix(release): store the source archive under its extension

### DIFF
--- a/docs/pre-releases.md
+++ b/docs/pre-releases.md
@@ -82,7 +82,7 @@ modules/rules_img/<version>/MODULE.bazel            what Bazel resolves against
 modules/rules_img/<version>/source.json             archive URL, integrity, overlay, patches
 modules/rules_img/<version>/overlay/                the prebuilt lockfile for this commit
 modules/rules_img/<version>/patches/                sets the version in the archive's MODULE.bazel
-assets/sha256/<digest>/file                         the module source, addressed by content
+assets/sha256/<digest>/file.tar.gz                  the module source, addressed by content
 ```
 
 Archives are stored by content, and the one thing that differs between two
@@ -90,8 +90,13 @@ commits with identical sources — the lockfile, which names blobs by digest —
 published as an [overlay](https://bazel.build/external/registry) rather than
 packaged into the archive. So a commit that does not touch the module's sources
 adds a few kilobytes of metadata and reuses the archive that is already there,
-instead of another copy of it. (Since the stored file is named after its digest
-and has no extension, `source.json` states `archive_type` for Bazel.)
+instead of another copy of it.
+
+The stored file keeps its `.tar.gz` extension even though it is addressed by
+digest: GitHub Pages serves a file it cannot type as `application/octet-stream`
+and gzips *that* on the wire, so the bytes arriving would no longer match the
+checksum. Named with its extension it is served as `application/gzip` and passed
+through untouched.
 
 Only module source is stored here; the tool binaries live in the container
 registry, and are not copied into the assets.

--- a/modules/rules_img_internal_tools/release/devregistry/devregistry.go
+++ b/modules/rules_img_internal_tools/release/devregistry/devregistry.go
@@ -142,7 +142,9 @@ func publish(cfg *Config, writer *registryWriter, publishVersion, archivePath, l
 		return fmt.Errorf("writing overlay %s: %w", lockfileName, err)
 	}
 
-	assetPath, integrity, reused, err := writer.storeAsset(archivePath)
+	// Stored under its extension, so that a static site host serves it as an
+	// archive rather than as something it feels free to compress on the wire.
+	assetPath, integrity, reused, err := writer.storeAsset(archivePath, assetFileStem+"."+archiveType)
 	if err != nil {
 		return fmt.Errorf("storing source archive: %w", err)
 	}

--- a/modules/rules_img_internal_tools/release/devregistry/devregistry_test.go
+++ b/modules/rules_img_internal_tools/release/devregistry/devregistry_test.go
@@ -259,7 +259,9 @@ func TestPublish(t *testing.T) {
 		t.Errorf("source.json integrity = %q, but the asset hashes to %q", source.Integrity, got)
 	}
 	digest := sha256.Sum256(asset)
-	if want := "sha256/" + hex.EncodeToString(digest[:]) + "/file"; assetURL != want {
+	// The extension is load bearing: a static site host that cannot type the file
+	// compresses it on the wire, and the bytes stop matching the checksum.
+	if want := "sha256/" + hex.EncodeToString(digest[:]) + "/file.tar.gz"; assetURL != want {
 		t.Errorf("archive stored at %q, want the content addressed %q", assetURL, want)
 	}
 	if source.ArchiveType != "tar.gz" {
@@ -481,7 +483,7 @@ func TestPublishStoresArchivesByContent(t *testing.T) {
 		if err := json.Unmarshal(content, &source); err != nil {
 			t.Fatal(err)
 		}
-		if !strings.HasSuffix(source.URL, "/file") {
+		if !strings.HasSuffix(source.URL, "/file.tar.gz") {
 			t.Errorf("%s: url = %q, want a content addressed path", version, source.URL)
 		}
 		urls[version] = source.URL

--- a/modules/rules_img_internal_tools/release/devregistry/registry.go
+++ b/modules/rules_img_internal_tools/release/devregistry/registry.go
@@ -27,11 +27,17 @@ const (
 	// drop paths it considers special.
 	noJekyll = ".nojekyll"
 
-	// Assets are content addressed, under assets/sha256/<digest>/<assetFileName>.
-	// The name carries no version or extension, so source.json states the archive
-	// type instead of leaving Bazel to infer it from the URL.
+	// Assets are content addressed, under
+	// assets/sha256/<digest>/<assetFileStem>.<archive type>.
+	//
+	// The extension is not decoration: GitHub Pages serves a file it cannot type
+	// as application/octet-stream and gzips *that* on the wire for any client
+	// offering gzip -- which is every Bazel -- so the bytes arriving are a gzip of
+	// the archive and no longer match the checksum the registry recorded. Named
+	// with its extension, the same file is served as application/gzip and passed
+	// through untouched.
 	assetsDir     = "assets"
-	assetFileName = "file"
+	assetFileStem = "file"
 	overlayDir    = "overlay"
 )
 
@@ -91,14 +97,14 @@ func sriOf(content []byte) string {
 	return "sha256-" + base64.StdEncoding.EncodeToString(digest[:])
 }
 
-// storeAsset adds a file to the registry's content addressed assets, and returns
-// where it landed relative to the registry root, its Subresource Integrity, and
-// whether it was already there.
+// storeAsset adds a file to the registry's content addressed assets under
+// fileName, and returns where it landed relative to the registry root, its
+// Subresource Integrity, and whether it was already there.
 //
 // Addressing assets by content rather than by version is what keeps the registry
 // from growing a copy of the same archive per commit: only commits that change
 // the module's sources produce an archive that is not already stored.
-func (w *registryWriter) storeAsset(srcPath string) (relPath, integrity string, reused bool, err error) {
+func (w *registryWriter) storeAsset(srcPath, fileName string) (relPath, integrity string, reused bool, err error) {
 	source, err := os.Open(srcPath)
 	if err != nil {
 		return "", "", false, err
@@ -110,7 +116,7 @@ func (w *registryWriter) storeAsset(srcPath string) (relPath, integrity string, 
 		return "", "", false, err
 	}
 	digest := hash.Sum(nil)
-	relPath = filepath.Join(assetsDir, "sha256", hex.EncodeToString(digest), assetFileName)
+	relPath = filepath.Join(assetsDir, "sha256", hex.EncodeToString(digest), fileName)
 	integrity = "sha256-" + base64.StdEncoding.EncodeToString(digest)
 	if w.exists(relPath) {
 		return relPath, integrity, true, nil


### PR DESCRIPTION
The first pre-release a consumer tried failed its checksum:

```
Checksum was sha256-bVCHfrSLeD2KF2BQuff+nugqCHl1pO0nCexJFWXmQpQ=
     but wanted sha256-sJ2GvYFFuRhnIJZSUiU7vt7Byfy6cNlGZZnR3GtgrXw=
```

The bytes on the branch were right. GitHub Pages cannot type a file named after nothing but its digest, serves it as `application/octet-stream`, and gzips *that* on the wire for any client offering gzip — which is every Bazel. What arrives is a gzip of the archive, and since `source.json` declares the payload already compressed, Bazel hands the encoded bytes straight to the checksum. The digest it reported is exactly the double-gzipped body.

Keep the extension on the stored file, so assets live at `assets/sha256/<digest>/file.tar.gz`. The same file is then served as `application/gzip` and passed through untouched, which is measurable: with an extension the body is byte for byte the same whether or not the client offers gzip.
