### PR TITLE
feat(deploy): cache and deduplicate blobs read from the remote cache

### DIFF
--- a/docs/push-strategies.md
+++ b/docs/push-strategies.md
@@ -112,15 +112,60 @@ bazel run //your:push_target
 ```
 
 When `IMG_DISK_CACHE` is set, rules_img reads blobs directly from the local Bazel
-disk cache before falling back to the remote CAS. This can speed up pushes on
+disk cache before falling back to the remote CAS, and blobs it fetches from the
+remote CAS are written back into that directory (see
+[Local blob cache](#local-blob-cache) below). This can speed up pushes on
 developer machines that have a warm disk cache.
 
-> **Note:** In most setups this has little practical effect:
+> **Note:** As an additional *source*, this has little effect in most setups:
 > - With **Build without the Bytes** (BwoB) enabled, Bazel does not download action
 >   outputs to the disk cache, so the cache will be mostly empty for recently-built
->   layers.
+>   layers. Blobs that rules_img itself fetched are there, though.
 > - If you are **not using lazy push** (for example, with the eager strategy), all
 >   blobs are already materialized as runfiles and the disk cache is never consulted.
+
+### Local blob cache
+
+Every blob `img deploy` reads from the remote CAS goes through a local cache. It
+does two things:
+
+- **Deduplicates reads.** Concurrent readers of one blob — the same layer pushed to
+  several registries, or a compact layer's input file referenced by several layers —
+  share a single download. A reader that arrives while a download is in flight
+  streams the bytes as they arrive instead of starting a second one.
+- **Keeps blobs on disk**, in Bazel's disk cache layout (`cas/<xx>/<digest>`), so a
+  later push — including a later `bazel run`, and Bazel itself when the directory is
+  its disk cache — reads them locally instead of from the remote CAS.
+
+By default the cache lives in a `rules_img` directory inside the user cache
+directory (`$XDG_CACHE_HOME` or `~/.cache` on Linux, `~/Library/Caches` on macOS,
+`%LocalAppData%` on Windows) and is capped at 10 GiB, evicting the least recently
+used blobs beyond that. Setting `IMG_DISK_CACHE` moves it into Bazel's disk cache,
+which shares the blobs with Bazel.
+
+Local caching never changes the outcome of a deploy: if the directory cannot be
+written, fills up, or is unavailable, the affected read falls back to streaming
+straight from the remote CAS.
+
+| Variable | Effect |
+|----------|--------|
+| `IMG_CAS_CACHE` | Set to `0`, `false`, `off` or `no` to disable local caching (and read deduplication) entirely |
+| `IMG_CAS_CACHE_DIR` | Cache directory, overriding both the default and `IMG_DISK_CACHE` |
+| `IMG_CAS_CACHE_MAX_SIZE` | Maximum cached bytes, e.g. `20GiB`. `0` means unlimited |
+| `IMG_CAS_CACHE_BUFFER_SIZE` | How much of a blob is written to disk before readers can consume it (default `1MiB`) |
+
+A size limit means rules_img manages that directory: it indexes what is already
+there on startup and prunes it. A directory you name — your own, or Bazel's disk
+cache — has no limit by default, so rules_img only ever adds to it and leaves
+pruning to Bazel's own disk cache garbage collection. It does evict blobs it wrote
+itself if the file system runs out of space.
+
+`img deploy` reports what the cache did after each deploy:
+
+```
+    blob transfers: 3 from disk, 0 from disk cache, 0 from container registry, 5 from remote cache, 0 from compact stream
+    remote cache blobs: 2 from local cache (48.1 MiB), 3 fetched (210.4 MiB), 1 deduplicated, 0 evicted
+```
 
 ## CAS Registry Push
 
@@ -528,8 +573,8 @@ changing it on the Bazel side breaks the mapping.
 
 The same requirement applies to the other blob sources that are addressed by
 digest:
-- the local Bazel disk cache (`IMG_DISK_CACHE`), which is looked up as
-  `cas/<sha256>`, and
+- the [local blob cache](#local-blob-cache) and the local Bazel disk cache
+  (`IMG_DISK_CACHE`), which are looked up as `cas/<sha256>`, and
 - the CAS references inside [compact layers](compact-stream.md): during a lazy
   push the layer's input files are fetched from the disk / remote cache by their
   content digest.

--- a/img_tool/cmd/deploy/BUILD.bazel
+++ b/img_tool/cmd/deploy/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
 go_test(
     name = "deploy_test",
     srcs = [
+        "casblobcache_test.go",
         "progress_test.go",
         "sign_sink_test.go",
         "sink_test.go",
@@ -46,6 +47,7 @@ go_test(
     embed = [":deploy"],
     deps = [
         "//pkg/api",
+        "//pkg/cas",
         "//pkg/deployvfs",
         "//pkg/ocilayout",
         "//pkg/progress",

--- a/img_tool/cmd/deploy/casblobcache_test.go
+++ b/img_tool/cmd/deploy/casblobcache_test.go
@@ -1,0 +1,179 @@
+package deploy
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/cas"
+)
+
+// clearCASCacheEnv unsets every variable configuring the local blob cache, so a
+// test starts from the defaults regardless of the developer's environment.
+func clearCASCacheEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{envCASCache, envCASCacheDir, envCASCacheMaxSize, envCASCacheBufferSize, "IMG_DISK_CACHE"} {
+		t.Setenv(name, "")
+	}
+}
+
+func TestCASCacheConfigDefaults(t *testing.T) {
+	clearCASCacheEnv(t)
+	config := casCacheConfigFromEnv()
+	if !config.enabled {
+		t.Fatal("the local blob cache should be on by default")
+	}
+	if config.dir != "" {
+		t.Errorf("dir = %q, want the cache's own default", config.dir)
+	}
+	// Nothing else manages the default directory, so it must be bounded.
+	if config.maxSize != cas.DefaultCacheMaxSize {
+		t.Errorf("maxSize = %d, want %d", config.maxSize, cas.DefaultCacheMaxSize)
+	}
+	if config.bufferSize != cas.DefaultCacheBufferSize {
+		t.Errorf("bufferSize = %d, want %d", config.bufferSize, cas.DefaultCacheBufferSize)
+	}
+}
+
+func TestCASCacheConfigDisabled(t *testing.T) {
+	for _, value := range []string{"0", "false", "off", "no", "OFF", " false "} {
+		t.Run(value, func(t *testing.T) {
+			clearCASCacheEnv(t)
+			t.Setenv(envCASCache, value)
+			if config := casCacheConfigFromEnv(); config.enabled {
+				t.Errorf("%s=%q should disable the local blob cache", envCASCache, value)
+			}
+		})
+	}
+	for _, value := range []string{"", "1", "true", "on"} {
+		t.Run("enabled/"+value, func(t *testing.T) {
+			clearCASCacheEnv(t)
+			t.Setenv(envCASCache, value)
+			if config := casCacheConfigFromEnv(); !config.enabled {
+				t.Errorf("%s=%q should leave the local blob cache on", envCASCache, value)
+			}
+		})
+	}
+}
+
+func TestCASCacheConfigSharesBazelDiskCache(t *testing.T) {
+	clearCASCacheEnv(t)
+	diskCache := filepath.FromSlash("/bazel/disk/cache")
+	t.Setenv("IMG_DISK_CACHE", diskCache)
+
+	config := casCacheConfigFromEnv()
+	if config.dir != diskCache {
+		t.Errorf("dir = %q, want Bazel's disk cache %q", config.dir, diskCache)
+	}
+	// Bazel's disk cache GC owns that directory's size; we don't prune it.
+	if config.maxSize != 0 {
+		t.Errorf("maxSize = %d, want no limit for a directory the user manages", config.maxSize)
+	}
+}
+
+func TestCASCacheConfigExplicitDirWins(t *testing.T) {
+	clearCASCacheEnv(t)
+	t.Setenv("IMG_DISK_CACHE", filepath.FromSlash("/bazel/disk/cache"))
+	explicit := filepath.FromSlash("/blob/cache")
+	t.Setenv(envCASCacheDir, explicit)
+
+	if config := casCacheConfigFromEnv(); config.dir != explicit {
+		t.Errorf("dir = %q, want %q", config.dir, explicit)
+	}
+}
+
+func TestCASCacheConfigSizeOverrides(t *testing.T) {
+	clearCASCacheEnv(t)
+	t.Setenv(envCASCacheMaxSize, "2GiB")
+	t.Setenv(envCASCacheBufferSize, "256KiB")
+
+	config := casCacheConfigFromEnv()
+	if config.maxSize != 2<<30 {
+		t.Errorf("maxSize = %d, want %d", config.maxSize, 2<<30)
+	}
+	if config.bufferSize != 256<<10 {
+		t.Errorf("bufferSize = %d, want %d", config.bufferSize, 256<<10)
+	}
+
+	// An explicit limit also applies to a directory that would otherwise be left
+	// alone.
+	clearCASCacheEnv(t)
+	t.Setenv("IMG_DISK_CACHE", filepath.FromSlash("/bazel/disk/cache"))
+	t.Setenv(envCASCacheMaxSize, "1024")
+	if config := casCacheConfigFromEnv(); config.maxSize != 1024 {
+		t.Errorf("maxSize = %d, want 1024", config.maxSize)
+	}
+}
+
+func TestCASCacheConfigInvalidSizeFallsBackToDefault(t *testing.T) {
+	clearCASCacheEnv(t)
+	t.Setenv(envCASCacheMaxSize, "lots")
+	t.Setenv(envCASCacheBufferSize, "-1MiB")
+
+	config := casCacheConfigFromEnv()
+	if config.maxSize != cas.DefaultCacheMaxSize {
+		t.Errorf("maxSize = %d, want the default %d", config.maxSize, cas.DefaultCacheMaxSize)
+	}
+	if config.bufferSize != cas.DefaultCacheBufferSize {
+		t.Errorf("bufferSize = %d, want the default %d", config.bufferSize, cas.DefaultCacheBufferSize)
+	}
+}
+
+func TestParseByteSize(t *testing.T) {
+	tests := []struct {
+		raw     string
+		want    int64
+		wantErr bool
+	}{
+		{raw: "0", want: 0},
+		{raw: "1024", want: 1024},
+		{raw: "  4096  ", want: 4096},
+		{raw: "1K", want: 1 << 10},
+		{raw: "1kb", want: 1 << 10},
+		{raw: "1KiB", want: 1 << 10},
+		{raw: "10MiB", want: 10 << 20},
+		{raw: "10 MB", want: 10 << 20},
+		{raw: "2GiB", want: 2 << 30},
+		{raw: "1.5GiB", want: 1610612736},
+		{raw: "1TiB", want: 1 << 40},
+		{raw: "512B", want: 512},
+		{raw: "", wantErr: true},
+		{raw: "lots", wantErr: true},
+		{raw: "-1MiB", wantErr: true},
+		{raw: "1EiB", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.raw, func(t *testing.T) {
+			got, err := parseByteSize(test.raw)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("parseByteSize(%q) = %d, want an error", test.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseByteSize(%q): %v", test.raw, err)
+			}
+			if got != test.want {
+				t.Errorf("parseByteSize(%q) = %d, want %d", test.raw, got, test.want)
+			}
+		})
+	}
+}
+
+func TestHumanizeBytes(t *testing.T) {
+	tests := map[int64]string{
+		0:          "0 B",
+		512:        "512 B",
+		1024:       "1.0 KiB",
+		1536:       "1.5 KiB",
+		10 << 20:   "10.0 MiB",
+		3 << 30:    "3.0 GiB",
+		5 << 40:    "5.0 TiB",
+		2048 << 40: "2.0 PiB",
+	}
+	for size, want := range tests {
+		if got := humanizeBytes(size); got != want {
+			t.Errorf("humanizeBytes(%d) = %q, want %q", size, got, want)
+		}
+	}
+}

--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -263,9 +263,12 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 			break
 		}
 	}
-	vfsBuilder, err = configureBuilderFromEnv(vfsBuilder, hasLazyStrategy, opts.Jobs)
+	vfsBuilder, blobCache, err := configureBuilderFromEnv(vfsBuilder, hasLazyStrategy, opts.Jobs)
 	if err != nil {
 		return err
+	}
+	if blobCache != nil {
+		defer blobCache.Close()
 	}
 	if opts.RunfilesRootSymlinksPrefix != "" {
 		vfsBuilder = vfsBuilder.WithRunfilesRootSymlinksPrefix(opts.RunfilesRootSymlinksPrefix)
@@ -317,7 +320,7 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 	// performs no registry/daemon network I/O for the destination (source blobs
 	// are still resolved from the VFS as usual).
 	if opts.Sink != "" {
-		return deployToSink(ctx, opts.Sink, vfs, pushOperations, loadOperations, registryTagOperations, req.Settings, opts)
+		return deployToSink(ctx, opts.Sink, vfs, blobCache, pushOperations, loadOperations, registryTagOperations, req.Settings, opts)
 	}
 
 	if len(pushOperations) == 0 && len(loadOperations) == 0 && len(registryTagOperations) == 0 {
@@ -424,9 +427,7 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 		return fmt.Errorf("deploying images: %w", err)
 	}
 
-	// Print VFS statistics to stderr
-	stats := vfs.Stats()
-	fmt.Fprintf(os.Stderr, "    blob transfers: %d from disk, %d from disk cache, %d from container registry, %d from remote cache, %d from compact stream\n", stats.BlobsFromLocalDisk.Load(), stats.BlobsFromDiskCache.Load(), stats.BlobsFromRegistry.Load(), stats.BlobsFromRemoteCache.Load(), stats.BlobsFromCompactStream.Load())
+	printBlobStats(vfs, blobCache)
 
 	// Print all pushed tags to stdout, one per line.
 	for _, tag := range pushedTags {
@@ -593,6 +594,43 @@ func preUploadStagingBlobs(ctx context.Context, vfs *deployvfs.VFS, ops []api.In
 	return g.Wait()
 }
 
+// printBlobStats reports where the deployed blobs came from, and how the local
+// CAS blob cache did, on stderr.
+func printBlobStats(vfs *deployvfs.VFS, blobCache *cas.CachingReader) {
+	stats := vfs.Stats()
+	fmt.Fprintf(os.Stderr, "    blob transfers: %d from disk, %d from disk cache, %d from container registry, %d from remote cache, %d from compact stream\n", stats.BlobsFromLocalDisk.Load(), stats.BlobsFromDiskCache.Load(), stats.BlobsFromRegistry.Load(), stats.BlobsFromRemoteCache.Load(), stats.BlobsFromCompactStream.Load())
+	if blobCache == nil {
+		return
+	}
+	cacheStats := blobCache.Stats()
+	if cacheStats.Hits == 0 && cacheStats.Fetches == 0 && cacheStats.Fallbacks == 0 {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "    remote cache blobs: %d from local cache (%s), %d fetched (%s), %d deduplicated, %d evicted\n",
+		cacheStats.Hits, humanizeBytes(cacheStats.BytesFromCache),
+		cacheStats.Fetches, humanizeBytes(cacheStats.BytesFetched),
+		cacheStats.Deduped, cacheStats.Evicted)
+	if cacheStats.DiskDisabled {
+		fmt.Fprintf(os.Stderr, "    remote cache blobs: local caching was disabled (see the warning above)\n")
+	}
+}
+
+// humanizeBytes renders a byte count with a binary unit.
+func humanizeBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	value := float64(n)
+	for _, suffix := range []string{"KiB", "MiB", "GiB", "TiB"} {
+		value /= unit
+		if value < unit {
+			return fmt.Sprintf("%.1f %s", value, suffix)
+		}
+	}
+	return fmt.Sprintf("%.1f PiB", value/unit)
+}
+
 // stringSliceFlag implements flag.Value for collecting multiple string values
 type stringSliceFlag []string
 
@@ -633,39 +671,170 @@ func credentialHelperInstance() credential.Helper {
 	return credential.NopHelper()
 }
 
-func configureBuilderFromEnv(builder *deployvfs.Builder, needsCAS bool, jobs int) (*deployvfs.Builder, error) {
+// configureBuilderFromEnv points the VFS builder at the blob sources described
+// by the environment: the Bazel disk cache and, when needed, the remote CAS.
+//
+// CAS reads go through a local blob cache (see casBlobCacheFromEnv), which is
+// returned so the caller can report its statistics and close it. It is nil when
+// no CAS is configured or the cache is disabled.
+func configureBuilderFromEnv(builder *deployvfs.Builder, needsCAS bool, jobs int) (*deployvfs.Builder, *cas.CachingReader, error) {
 	diskCachePath := os.Getenv("IMG_DISK_CACHE")
 	if diskCachePath != "" {
 		builder = builder.WithDiskCache(diskCachePath)
 	}
 
-	if needsCAS {
-		reapiEndpoint := os.Getenv("IMG_REAPI_ENDPOINT")
-		if reapiEndpoint != "" {
-			reapiInstanceName := os.Getenv("IMG_REAPI_INSTANCE_NAME")
-			credHelper := credentialHelperInstance()
-			// A single gRPC connection multiplexes all CAS reads onto one TCP
-			// connection, which bottlenecks bulk downloads on high-latency
-			// links. Optionally open a pool of connections and round-robin
-			// reads across them (cf. Bazel's --remote_max_connections).
-			numConns := reapiMaxConnections(jobs)
-			members := make([]*cas.CAS, 0, numConns)
-			for range numConns {
-				grpcConn, err := protohelper.Client(reapiEndpoint, credHelper)
-				if err != nil {
-					return nil, fmt.Errorf("creating gRPC client for REAPI: %w", err)
-				}
-				member, err := cas.New(grpcConn, cas.WithInstanceName(reapiInstanceName))
-				if err != nil {
-					return nil, fmt.Errorf("creating CAS client: %w", err)
-				}
-				members = append(members, member)
-			}
-			builder = builder.WithCASReader(cas.NewPool(members))
-		}
+	if !needsCAS {
+		return builder, nil, nil
+	}
+	reapiEndpoint := os.Getenv("IMG_REAPI_ENDPOINT")
+	if reapiEndpoint == "" {
+		return builder, nil, nil
 	}
 
-	return builder, nil
+	reapiInstanceName := os.Getenv("IMG_REAPI_INSTANCE_NAME")
+	credHelper := credentialHelperInstance()
+	// A single gRPC connection multiplexes all CAS reads onto one TCP
+	// connection, which bottlenecks bulk downloads on high-latency
+	// links. Optionally open a pool of connections and round-robin
+	// reads across them (cf. Bazel's --remote_max_connections).
+	numConns := reapiMaxConnections(jobs)
+	members := make([]*cas.CAS, 0, numConns)
+	for range numConns {
+		grpcConn, err := protohelper.Client(reapiEndpoint, credHelper)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating gRPC client for REAPI: %w", err)
+		}
+		member, err := cas.New(grpcConn, cas.WithInstanceName(reapiInstanceName))
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating CAS client: %w", err)
+		}
+		members = append(members, member)
+	}
+	pool := cas.NewPool(members)
+
+	blobCache, err := casBlobCacheFromEnv(pool)
+	if err != nil {
+		// Caching is an optimization: read straight from the remote cache instead.
+		fmt.Fprintf(os.Stderr, "WARNING: not caching remote cache blobs locally: %v\n", err)
+		return builder.WithCASReader(pool), nil, nil
+	}
+	if blobCache == nil {
+		return builder.WithCASReader(pool), nil, nil
+	}
+	return builder.WithCASReader(blobCache), blobCache, nil
+}
+
+// Environment variables configuring the local cache of blobs read from the
+// remote CAS.
+const (
+	// envCASCache turns the local blob cache off when set to 0/false/off/no.
+	envCASCache = "IMG_CAS_CACHE"
+	// envCASCacheDir overrides the cache directory. Defaults to IMG_DISK_CACHE
+	// (sharing Bazel's disk cache) and, failing that, to a directory under the
+	// user's cache directory.
+	envCASCacheDir = "IMG_CAS_CACHE_DIR"
+	// envCASCacheMaxSize limits the cached bytes, evicting the least recently
+	// used blobs beyond that. Accepts a plain byte count or a KiB/MiB/GiB suffix.
+	envCASCacheMaxSize = "IMG_CAS_CACHE_MAX_SIZE"
+	// envCASCacheBufferSize is how much of a blob is written to disk before
+	// readers can consume it.
+	envCASCacheBufferSize = "IMG_CAS_CACHE_BUFFER_SIZE"
+)
+
+// casCacheConfig is how the local cache of remote-CAS blobs is configured.
+type casCacheConfig struct {
+	enabled    bool
+	dir        string // empty: let the cache pick its default directory
+	maxSize    int64  // 0: unlimited
+	bufferSize int
+}
+
+// casCacheConfigFromEnv reads the local blob cache configuration from the
+// environment.
+func casCacheConfigFromEnv() casCacheConfig {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(envCASCache))) {
+	case "0", "false", "off", "no":
+		return casCacheConfig{}
+	}
+	config := casCacheConfig{enabled: true, bufferSize: cas.DefaultCacheBufferSize}
+
+	// A directory the user names -- their own, or Bazel's disk cache -- is theirs
+	// to manage, so it stays unlimited unless they ask for a limit. The default
+	// directory has nobody else looking after it and gets one.
+	config.dir = os.Getenv(envCASCacheDir)
+	if config.dir == "" {
+		config.dir = os.Getenv("IMG_DISK_CACHE")
+	}
+	if config.dir == "" {
+		config.maxSize = cas.DefaultCacheMaxSize
+	}
+	if size, ok := byteSizeFromEnv(envCASCacheMaxSize, config.maxSize); ok {
+		config.maxSize = size
+	}
+	if size, ok := byteSizeFromEnv(envCASCacheBufferSize, int64(config.bufferSize)); ok {
+		config.bufferSize = int(size)
+	}
+	return config
+}
+
+// casBlobCacheFromEnv wraps upstream in a local blob cache, which deduplicates
+// concurrent reads of one blob and keeps what it fetched on disk for later runs.
+// It returns nil if the cache is disabled.
+func casBlobCacheFromEnv(upstream cas.BlobSource) (*cas.CachingReader, error) {
+	config := casCacheConfigFromEnv()
+	if !config.enabled {
+		return nil, nil
+	}
+	return cas.NewCachingReader(upstream,
+		cas.WithCacheDir(config.dir),
+		cas.WithCacheMaxSize(config.maxSize),
+		cas.WithCacheBufferSize(config.bufferSize),
+	)
+}
+
+// byteSizeFromEnv reads a byte count from an environment variable, warning and
+// falling back to fallback if it cannot be parsed.
+func byteSizeFromEnv(name string, fallback int64) (int64, bool) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return 0, false
+	}
+	size, err := parseByteSize(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: ignoring invalid %s=%q: %v, using %d\n", name, raw, err, fallback)
+		return 0, false
+	}
+	return size, true
+}
+
+// parseByteSize parses a byte count, optionally with a binary unit suffix
+// (K/KB/KiB, M/MB/MiB, G/GB/GiB, T/TB/TiB, case-insensitive). Suffixes are
+// powers of 1024 either way, as everywhere else in Bazel's ecosystem.
+func parseByteSize(raw string) (int64, error) {
+	digits := strings.TrimRight(raw, "kKmMgGtTiIbB \t")
+	unit := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(raw, digits)))
+	value, err := strconv.ParseFloat(strings.TrimSpace(digits), 64)
+	if err != nil {
+		return 0, fmt.Errorf("not a byte count")
+	}
+	multiplier := int64(1)
+	switch unit {
+	case "", "b":
+	case "k", "kb", "kib":
+		multiplier = 1 << 10
+	case "m", "mb", "mib":
+		multiplier = 1 << 20
+	case "g", "gb", "gib":
+		multiplier = 1 << 30
+	case "t", "tb", "tib":
+		multiplier = 1 << 40
+	default:
+		return 0, fmt.Errorf("unknown unit %q", unit)
+	}
+	if value < 0 {
+		return 0, fmt.Errorf("negative size")
+	}
+	return int64(value * float64(multiplier)), nil
 }
 
 // reapiMaxConnections returns the size of the gRPC connection pool used to read
@@ -764,7 +933,7 @@ func applyProgressMode(value string, isPersistentWorker bool) error {
 // deployToSink builds the requested sink, routes every operation into it, and
 // prints the resulting image references. It performs no registry/daemon network
 // I/O for the destination.
-func deployToSink(ctx context.Context, spec string, vfs *deployvfs.VFS, pushOps []api.IndexedPushDeployOperation, loadOps []api.IndexedLoadDeployOperation, tagOps []api.IndexedRegistryTagDeployOperation, settings api.DeploySettings, opts DeployOptions) error {
+func deployToSink(ctx context.Context, spec string, vfs *deployvfs.VFS, blobCache *cas.CachingReader, pushOps []api.IndexedPushDeployOperation, loadOps []api.IndexedLoadDeployOperation, tagOps []api.IndexedRegistryTagDeployOperation, settings api.DeploySettings, opts DeployOptions) error {
 	kind, path, err := parseSink(spec)
 	if err != nil {
 		return err
@@ -799,8 +968,7 @@ func deployToSink(ctx context.Context, spec string, vfs *deployvfs.VFS, pushOps 
 	if err := s.Close(); err != nil {
 		return fmt.Errorf("finalizing sink: %w", err)
 	}
-	stats := vfs.Stats()
-	fmt.Fprintf(os.Stderr, "    blob transfers: %d from disk, %d from disk cache, %d from container registry, %d from remote cache, %d from compact stream\n", stats.BlobsFromLocalDisk.Load(), stats.BlobsFromDiskCache.Load(), stats.BlobsFromRegistry.Load(), stats.BlobsFromRemoteCache.Load(), stats.BlobsFromCompactStream.Load())
+	printBlobStats(vfs, blobCache)
 	for _, ref := range refs {
 		fmt.Println(ref)
 	}

--- a/img_tool/cmd/deploy/persistentworker.go
+++ b/img_tool/cmd/deploy/persistentworker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/api"
+	"github.com/bazel-contrib/rules_img/img_tool/pkg/cas"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/deployvfs"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/gateway"
 	"github.com/bazel-contrib/rules_img/img_tool/pkg/load"
@@ -29,6 +30,11 @@ type deployWorkerHandler struct {
 	jobs          int
 	baseBuilder   *deployvfs.Builder
 	pushTransport http.RoundTripper
+
+	// blobCache caches blobs read from the remote CAS for the lifetime of the
+	// worker, so requests that share a blob only fetch it once. It is nil when no
+	// remote cache is configured or the cache is disabled.
+	blobCache *cas.CachingReader
 
 	// globalSink, when set, redirects every request's operations into a shared
 	// local sink (distribution/oci) instead of a registry. It is not
@@ -60,12 +66,12 @@ func newDeployWorkerHandler(jobs int, sinkSpec string) (*deployWorkerHandler, er
 	// We set needsCAS to true unconditionally.
 	// The reason is that we just cannot know in advance whether a future work request
 	// wants to connect to the remote cache or not.
-	baseBuilder, err = configureBuilderFromEnv(baseBuilder, true /* needsCAS */, jobs)
+	baseBuilder, blobCache, err := configureBuilderFromEnv(baseBuilder, true /* needsCAS */, jobs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to configure VFS from environment: %v\n", err)
 	}
 
-	h := &deployWorkerHandler{jobs: jobs, baseBuilder: baseBuilder, pushTransport: pushTransport}
+	h := &deployWorkerHandler{jobs: jobs, baseBuilder: baseBuilder, pushTransport: pushTransport, blobCache: blobCache}
 
 	if sinkSpec != "" {
 		// A global distribution/oci sink redirects every request; no pusher is
@@ -89,6 +95,15 @@ func newDeployWorkerHandler(jobs int, sinkSpec string) (*deployWorkerHandler, er
 	}
 	h.pusher = p
 	return h, nil
+}
+
+// Close releases resources held for the lifetime of the worker. Blobs already
+// cached on disk are kept for the next run.
+func (h *deployWorkerHandler) Close() error {
+	if h.blobCache == nil {
+		return nil
+	}
+	return h.blobCache.Close()
 }
 
 func (h *deployWorkerHandler) HandleRequest(ctx context.Context, req persistentworker.WorkRequest) persistentworker.WorkResponse {
@@ -509,6 +524,7 @@ func persistentWorker(jobs int, sinkSpec string) error {
 	if err != nil {
 		return err
 	}
+	defer handler.Close()
 	worker := persistentworker.NewWorker(handler)
 	return worker.Run()
 }

--- a/img_tool/pkg/cas/BUILD.bazel
+++ b/img_tool/pkg/cas/BUILD.bazel
@@ -3,6 +3,8 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "cas",
     srcs = [
+        "cache.go",
+        "cachestore.go",
         "error.go",
         "pool.go",
         "read.go",
@@ -24,6 +26,8 @@ go_test(
     name = "cas_test",
     size = "small",
     srcs = [
+        "cache_test.go",
+        "cachestore_test.go",
         "pool_test.go",
         "read_test.go",
     ],

--- a/img_tool/pkg/cas/cache.go
+++ b/img_tool/pkg/cas/cache.go
@@ -1,0 +1,765 @@
+package cas
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// DefaultCacheBufferSize is how much of a blob is written to disk before it
+	// is published to readers.
+	DefaultCacheBufferSize = 1 << 20 // 1 MiB
+
+	// DefaultCacheMaxSize is a reasonable size limit for a cache directory that
+	// nothing else manages. It is not applied automatically: an unset limit means
+	// unlimited, which is what a directory shared with Bazel wants (Bazel's disk
+	// cache GC owns it).
+	DefaultCacheMaxSize = 10 << 30 // 10 GiB
+
+	// cacheDirName is the directory created inside the user cache directory when
+	// no cache directory is configured.
+	cacheDirName = "rules_img"
+
+	// closeWaitTimeout bounds how long Close waits for the fetch goroutines to
+	// notice its cancellation and let go of their files.
+	closeWaitTimeout = 5 * time.Second
+
+	// maxAttachAttempts bounds how often ReaderForBlob retries the
+	// cache-hit/join-a-fetch dance before it gives up and reads straight from
+	// upstream. Retries only happen when a fetch completes or is abandoned in the
+	// window between looking it up and attaching to it.
+	maxAttachAttempts = 3
+)
+
+// CachingReader is a BlobSource that deduplicates reads and caches blobs on
+// disk. It wraps another BlobSource (typically a *Pool) and adds two things:
+//
+//   - Request deduplication. Concurrent reads of one digest share a single
+//     upstream fetch; a caller arriving while a fetch is in flight attaches to it
+//     and streams the bytes as they arrive rather than opening a second read.
+//   - Local caching. Fetched blobs are written into a directory with the same
+//     layout as Bazel's disk cache (cas/<first two hex chars>/<hex>), so later
+//     reads -- in this process or a later one, and including Bazel itself when
+//     the directory is its disk cache -- are served from disk.
+//
+// Consumers do not wait for a blob to be complete: a fetch publishes what it has
+// written every time the configured buffer size fills up, and readers are woken
+// as soon as data is available.
+//
+// Local problems never fail a read. If the cache directory cannot be written,
+// runs out of space, or loses a file underneath a reader, the affected read
+// degrades to streaming straight from upstream -- blobs are immutable and
+// content-addressed, so re-reading and skipping to the reader's offset is always
+// correct. Only errors from upstream (and bad content) reach callers.
+//
+// A CachingReader is safe for concurrent use.
+type CachingReader struct {
+	upstream   BlobSource
+	store      *diskStore
+	bufferSize int
+
+	// baseCtx scopes the fetch goroutines. They must outlive the caller that
+	// started them, because other callers may be reading the same fetch; Close
+	// cancels them all.
+	baseCtx context.Context
+	cancel  context.CancelFunc
+
+	mu       sync.Mutex
+	inflight map[string]*blobFetch
+
+	// running tracks the fetch goroutines, so Close can wait for them to let go
+	// of their files before removing anything.
+	running sync.WaitGroup
+
+	counters cacheCounters
+}
+
+var _ BlobSource = (*CachingReader)(nil)
+
+type cacheCounters struct {
+	hits           atomic.Uint64
+	fetches        atomic.Uint64
+	deduped        atomic.Uint64
+	fallbacks      atomic.Uint64
+	bytesFromCache atomic.Int64
+	bytesFetched   atomic.Int64
+}
+
+// CacheStats is a snapshot of a CachingReader's counters.
+type CacheStats struct {
+	Hits           uint64 // blobs served from the cache directory
+	Fetches        uint64 // blobs fetched from upstream
+	Deduped        uint64 // reads that joined a fetch already in flight
+	Fallbacks      uint64 // reads streamed from upstream without caching
+	BytesFromCache int64
+	BytesFetched   int64
+	Evicted        uint64 // blobs removed from the cache directory
+	DiskDisabled   bool   // disk caching gave up (see diskStore.disable)
+}
+
+// CacheOption configures a CachingReader.
+type CacheOption func(*cacheOptions)
+
+type cacheOptions struct {
+	dir        string
+	maxSize    int64
+	bufferSize int
+}
+
+// WithCacheDir sets the cache directory. It is used as the root of a
+// Bazel-disk-cache layout, so passing Bazel's --disk_cache directory shares the
+// cache with Bazel. The empty default means <user cache dir>/rules_img, or a
+// temporary directory (removed by Close) if there is no user cache directory.
+func WithCacheDir(dir string) CacheOption {
+	return func(o *cacheOptions) { o.dir = dir }
+}
+
+// WithCacheMaxSize limits how many bytes of cached blobs to keep, evicting the
+// least recently used ones beyond that. Zero (the default) means unlimited: the
+// cache directory is then neither indexed at startup nor pruned, and only an
+// out-of-space error evicts anything.
+func WithCacheMaxSize(n int64) CacheOption {
+	return func(o *cacheOptions) { o.maxSize = n }
+}
+
+// WithCacheBufferSize sets how much of a blob is written to disk before it is
+// published to readers. Defaults to DefaultCacheBufferSize.
+func WithCacheBufferSize(n int) CacheOption {
+	return func(o *cacheOptions) { o.bufferSize = n }
+}
+
+// NewCachingReader returns a CachingReader in front of upstream. It fails only
+// if the cache directory cannot be prepared; callers that treat caching as
+// optional can then fall back to using upstream directly.
+func NewCachingReader(upstream BlobSource, opts ...CacheOption) (*CachingReader, error) {
+	if upstream == nil {
+		return nil, errors.New("cas: upstream blob source is required")
+	}
+	options := cacheOptions{bufferSize: DefaultCacheBufferSize}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	if options.bufferSize <= 0 {
+		options.bufferSize = DefaultCacheBufferSize
+	}
+
+	dir, ephemeral, err := resolveCacheDir(options.dir)
+	if err != nil {
+		return nil, err
+	}
+	store, err := newDiskStore(dir, ephemeral, options.maxSize)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	return &CachingReader{
+		upstream:   upstream,
+		store:      store,
+		bufferSize: options.bufferSize,
+		baseCtx:    ctx,
+		cancel:     cancel,
+		inflight:   make(map[string]*blobFetch),
+	}, nil
+}
+
+// resolveCacheDir picks the cache directory, reporting whether it is a
+// temporary one that Close should remove.
+func resolveCacheDir(dir string) (string, bool, error) {
+	if dir != "" {
+		return dir, false, nil
+	}
+	if userCacheDir, err := os.UserCacheDir(); err == nil {
+		return filepath.Join(userCacheDir, cacheDirName), false, nil
+	}
+	// No user cache directory (no HOME, for example). A temporary directory still
+	// deduplicates reads within this process.
+	tempDir, err := os.MkdirTemp("", "img-cas-cache-")
+	if err != nil {
+		return "", false, fmt.Errorf("creating temporary CAS cache directory: %w", err)
+	}
+	return tempDir, true, nil
+}
+
+// Dir returns the cache directory.
+func (c *CachingReader) Dir() string {
+	return c.store.dir
+}
+
+// Stats returns a snapshot of the cache counters.
+func (c *CachingReader) Stats() CacheStats {
+	return CacheStats{
+		Hits:           c.counters.hits.Load(),
+		Fetches:        c.counters.fetches.Load(),
+		Deduped:        c.counters.deduped.Load(),
+		Fallbacks:      c.counters.fallbacks.Load(),
+		BytesFromCache: c.counters.bytesFromCache.Load(),
+		BytesFetched:   c.counters.bytesFetched.Load(),
+		Evicted:        c.store.evictions(),
+		DiskDisabled:   c.store.isDisabled(),
+	}
+}
+
+// Close cancels every fetch still in flight, waits for them to stop writing,
+// cleans up their partial files and removes the cache directory if it was a
+// temporary one. Cached blobs in a configured directory are left for the next
+// run.
+func (c *CachingReader) Close() error {
+	c.cancel()
+	// Wait for the fetch goroutines to close their files: on Windows a file with
+	// an open handle can be neither removed nor renamed. A source that ignores
+	// cancellation must not keep the process from exiting, so the wait is bounded.
+	c.waitForFetches()
+
+	c.mu.Lock()
+	fetches := make([]*blobFetch, 0, len(c.inflight))
+	for _, fetch := range c.inflight {
+		fetches = append(fetches, fetch)
+	}
+	c.inflight = make(map[string]*blobFetch)
+	c.mu.Unlock()
+
+	for _, fetch := range fetches {
+		os.Remove(fetch.tempPath)
+	}
+	return c.store.close()
+}
+
+// waitForFetches waits for the fetch goroutines to return, up to
+// closeWaitTimeout.
+func (c *CachingReader) waitForFetches() {
+	stopped := make(chan struct{})
+	go func() {
+		c.running.Wait()
+		close(stopped)
+	}()
+	timer := time.NewTimer(closeWaitTimeout)
+	defer timer.Stop()
+	select {
+	case <-stopped:
+	case <-timer.C:
+	}
+}
+
+// FindMissingBlobs answers from the cache directory where it can: a blob that is
+// cached locally is readable regardless of what upstream still has, so it is
+// neither asked about nor reported missing.
+func (c *CachingReader) FindMissingBlobs(ctx context.Context, digests []Digest) ([]Digest, error) {
+	if len(digests) == 0 {
+		return nil, nil
+	}
+	remaining := make([]Digest, 0, len(digests))
+	for _, digest := range digests {
+		if digest.SizeBytes > 0 && c.store.has(digest) {
+			continue
+		}
+		remaining = append(remaining, digest)
+	}
+	if len(remaining) == 0 {
+		return nil, nil
+	}
+	return c.upstream.FindMissingBlobs(ctx, remaining)
+}
+
+// ReadBlob returns the whole blob, going through the same cache and
+// deduplication as ReaderForBlob.
+func (c *CachingReader) ReadBlob(ctx context.Context, digest Digest) ([]byte, error) {
+	if digest.SizeBytes == 0 {
+		return c.upstream.ReadBlob(ctx, digest)
+	}
+	reader, err := c.ReaderForBlob(ctx, digest)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	buf := make([]byte, digest.SizeBytes)
+	if _, err := io.ReadFull(reader, buf); err != nil {
+		return nil, fmt.Errorf("failed to read blob: %w", err)
+	}
+	return buf, nil
+}
+
+// ReaderForBlob returns a reader for the blob, served from the cache directory
+// if it is there, otherwise from a single shared fetch of the blob that also
+// populates the cache.
+func (c *CachingReader) ReaderForBlob(ctx context.Context, digest Digest) (io.ReadCloser, error) {
+	if digest.SizeBytes == 0 {
+		return c.upstream.ReaderForBlob(ctx, digest)
+	}
+
+	for range maxAttachAttempts {
+		if file, err := c.store.open(digest); err == nil {
+			c.counters.hits.Add(1)
+			c.counters.bytesFromCache.Add(digest.SizeBytes)
+			return file, nil
+		}
+
+		fetch, joined := c.fetchFor(digest)
+		if fetch == nil {
+			break // the cache directory is unusable; read straight from upstream
+		}
+		reader, err := fetch.attach(ctx)
+		if err == nil {
+			if joined {
+				c.counters.deduped.Add(1)
+			}
+			return reader, nil
+		}
+		// The fetch completed or was abandoned between the lookup and the attach.
+		// Look again: the blob is probably in the cache directory now.
+	}
+	return c.passthrough(ctx, digest, 0)
+}
+
+// fetchFor returns the fetch for a digest, starting one if none is in flight,
+// and reports whether it joined an existing one. It returns nil if the blob
+// cannot be cached locally.
+func (c *CachingReader) fetchFor(digest Digest) (*blobFetch, bool) {
+	key := digest.cacheKey()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if fetch, ok := c.inflight[key]; ok {
+		return fetch, true
+	}
+	fetch := c.startFetch(digest, key)
+	if fetch == nil {
+		return nil, false
+	}
+	c.inflight[key] = fetch
+	return fetch, false
+}
+
+// startFetch begins fetching a blob into a temp file. c.mu must be held.
+func (c *CachingReader) startFetch(digest Digest, key string) *blobFetch {
+	file, err := c.store.createTemp(digest.SizeBytes)
+	if err != nil {
+		if !errors.Is(err, errDiskCacheDisabled) {
+			// The cache directory is not writable at all; stop trying.
+			c.store.disable(err)
+		}
+		return nil
+	}
+	ctx, cancel := context.WithCancel(c.baseCtx)
+	fetch := &blobFetch{
+		cache:    c,
+		digest:   digest,
+		key:      key,
+		tempPath: file.Name(),
+		cancel:   cancel,
+		changed:  make(chan struct{}),
+	}
+	c.counters.fetches.Add(1)
+	c.running.Add(1)
+	go fetch.run(ctx, file)
+	return fetch
+}
+
+// forget drops a fetch from the in-flight map unless it has already been
+// replaced by a newer one for the same digest.
+func (c *CachingReader) forget(key string, fetch *blobFetch) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inflight[key] == fetch {
+		delete(c.inflight, key)
+	}
+}
+
+// passthrough reads a blob straight from upstream, skipping the first off bytes.
+// It is how every local failure degrades.
+func (c *CachingReader) passthrough(ctx context.Context, digest Digest, off int64) (io.ReadCloser, error) {
+	c.counters.fallbacks.Add(1)
+	reader, err := c.upstream.ReaderForBlob(ctx, digest)
+	if err != nil {
+		return nil, err
+	}
+	if off > 0 {
+		if _, err := io.CopyN(io.Discard, reader, off); err != nil {
+			reader.Close()
+			return nil, fmt.Errorf("skipping %d bytes of blob %s: %w", off, digest.hexHash(), err)
+		}
+	}
+	return reader, nil
+}
+
+// blobFetch is one in-flight download of a blob into the cache directory, shared
+// by every reader that wants it.
+type blobFetch struct {
+	cache    *CachingReader
+	digest   Digest
+	key      string
+	tempPath string
+	cancel   context.CancelFunc
+
+	mu sync.Mutex
+	// changed is closed and replaced whenever published or the terminal state
+	// changes, so readers can wait on it while still honoring their context.
+	changed   chan struct{}
+	published int64 // bytes written to tempPath and visible to readers
+	readers   int
+	done      bool
+	err       error
+	local     bool // err is a local problem: readers should fall back to upstream
+	abandoned bool // no readers left before completion; no longer attachable
+	finalized bool
+	discarded bool
+}
+
+// fetchState is a snapshot of what a reader needs to decide what to do next.
+type fetchState struct {
+	available int64
+	done      bool
+	local     bool
+	err       error
+}
+
+func (b *blobFetch) run(ctx context.Context, file *os.File) {
+	defer b.cache.running.Done()
+	err := b.stream(ctx, file)
+	file.Close()
+	b.finish(err)
+}
+
+// stream copies the blob from upstream into file, publishing every full buffer,
+// and verifies size and content digest at the end.
+func (b *blobFetch) stream(ctx context.Context, file *os.File) error {
+	source, err := b.cache.upstream.ReaderForBlob(ctx, b.digest)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	hasher := digestHasher(b.digest)
+	// Read one byte past the expected size: enough to notice a source that sends
+	// too much, without letting it write an unbounded amount to disk.
+	limited := io.LimitReader(source, b.digest.SizeBytes+1)
+	buf := make([]byte, b.cache.bufferSize)
+	var total int64
+	for {
+		n, readErr := io.ReadFull(limited, buf)
+		if n > 0 {
+			if err := b.cache.store.writeAll(file, buf[:n]); err != nil {
+				b.cache.store.disable(err)
+				return &localCacheError{err: err}
+			}
+			if hasher != nil {
+				hasher.Write(buf[:n])
+			}
+			total += int64(n)
+			b.publish(total)
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF) {
+				break
+			}
+			return readErr
+		}
+	}
+
+	if total != b.digest.SizeBytes {
+		return fmt.Errorf("blob %s: read %d bytes from remote cache, expected %d", b.digest.hexHash(), total, b.digest.SizeBytes)
+	}
+	if hasher != nil {
+		if sum := hasher.Sum(nil); !bytes.Equal(sum, b.digest.Hash) {
+			return fmt.Errorf("blob %s: content from remote cache hashes to %x", b.digest.hexHash(), sum)
+		}
+	}
+	return nil
+}
+
+// publish makes the first total bytes of the temp file visible to readers.
+func (b *blobFetch) publish(total int64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.published = total
+	b.broadcastLocked()
+}
+
+// broadcastLocked wakes every reader waiting for a state change.
+func (b *blobFetch) broadcastLocked() {
+	close(b.changed)
+	b.changed = make(chan struct{})
+}
+
+// finish records the terminal state of the fetch and either caches the blob or
+// cleans up after it.
+func (b *blobFetch) finish(err error) {
+	var localErr *localCacheError
+	isLocal := errors.As(err, &localErr)
+	if isLocal {
+		err = localErr.err
+	}
+
+	b.mu.Lock()
+	b.done = true
+	b.err = err
+	b.local = isLocal
+	readers := b.readers
+	b.broadcastLocked()
+	b.mu.Unlock()
+
+	if err != nil {
+		// Let the next caller try again, and drop the partial file once nobody
+		// holds it open any more: readers still attached keep their handle (and,
+		// for a local failure, fall back to upstream), and on Windows a file with
+		// an open handle cannot be removed at all.
+		b.cache.forget(b.key, b)
+		if readers == 0 {
+			b.discard()
+		}
+		return
+	}
+	b.cache.counters.bytesFetched.Add(b.digest.SizeBytes)
+	if readers == 0 {
+		b.finalize()
+	}
+}
+
+// discard removes the partial file of a fetch that failed. It runs once, when
+// the fetch and every reader of it are done with the file.
+func (b *blobFetch) discard() {
+	b.mu.Lock()
+	first := !b.discarded
+	b.discarded = true
+	b.mu.Unlock()
+	if !first {
+		return
+	}
+	b.cache.store.discard(b.tempPath, b.digest.SizeBytes)
+}
+
+// attach returns a reader over the fetch's temp file. It fails if the file
+// cannot be opened or the fetch has been abandoned, which makes the caller look
+// for the blob again.
+func (b *blobFetch) attach(ctx context.Context) (io.ReadCloser, error) {
+	b.mu.Lock()
+	if b.abandoned {
+		b.mu.Unlock()
+		return nil, errors.New("cas: blob fetch abandoned")
+	}
+	b.readers++
+	b.mu.Unlock()
+
+	file, err := os.Open(b.tempPath)
+	if err != nil {
+		b.detach()
+		return nil, err
+	}
+	return &fetchReader{fetch: b, ctx: ctx, file: file}, nil
+}
+
+// detach releases a reader. The last reader to leave either publishes the blob
+// into the cache directory or, if the blob is still incomplete, cancels the
+// fetch.
+func (b *blobFetch) detach() {
+	b.mu.Lock()
+	b.readers--
+	readers, done, err := b.readers, b.done, b.err
+	// A fetch that has already written every byte is worth finishing even with
+	// nobody reading it: it only has verification left, and a reader that
+	// consumed the whole blob routinely closes before the fetch records that it
+	// is done.
+	abandon := readers <= 0 && !done && b.published < b.digest.SizeBytes
+	if abandon {
+		b.abandoned = true
+	}
+	b.mu.Unlock()
+
+	if readers > 0 {
+		return
+	}
+	if abandon {
+		// Nobody wants this blob any more. The fetch goroutine notices the
+		// cancellation and removes the temp file.
+		b.cache.forget(b.key, b)
+		b.cancel()
+		return
+	}
+	if done && err == nil {
+		b.finalize()
+		return
+	}
+	if done {
+		// The fetch failed and this was the last handle on its partial file.
+		b.discard()
+	}
+}
+
+// finalize moves the completed blob into the cache directory. A failure here
+// only costs the caching of one blob, so it is not reported.
+func (b *blobFetch) finalize() {
+	b.mu.Lock()
+	eligible := b.done && b.err == nil && b.readers == 0 && !b.finalized
+	if eligible {
+		b.finalized = true
+	}
+	b.mu.Unlock()
+	if !eligible {
+		return
+	}
+	b.cache.forget(b.key, b)
+	if err := b.cache.store.finalize(b.tempPath, b.digest); err != nil && isNoSpace(err) {
+		b.cache.store.disable(err)
+	}
+}
+
+// waitFor blocks until data past off is available or the fetch has ended,
+// honoring the reader's context.
+func (b *blobFetch) waitFor(ctx context.Context, off int64) (fetchState, error) {
+	for {
+		b.mu.Lock()
+		state := fetchState{available: b.published, done: b.done, local: b.local, err: b.err}
+		changed := b.changed
+		b.mu.Unlock()
+
+		if state.available > off || state.done {
+			return state, nil
+		}
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			return fetchState{}, ctx.Err()
+		}
+	}
+}
+
+// fetchReader streams one blob from a shared fetch, reading the temp file as it
+// grows and falling back to upstream if the local copy fails.
+type fetchReader struct {
+	fetch *blobFetch
+	ctx   context.Context
+
+	file        *os.File
+	passthrough io.ReadCloser
+	off         int64
+	detached    bool
+	closed      bool
+}
+
+func (r *fetchReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	for {
+		if r.passthrough != nil {
+			n, err := r.passthrough.Read(p)
+			r.off += int64(n)
+			return n, err
+		}
+
+		state, err := r.fetch.waitFor(r.ctx, r.off)
+		if err != nil {
+			return 0, err
+		}
+		if state.available > r.off {
+			limit := min(int64(len(p)), state.available-r.off)
+			n, readErr := r.file.Read(p[:limit])
+			r.off += int64(n)
+			if n > 0 {
+				return n, nil
+			}
+			// Published bytes must be readable; if they are not, the local file is
+			// broken and upstream is the only way forward.
+			if fallbackErr := r.startPassthrough(); fallbackErr != nil {
+				return 0, fmt.Errorf("reading cached blob %s: %w", r.fetch.digest.hexHash(), errors.Join(readErr, fallbackErr))
+			}
+			continue
+		}
+		// The fetch has ended.
+		if state.err == nil {
+			return 0, io.EOF
+		}
+		if !state.local {
+			return 0, state.err
+		}
+		if fallbackErr := r.startPassthrough(); fallbackErr != nil {
+			return 0, errors.Join(state.err, fallbackErr)
+		}
+	}
+}
+
+// startPassthrough switches this reader over to a fresh upstream read, skipping
+// the bytes it already delivered.
+func (r *fetchReader) startPassthrough() error {
+	reader, err := r.fetch.cache.passthrough(r.ctx, r.fetch.digest, r.off)
+	if err != nil {
+		return err
+	}
+	if r.file != nil {
+		r.file.Close()
+		r.file = nil
+	}
+	r.passthrough = reader
+	// This reader no longer depends on the fetch.
+	if !r.detached {
+		r.detached = true
+		r.fetch.detach()
+	}
+	return nil
+}
+
+func (r *fetchReader) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+
+	var errs []error
+	if r.file != nil {
+		errs = append(errs, r.file.Close())
+		r.file = nil
+	}
+	if r.passthrough != nil {
+		errs = append(errs, r.passthrough.Close())
+		r.passthrough = nil
+	}
+	if !r.detached {
+		r.detached = true
+		r.fetch.detach()
+	}
+	return errors.Join(errs...)
+}
+
+// localCacheError marks an error as a local cache failure, which readers
+// recover from by reading straight from upstream.
+type localCacheError struct {
+	err error
+}
+
+func (e *localCacheError) Error() string { return e.err.Error() }
+func (e *localCacheError) Unwrap() error { return e.err }
+
+// digestHasher returns a hasher for the digest's algorithm, or nil if we cannot
+// verify content for it.
+func digestHasher(digest Digest) hash.Hash {
+	switch digest.algorithm {
+	case "sha256":
+		return sha256.New()
+	case "sha512":
+		return sha512.New()
+	}
+	return nil
+}
+
+// hexHash returns the digest's hash in hex, which is also its file name in the
+// cache directory.
+func (d Digest) hexHash() string {
+	return hex.EncodeToString(d.Hash)
+}
+
+// cacheKey identifies a blob for in-flight deduplication.
+func (d Digest) cacheKey() string {
+	return d.algorithm + ":" + d.hexHash()
+}

--- a/img_tool/pkg/cas/cache_test.go
+++ b/img_tool/pkg/cas/cache_test.go
@@ -1,0 +1,750 @@
+package cas
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// fakeBlobs is a BlobSource serving blobs from memory. It counts reads per
+// digest and can be told to deliver in fixed-size chunks and to block partway
+// through a blob until the test lets it continue.
+type fakeBlobs struct {
+	// Configured before use and then only read.
+	chunk     int           // bytes per Read call (0: as much as fits)
+	gate      chan struct{} // if non-nil, block once gateAfter bytes were served
+	gateAfter int
+	openErr   error // returned by ReaderForBlob instead of a reader
+
+	mu        sync.Mutex
+	data      map[string][]byte // hex digest -> served content
+	reads     map[string]int
+	findCalls [][]Digest
+}
+
+func newFakeBlobs(blobs ...[]byte) *fakeBlobs {
+	f := &fakeBlobs{data: make(map[string][]byte), reads: make(map[string]int)}
+	for _, blob := range blobs {
+		f.data[blobDigest(blob).hexHash()] = blob
+	}
+	return f
+}
+
+// serveInstead makes the source answer reads for digest with other content,
+// simulating a corrupt or truncated remote blob.
+func (f *fakeBlobs) serveInstead(digest Digest, content []byte) {
+	f.data[digest.hexHash()] = content
+}
+
+func (f *fakeBlobs) FindMissingBlobs(_ context.Context, digests []Digest) ([]Digest, error) {
+	f.mu.Lock()
+	f.findCalls = append(f.findCalls, slices.Clone(digests))
+	f.mu.Unlock()
+
+	var missing []Digest
+	for _, digest := range digests {
+		f.mu.Lock()
+		_, found := f.data[digest.hexHash()]
+		f.mu.Unlock()
+		if !found {
+			missing = append(missing, digest)
+		}
+	}
+	return missing, nil
+}
+
+func (f *fakeBlobs) ReadBlob(ctx context.Context, digest Digest) ([]byte, error) {
+	reader, err := f.ReaderForBlob(ctx, digest)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	return io.ReadAll(reader)
+}
+
+func (f *fakeBlobs) ReaderForBlob(ctx context.Context, digest Digest) (io.ReadCloser, error) {
+	f.mu.Lock()
+	f.reads[digest.hexHash()]++
+	data, found := f.data[digest.hexHash()]
+	f.mu.Unlock()
+
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	if !found {
+		return nil, fmt.Errorf("fake: blob %s not found", digest.hexHash())
+	}
+	return &fakeBlobReader{source: f, data: data, ctx: ctx}, nil
+}
+
+func (f *fakeBlobs) readCount(digest Digest) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reads[digest.hexHash()]
+}
+
+func (f *fakeBlobs) findMissingCalls() [][]Digest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.findCalls)
+}
+
+type fakeBlobReader struct {
+	source *fakeBlobs
+	data   []byte
+	ctx    context.Context
+	pos    int
+}
+
+func (r *fakeBlobReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	if r.source.gate != nil && r.pos >= r.source.gateAfter {
+		select {
+		case <-r.source.gate:
+		case <-r.ctx.Done():
+			return 0, r.ctx.Err()
+		}
+	}
+	n := len(p)
+	if r.source.chunk > 0 && n > r.source.chunk {
+		n = r.source.chunk
+	}
+	if remaining := len(r.data) - r.pos; n > remaining {
+		n = remaining
+	}
+	// Stop at the gate rather than serving through it.
+	if r.source.gate != nil && r.pos < r.source.gateAfter && r.pos+n > r.source.gateAfter {
+		n = r.source.gateAfter - r.pos
+	}
+	copy(p, r.data[r.pos:r.pos+n])
+	r.pos += n
+	return n, nil
+}
+
+func (r *fakeBlobReader) Close() error { return nil }
+
+func blobDigest(content []byte) Digest {
+	sum := sha256.Sum256(content)
+	return SHA256(sum[:], int64(len(content)))
+}
+
+// blobContent returns deterministic, distinguishable bytes.
+func blobContent(seed byte, size int) []byte {
+	content := make([]byte, size)
+	for i := range content {
+		content[i] = seed + byte(i%251)
+	}
+	return content
+}
+
+func newTestCache(t *testing.T, source BlobSource, opts ...CacheOption) *CachingReader {
+	t.Helper()
+	opts = append([]CacheOption{WithCacheDir(t.TempDir())}, opts...)
+	reader, err := NewCachingReader(source, opts...)
+	if err != nil {
+		t.Fatalf("NewCachingReader: %v", err)
+	}
+	t.Cleanup(func() { reader.Close() })
+	return reader
+}
+
+func readAllAndClose(t *testing.T, reader io.ReadCloser) []byte {
+	t.Helper()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("reading blob: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("closing blob reader: %v", err)
+	}
+	return data
+}
+
+func eventually(t *testing.T, what string, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// settle waits until no fetch is in flight and no partial blob is left, so that
+// what is (or is not) in the cache directory has stopped changing. A reader that
+// consumed a whole blob usually closes just before its fetch records completion,
+// so caching finishes a moment after the read does. Callers must close their
+// readers first: a partial file is only removed once nobody holds it open, which
+// on Windows is the only time it can be removed at all.
+func settle(t *testing.T, cache *CachingReader) {
+	t.Helper()
+	eventually(t, "the cache to settle", func() bool {
+		entries, err := os.ReadDir(filepath.Join(cache.Dir(), tempDirName))
+		if err != nil || len(entries) != 0 {
+			return false
+		}
+		cache.mu.Lock()
+		defer cache.mu.Unlock()
+		return len(cache.inflight) == 0
+	})
+}
+
+// assertCached fails unless the blob is in the cache directory with its full size.
+func assertCached(t *testing.T, cache *CachingReader, digest Digest) {
+	t.Helper()
+	path := DiskCacheBlobPath(cache.Dir(), digest.hexHash())
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("blob was not cached at %s: %v", path, err)
+	}
+	if info.Size() != digest.SizeBytes {
+		t.Fatalf("cached blob %s has size %d, want %d", path, info.Size(), digest.SizeBytes)
+	}
+}
+
+// assertNotCached fails if the blob is in the cache directory.
+func assertNotCached(t *testing.T, cache *CachingReader, digest Digest) {
+	t.Helper()
+	path := DiskCacheBlobPath(cache.Dir(), digest.hexHash())
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("blob at %s should not be cached (stat error: %v)", path, err)
+	}
+}
+
+func TestCachingReaderCachesBlobOnDisk(t *testing.T) {
+	content := blobContent(1, 4096)
+	digest := blobDigest(content)
+	source := newFakeBlobs(content)
+	cache := newTestCache(t, source)
+
+	reader, err := cache.ReaderForBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := readAllAndClose(t, reader); !slices.Equal(got, content) {
+		t.Fatalf("first read returned %d bytes, want the blob", len(got))
+	}
+	settle(t, cache)
+	assertCached(t, cache, digest)
+
+	// A second read is served from disk without touching upstream.
+	reader, err = cache.ReaderForBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := readAllAndClose(t, reader); !slices.Equal(got, content) {
+		t.Fatal("second read returned the wrong bytes")
+	}
+	if reads := source.readCount(digest); reads != 1 {
+		t.Errorf("upstream was read %d times, want 1", reads)
+	}
+	stats := cache.Stats()
+	if stats.Hits != 1 || stats.Fetches != 1 {
+		t.Errorf("stats = %+v, want 1 hit and 1 fetch", stats)
+	}
+}
+
+func TestCachingReaderReadBlobSharesCache(t *testing.T) {
+	content := blobContent(2, 1024)
+	digest := blobDigest(content)
+	source := newFakeBlobs(content)
+	cache := newTestCache(t, source)
+
+	got, err := cache.ReadBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(got, content) {
+		t.Fatal("ReadBlob returned the wrong bytes")
+	}
+	settle(t, cache)
+
+	reader, err := cache.ReaderForBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	readAllAndClose(t, reader)
+	if reads := source.readCount(digest); reads != 1 {
+		t.Errorf("upstream was read %d times, want 1", reads)
+	}
+}
+
+func TestCachingReaderDeduplicatesInFlightReads(t *testing.T) {
+	content := blobContent(3, 64)
+	digest := blobDigest(content)
+	source := newFakeBlobs(content)
+	source.chunk = 16
+	source.gateAfter = 16
+	source.gate = make(chan struct{})
+	cache := newTestCache(t, source, WithCacheBufferSize(16))
+
+	first, err := cache.ReaderForBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Wait until the fetch has published its first buffer, so the second caller
+	// certainly arrives while the fetch is in flight.
+	head := make([]byte, 16)
+	if _, err := io.ReadFull(first, head); err != nil {
+		t.Fatalf("reading the first buffer: %v", err)
+	}
+
+	second, err := cache.ReaderForBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(source.gate)
+
+	rest := readAllAndClose(t, first)
+	if got := append(head, rest...); !slices.Equal(got, content) {
+		t.Error("the first reader did not see the whole blob")
+	}
+	if got := readAllAndClose(t, second); !slices.Equal(got, content) {
+		t.Error("the second reader did not see the whole blob")
+	}
+	if reads := source.readCount(digest); reads != 1 {
+		t.Errorf("upstream was read %d times, want 1", reads)
+	}
+	if stats := cache.Stats(); stats.Deduped != 1 {
+		t.Errorf("stats = %+v, want 1 deduplicated read", stats)
+	}
+}
+
+func TestCachingReaderPublishesAtBufferSize(t *testing.T) {
+	content := blobContent(4, 64)
+	digest := blobDigest(content)
+	source := newFakeBlobs(content)
+	source.chunk = 8
+	source.gateAfter = 8
+	source.gate = make(chan struct{})
+	cache := newTestCache(t, source, WithCacheBufferSize(8))
+
+	reader, err := cache.ReaderForBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The first buffer is available even though the blob is far from complete.
+	head := make([]byte, 8)
+	if _, err := io.ReadFull(reader, head); err != nil {
+		t.Fatalf("reading the first buffer: %v", err)
+	}
+	if !slices.Equal(head, content[:8]) {
+		t.Fatal("the first buffer has the wrong content")
+	}
+
+	// Nothing beyond it, until upstream delivers more.
+	blocked := make(chan struct{})
+	go func() {
+		defer close(blocked)
+		io.ReadFull(reader, make([]byte, 1))
+	}()
+	select {
+	case <-blocked:
+		t.Fatal("read past the published offset returned before more data arrived")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(source.gate)
+	<-blocked
+	readAllAndClose(t, reader)
+}
+
+func TestCachingReaderEarlyCloseStillCaches(t *testing.T) {
+	content := blobContent(5, 2048)
+	digest := blobDigest(content)
+	source := newFakeBlobs(content)
+	cache := newTestCache(t, source, WithCacheBufferSize(256))
+
+	abandoning, err := cache.ReaderForBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadFull(abandoning, make([]byte, 1)); err != nil {
+		t.Fatal(err)
+	}
+	completing, err := cache.ReaderForBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := abandoning.Close(); err != nil {
+		t.Fatalf("closing the first reader: %v", err)
+	}
+	if got := readAllAndClose(t, completing); !slices.Equal(got, content) {
+		t.Fatal("the remaining reader did not see the whole blob")
+	}
+
+	settle(t, cache)
+	assertCached(t, cache, digest)
+	if reads := source.readCount(digest); reads != 1 {
+		t.Errorf("upstream was read %d times, want 1", reads)
+	}
+}
+
+func TestCachingReaderAbandonedFetchLeavesNothingBehind(t *testing.T) {
+	content := blobContent(6, 64)
+	digest := blobDigest(content)
+	source := newFakeBlobs(content)
+	source.chunk = 16
+	source.gateAfter = 16
+	source.gate = make(chan struct{})
+	cache := newTestCache(t, source, WithCacheBufferSize(16))
+
+	reader, err := cache.ReaderForBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadFull(reader, make([]byte, 16)); err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("closing the only reader: %v", err)
+	}
+	close(source.gate)
+
+	tempDir := filepath.Join(cache.Dir(), tempDirName)
+	eventually(t, "the partial blob to be cleaned up", func() bool {
+		entries, err := os.ReadDir(tempDir)
+		return err == nil && len(entries) == 0
+	})
+	assertNotCached(t, cache, digest)
+}
+
+func TestCachingReaderReaderContextCancellation(t *testing.T) {
+	content := blobContent(7, 64)
+	digest := blobDigest(content)
+	source := newFakeBlobs(content)
+	source.chunk = 16
+	source.gateAfter = 16
+	source.gate = make(chan struct{})
+	cache := newTestCache(t, source, WithCacheBufferSize(16))
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancelled, err := cache.ReaderForBlob(cancelledCtx, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancelled.Close()
+	if _, err := io.ReadFull(cancelled, make([]byte, 16)); err != nil {
+		t.Fatal(err)
+	}
+	// A second reader shares the same fetch and must survive the first one's
+	// cancellation.
+	surviving, err := cache.ReaderForBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blocked := make(chan error, 1)
+	go func() {
+		_, err := io.ReadFull(cancelled, make([]byte, 1))
+		blocked <- err
+	}()
+	cancel()
+	if err := <-blocked; !errors.Is(err, context.Canceled) {
+		t.Errorf("cancelled read returned %v, want context.Canceled", err)
+	}
+
+	close(source.gate)
+	if got := readAllAndClose(t, surviving); !slices.Equal(got, content) {
+		t.Error("the surviving reader did not see the whole blob")
+	}
+}
+
+func TestCachingReaderRejectsCorruptContent(t *testing.T) {
+	content := blobContent(8, 512)
+	digest := blobDigest(content)
+	source := newFakeBlobs(content)
+	source.serveInstead(digest, blobContent(9, 512))
+	cache := newTestCache(t, source)
+
+	reader, err := cache.ReaderForBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(reader); err == nil {
+		t.Fatal("reading a blob whose content does not match its digest succeeded")
+	}
+	// The reader still holds the partial file, so it is still there: a file with
+	// an open handle cannot be removed on Windows, and removing it early would
+	// pull it out from under the reader everywhere else.
+	tempDir := filepath.Join(cache.Dir(), tempDirName)
+	if entries, err := os.ReadDir(tempDir); err != nil || len(entries) != 1 {
+		t.Fatalf("temp directory holds %v (err %v), want the partial file the reader has open", entries, err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// Letting go of it is what cleans it up.
+	settle(t, cache)
+	assertNotCached(t, cache, digest)
+}
+
+func TestCachingReaderRejectsTruncatedContent(t *testing.T) {
+	content := blobContent(10, 512)
+	digest := blobDigest(content)
+	source := newFakeBlobs(content)
+	source.serveInstead(digest, content[:256])
+	cache := newTestCache(t, source)
+
+	reader, err := cache.ReaderForBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(reader); err == nil {
+		t.Fatal("reading a short blob succeeded")
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	settle(t, cache)
+	assertNotCached(t, cache, digest)
+}
+
+func TestCachingReaderRejectsOversizedContent(t *testing.T) {
+	content := blobContent(21, 512)
+	digest := blobDigest(content)
+	source := newFakeBlobs(content)
+	// A source that keeps sending past the digest's size must not be allowed to
+	// write an unbounded amount to disk, and its content must be rejected.
+	source.serveInstead(digest, blobContent(22, 4096))
+	cache := newTestCache(t, source)
+
+	reader, err := cache.ReaderForBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(reader)
+	if err == nil {
+		t.Fatal("reading an oversized blob succeeded")
+	}
+	if int64(len(got)) > digest.SizeBytes+1 {
+		t.Errorf("read %d bytes of an oversized blob, want at most %d", len(got), digest.SizeBytes+1)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	settle(t, cache)
+	assertNotCached(t, cache, digest)
+}
+
+func TestCachingReaderUpstreamErrorIsReported(t *testing.T) {
+	content := blobContent(11, 128)
+	digest := blobDigest(content)
+	source := newFakeBlobs(content)
+	source.openErr = errors.New("remote cache unavailable")
+	cache := newTestCache(t, source)
+
+	if _, err := cache.ReadBlob(context.Background(), digest); err == nil {
+		t.Fatal("ReadBlob succeeded despite an upstream failure")
+	}
+	// The failed fetch is forgotten, so a later attempt tries again.
+	source.openErr = nil
+	got, err := cache.ReadBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatalf("retry after an upstream failure: %v", err)
+	}
+	if !slices.Equal(got, content) {
+		t.Error("the retry returned the wrong bytes")
+	}
+}
+
+func TestCachingReaderEvictsOnNoSpaceAndRetries(t *testing.T) {
+	first := blobContent(12, 1024)
+	second := blobContent(13, 1024)
+	firstDigest, secondDigest := blobDigest(first), blobDigest(second)
+	source := newFakeBlobs(first, second)
+	cache := newTestCache(t, source)
+
+	// Cache the first blob so there is something to evict.
+	if _, err := cache.ReadBlob(context.Background(), firstDigest); err != nil {
+		t.Fatal(err)
+	}
+	settle(t, cache)
+	assertCached(t, cache, firstDigest)
+
+	var failures int
+	var mu sync.Mutex
+	realWrite := cache.store.write
+	cache.store.write = func(f *os.File, p []byte) (int, error) {
+		mu.Lock()
+		failures++
+		fail := failures == 1
+		mu.Unlock()
+		if fail {
+			return 0, &os.PathError{Op: "write", Path: f.Name(), Err: syscall.ENOSPC}
+		}
+		return realWrite(f, p)
+	}
+
+	got, err := cache.ReadBlob(context.Background(), secondDigest)
+	if err != nil {
+		t.Fatalf("reading a blob after an out-of-space error: %v", err)
+	}
+	if !slices.Equal(got, second) {
+		t.Fatal("the blob read after an out-of-space error is wrong")
+	}
+	settle(t, cache)
+	assertCached(t, cache, secondDigest)
+	assertNotCached(t, cache, firstDigest)
+	if stats := cache.Stats(); stats.Evicted != 1 || stats.DiskDisabled {
+		t.Errorf("stats = %+v, want 1 eviction and caching still enabled", stats)
+	}
+}
+
+func TestCachingReaderFallsBackWhenDiskIsFull(t *testing.T) {
+	content := blobContent(14, 1024)
+	digest := blobDigest(content)
+	source := newFakeBlobs(content)
+	cache := newTestCache(t, source)
+	cache.store.write = func(f *os.File, p []byte) (int, error) {
+		return 0, &os.PathError{Op: "write", Path: f.Name(), Err: syscall.ENOSPC}
+	}
+
+	got, err := cache.ReadBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatalf("reading a blob with a full disk: %v", err)
+	}
+	if !slices.Equal(got, content) {
+		t.Fatal("the blob read with a full disk is wrong")
+	}
+	stats := cache.Stats()
+	if !stats.DiskDisabled {
+		t.Error("disk caching should be disabled after an unrecoverable write failure")
+	}
+	if stats.Fallbacks == 0 {
+		t.Error("the read should be counted as a fallback")
+	}
+
+	// Later reads skip the disk entirely and still work.
+	if _, err := cache.ReadBlob(context.Background(), digest); err != nil {
+		t.Fatalf("reading a blob after disk caching was disabled: %v", err)
+	}
+}
+
+func TestCachingReaderEnforcesMaxSize(t *testing.T) {
+	blobs := [][]byte{blobContent(15, 1024), blobContent(16, 1024), blobContent(17, 1024)}
+	source := newFakeBlobs(blobs...)
+	cache := newTestCache(t, source, WithCacheMaxSize(2048))
+
+	for _, blob := range blobs {
+		if _, err := cache.ReadBlob(context.Background(), blobDigest(blob)); err != nil {
+			t.Fatal(err)
+		}
+		settle(t, cache)
+	}
+
+	assertNotCached(t, cache, blobDigest(blobs[0]))
+	for _, blob := range blobs[1:] {
+		assertCached(t, cache, blobDigest(blob))
+	}
+	if stats := cache.Stats(); stats.Evicted != 1 {
+		t.Errorf("stats = %+v, want 1 eviction", stats)
+	}
+}
+
+func TestCachingReaderFindMissingBlobsAnswersFromCache(t *testing.T) {
+	cached := blobContent(18, 256)
+	uncached := blobContent(19, 256)
+	cachedDigest, uncachedDigest := blobDigest(cached), blobDigest(uncached)
+	source := newFakeBlobs(cached, uncached)
+	cache := newTestCache(t, source)
+
+	if _, err := cache.ReadBlob(context.Background(), cachedDigest); err != nil {
+		t.Fatal(err)
+	}
+	settle(t, cache)
+
+	// A cached blob is never asked about.
+	missing, err := cache.FindMissingBlobs(context.Background(), []Digest{cachedDigest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(missing) != 0 {
+		t.Errorf("FindMissingBlobs reported %d missing blobs, want 0", len(missing))
+	}
+	if calls := source.findMissingCalls(); len(calls) != 0 {
+		t.Errorf("upstream was asked %d times, want 0", len(calls))
+	}
+
+	// Uncached digests still go upstream, and only those.
+	if _, err := cache.FindMissingBlobs(context.Background(), []Digest{cachedDigest, uncachedDigest}); err != nil {
+		t.Fatal(err)
+	}
+	calls := source.findMissingCalls()
+	if len(calls) != 1 || len(calls[0]) != 1 || calls[0][0].hexHash() != uncachedDigest.hexHash() {
+		t.Errorf("upstream was asked about %v, want only the uncached digest", calls)
+	}
+}
+
+func TestCachingReaderEmptyBlob(t *testing.T) {
+	source := newFakeBlobs(nil)
+	cache := newTestCache(t, source)
+	digest := blobDigest(nil)
+
+	got, err := cache.ReadBlob(context.Background(), digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("empty blob read returned %d bytes", len(got))
+	}
+	assertNotCached(t, cache, digest)
+}
+
+func TestCachingReaderConcurrentReadersShareOneFetch(t *testing.T) {
+	content := blobContent(20, 1<<16)
+	digest := blobDigest(content)
+	source := newFakeBlobs(content)
+	source.chunk = 4096
+	cache := newTestCache(t, source, WithCacheBufferSize(4096))
+
+	const readers = 8
+	var wg sync.WaitGroup
+	errs := make([]error, readers)
+	for i := range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := cache.ReadBlob(context.Background(), digest)
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			if !slices.Equal(got, content) {
+				errs[i] = fmt.Errorf("reader %d got %d bytes, want %d", i, len(got), len(content))
+			}
+		}()
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Every read was either the one fetch, a reader joining it, a hit on what it
+	// wrote, or -- if the local copy could not be used -- a fallback.
+	stats := cache.Stats()
+	if stats.Fetches == 0 || stats.Fetches+stats.Hits+stats.Deduped+stats.Fallbacks < readers {
+		t.Errorf("stats = %+v, want every one of the %d reads accounted for", stats, readers)
+	}
+	if reads, upstream := source.readCount(digest), int(stats.Fetches+stats.Fallbacks); reads > upstream {
+		t.Errorf("upstream was read %d times, want at most the %d fetches and fallbacks", reads, upstream)
+	}
+}

--- a/img_tool/pkg/cas/cachestore.go
+++ b/img_tool/pkg/cas/cachestore.go
@@ -1,0 +1,439 @@
+package cas
+
+import (
+	"container/list"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	// tempDirName is the subdirectory of the cache root that holds partially
+	// fetched blobs. It deliberately sits next to (not inside) cas/ so that a
+	// half-written blob is never mistaken for a cache entry -- neither by us nor
+	// by Bazel, when the root is a shared Bazel disk cache.
+	tempDirName = "img-cas-tmp"
+
+	// tempMaxAge is how long a temp file must be untouched before a later run
+	// deletes it. Anything younger may belong to a concurrently running process.
+	tempMaxAge = 24 * time.Hour
+
+	dirPerm  = 0o755
+	filePerm = 0o644
+)
+
+// DiskCacheBlobPath returns the path of a CAS blob inside a Bazel disk cache
+// rooted at cacheDir. The layout is Bazel's: cas/<first two hex chars>/<hex>,
+// with no digest function in the path.
+func DiskCacheBlobPath(cacheDir string, hexDigest string) string {
+	return filepath.Join(cacheDir, "cas", hexDigest[:2], hexDigest)
+}
+
+// diskStore is the on-disk half of a CachingReader: a Bazel-disk-cache-shaped
+// directory plus an in-memory index of the blobs it may evict from it.
+//
+// The index only ever holds entries this store put there -- blobs it wrote, and,
+// when a size limit applies, the entries found by the startup scan of a
+// directory we manage. A shared Bazel disk cache is never scanned, so Bazel's
+// own entries never become eviction candidates; Bazel's disk cache GC owns those.
+type diskStore struct {
+	dir string
+	// ephemeral marks a directory this process created because no user cache
+	// directory was available. close removes it; a configured directory survives.
+	ephemeral bool
+	maxSize   int64 // 0: unlimited, no scan and no proactive eviction
+
+	// write is indirected so tests can inject write failures (ENOSPC).
+	write func(f *os.File, p []byte) (int, error)
+
+	mu        sync.Mutex
+	entries   map[string]*list.Element // blob key -> element of lru
+	lru       *list.List               // *storeEntry, most recently used at the front
+	totalSize int64                    // bytes tracked in entries
+	reserved  int64                    // bytes promised to in-flight fetches
+	disabled  bool                     // disk caching gave up
+	evicted   uint64
+}
+
+// storeEntry is one evictable blob in the index.
+type storeEntry struct {
+	key  string
+	path string
+	size int64
+}
+
+// newDiskStore prepares dir for use: creates the cas/ and temp directories,
+// removes stale temp files, and, if a size limit applies, indexes the blobs
+// already there and evicts down to the limit.
+func newDiskStore(dir string, ephemeral bool, maxSize int64) (*diskStore, error) {
+	s := &diskStore{
+		dir:       dir,
+		ephemeral: ephemeral,
+		maxSize:   maxSize,
+		write:     func(f *os.File, p []byte) (int, error) { return f.Write(p) },
+		entries:   make(map[string]*list.Element),
+		lru:       list.New(),
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "cas"), dirPerm); err != nil {
+		return nil, fmt.Errorf("creating CAS cache directory: %w", err)
+	}
+	if err := os.MkdirAll(s.tempDir(), dirPerm); err != nil {
+		return nil, fmt.Errorf("creating CAS cache temp directory: %w", err)
+	}
+	s.sweepTemp()
+	if maxSize > 0 {
+		s.scan()
+		s.prune()
+	}
+	return s, nil
+}
+
+func (s *diskStore) tempDir() string {
+	return filepath.Join(s.dir, tempDirName)
+}
+
+func (s *diskStore) blobPath(d Digest) string {
+	return DiskCacheBlobPath(s.dir, hex.EncodeToString(d.Hash))
+}
+
+// scan indexes the blobs already in the cache directory, oldest first, so that
+// the size limit covers entries written by earlier runs. It is only called for
+// directories this store manages (see newDiskStore).
+func (s *diskStore) scan() {
+	type found struct {
+		entry   storeEntry
+		modTime time.Time
+	}
+	var blobs []found
+	casDir := filepath.Join(s.dir, "cas")
+	shards, err := os.ReadDir(casDir)
+	if err != nil {
+		return
+	}
+	for _, shard := range shards {
+		if !shard.IsDir() {
+			continue
+		}
+		files, err := os.ReadDir(filepath.Join(casDir, shard.Name()))
+		if err != nil {
+			continue
+		}
+		for _, file := range files {
+			info, err := file.Info()
+			if err != nil || info.IsDir() {
+				continue
+			}
+			blobs = append(blobs, found{
+				entry: storeEntry{
+					key:  file.Name(),
+					path: filepath.Join(casDir, shard.Name(), file.Name()),
+					size: info.Size(),
+				},
+				modTime: info.ModTime(),
+			})
+		}
+	}
+	// Insert oldest first so the LRU order reflects the recorded access times.
+	slices.SortStableFunc(blobs, func(a, b found) int { return a.modTime.Compare(b.modTime) })
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, blob := range blobs {
+		if _, ok := s.entries[blob.entry.key]; ok {
+			continue
+		}
+		entry := blob.entry
+		s.entries[entry.key] = s.lru.PushFront(&entry)
+		s.totalSize += entry.size
+	}
+}
+
+// sweepTemp removes temp files left behind by a killed process. Files younger
+// than tempMaxAge are left alone: they may belong to a running process.
+func (s *diskStore) sweepTemp() {
+	files, err := os.ReadDir(s.tempDir())
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-tempMaxAge)
+	for _, file := range files {
+		info, err := file.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		os.Remove(filepath.Join(s.tempDir(), file.Name()))
+	}
+}
+
+// open returns a reader for a blob that is already in the cache directory. It
+// fails if the blob is absent or has the wrong size (a truncated or foreign file
+// under that name).
+func (s *diskStore) open(d Digest) (*os.File, error) {
+	path := s.blobPath(d)
+	// Record the access before opening the file: it keeps blobs we are still
+	// using in our LRU and in Bazel's disk cache GC, and on Windows a file's
+	// times cannot be set while we hold a read handle on it.
+	now := time.Now()
+	os.Chtimes(path, now, now)
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	if info.Size() != d.SizeBytes {
+		f.Close()
+		return nil, fmt.Errorf("cached blob %s has size %d, want %d", path, info.Size(), d.SizeBytes)
+	}
+	s.touch(d)
+	return f, nil
+}
+
+// has reports whether the blob is in the cache directory with the expected size.
+func (s *diskStore) has(d Digest) bool {
+	info, err := os.Stat(s.blobPath(d))
+	return err == nil && info.Size() == d.SizeBytes
+}
+
+// touch moves an indexed blob to the front of the LRU. Blobs we did not put in
+// the index (a shared Bazel disk cache's own entries) stay untracked.
+func (s *diskStore) touch(d Digest) {
+	key := hex.EncodeToString(d.Hash)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if element, ok := s.entries[key]; ok {
+		s.lru.MoveToFront(element)
+	}
+}
+
+// createTemp opens a file for a blob being fetched and reserves size bytes
+// against the limit, evicting first if necessary. The caller must eventually
+// call finalize or discard.
+func (s *diskStore) createTemp(size int64) (*os.File, error) {
+	s.mu.Lock()
+	disabled := s.disabled
+	s.mu.Unlock()
+	if disabled {
+		return nil, errDiskCacheDisabled
+	}
+	s.makeRoom(size)
+
+	s.mu.Lock()
+	s.reserved += size
+	s.mu.Unlock()
+
+	f, err := os.CreateTemp(s.tempDir(), "blob-*")
+	if err != nil {
+		s.release(size)
+		return nil, err
+	}
+	// CreateTemp uses 0600; cache entries are world-readable like Bazel's, which
+	// matters when the directory is shared between users.
+	os.Chmod(f.Name(), filePerm)
+	return f, nil
+}
+
+// release gives back a reservation made by createTemp.
+func (s *diskStore) release(size int64) {
+	s.mu.Lock()
+	s.releaseLocked(size)
+	s.mu.Unlock()
+}
+
+// releaseLocked implements release. s.mu must be held.
+func (s *diskStore) releaseLocked(size int64) {
+	s.reserved -= size
+	if s.reserved < 0 {
+		s.reserved = 0
+	}
+}
+
+// discard removes a temp file and releases its reservation.
+func (s *diskStore) discard(tempPath string, size int64) {
+	os.Remove(tempPath)
+	s.release(size)
+}
+
+// finalize moves a completely written temp file to its content-addressed path
+// and indexes it. It releases the reservation either way.
+func (s *diskStore) finalize(tempPath string, d Digest) error {
+	path := s.blobPath(d)
+	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
+		s.discard(tempPath, d.SizeBytes)
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		// Another process may have won the race (or, on Windows, hold the
+		// destination open). Identical content under the same digest means the
+		// entry is there, which is all we wanted.
+		os.Remove(tempPath)
+		if !s.has(d) {
+			s.release(d.SizeBytes)
+			return err
+		}
+	}
+
+	key := hex.EncodeToString(d.Hash)
+	s.mu.Lock()
+	if element, ok := s.entries[key]; ok {
+		s.lru.MoveToFront(element)
+	} else {
+		s.entries[key] = s.lru.PushFront(&storeEntry{key: key, path: path, size: d.SizeBytes})
+		s.totalSize += d.SizeBytes
+	}
+	// The blob is accounted for by the index now, so drop the reservation before
+	// pruning -- otherwise it would be counted twice and evict a blob too many.
+	s.releaseLocked(d.SizeBytes)
+	s.mu.Unlock()
+
+	s.prune()
+	return nil
+}
+
+// writeAll writes p to f, making room by evicting cached blobs when the file
+// system reports it is out of space. The bytes already written stay valid, so a
+// retry never needs to re-fetch anything.
+func (s *diskStore) writeAll(f *os.File, p []byte) error {
+	for len(p) > 0 {
+		n, err := s.write(f, p)
+		p = p[n:]
+		switch {
+		case err == nil && n == 0:
+			return io.ErrShortWrite
+		case err == nil:
+			continue // short write, keep going
+		case !isNoSpace(err):
+			return err
+		}
+		// Out of space: free at least what is left to write, then retry. Eviction
+		// can only free a finite amount, so this terminates.
+		if freed := s.freeAtLeast(int64(len(p))); freed == 0 {
+			return err
+		}
+	}
+	return nil
+}
+
+// evict removes least recently used blobs while more reports that eviction
+// should continue, and returns the number of bytes freed. s.mu must be held.
+//
+// Entries we fail to delete (another process holds the file open on Windows)
+// stay indexed and accounted for; eviction just moves on to the next candidate.
+func (s *diskStore) evictLocked(more func(freed int64) bool) int64 {
+	var freed int64
+	// Walk from the least recently used entry towards the most recently used.
+	for element := s.lru.Back(); element != nil && more(freed); {
+		prev := element.Prev()
+		entry := element.Value.(*storeEntry)
+		err := os.Remove(entry.path)
+		if err == nil || errors.Is(err, os.ErrNotExist) {
+			s.lru.Remove(element)
+			delete(s.entries, entry.key)
+			s.totalSize -= entry.size
+			if err == nil {
+				freed += entry.size
+				s.evicted++
+			}
+		}
+		element = prev
+	}
+	return freed
+}
+
+// makeRoom evicts so that size more bytes fit under the size limit. Without a
+// limit nothing is evicted: a cache directory we do not manage (a Bazel disk
+// cache) is only ever pruned when the file system actually runs out of space.
+func (s *diskStore) makeRoom(size int64) {
+	if s.maxSize <= 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.evictLocked(func(int64) bool { return s.totalSize+s.reserved+size > s.maxSize })
+}
+
+// prune brings the cache back under the size limit.
+func (s *diskStore) prune() {
+	if s.maxSize <= 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.evictLocked(func(int64) bool { return s.totalSize+s.reserved > s.maxSize })
+}
+
+// freeAtLeast evicts, regardless of any size limit, until want bytes have been
+// freed or there is nothing left to evict. It returns the bytes freed. This is
+// the out-of-space emergency: the size limit is not what is binding.
+func (s *diskStore) freeAtLeast(want int64) int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.evictLocked(func(freed int64) bool { return freed < want })
+}
+
+// disable turns off disk caching for the rest of the process. Reads keep
+// working: the caching reader falls back to streaming straight from upstream.
+func (s *diskStore) disable(reason error) {
+	s.mu.Lock()
+	alreadyDisabled := s.disabled
+	s.disabled = true
+	s.mu.Unlock()
+	if !alreadyDisabled {
+		fmt.Fprintf(os.Stderr, "WARNING: cannot write to CAS blob cache %s (%v); continuing without local caching\n", s.dir, reason)
+	}
+}
+
+func (s *diskStore) isDisabled() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.disabled
+}
+
+func (s *diskStore) evictions() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.evicted
+}
+
+// close removes the cache directory if this process created it as a temporary
+// stand-in. Persistent directories are left for the next run.
+func (s *diskStore) close() error {
+	if s.ephemeral {
+		return os.RemoveAll(s.dir)
+	}
+	return nil
+}
+
+// errDiskCacheDisabled reports that a blob cannot be cached locally. It is never
+// returned to callers of the CachingReader -- it makes them fall back to reading
+// straight from upstream.
+var errDiskCacheDisabled = errors.New("cas: disk caching disabled")
+
+// isNoSpace reports whether err is the file system refusing a write for lack of
+// space. Go maps this to ENOSPC on Unix; Windows reports ERROR_DISK_FULL /
+// ERROR_HANDLE_DISK_FULL, which have no errno equivalent, so their messages are
+// matched as well.
+func isNoSpace(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ENOSPC) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no space left on device") ||
+		strings.Contains(msg, "not enough space on the disk") ||
+		strings.Contains(msg, "disk is full")
+}

--- a/img_tool/pkg/cas/cachestore_test.go
+++ b/img_tool/pkg/cas/cachestore_test.go
@@ -1,0 +1,215 @@
+package cas
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// writeCachedBlob puts content in a cache directory the way the store would,
+// with the given modification time, and returns its digest.
+func writeCachedBlob(t *testing.T, dir string, content []byte, modTime time.Time) Digest {
+	t.Helper()
+	digest := blobDigest(content)
+	path := DiskCacheBlobPath(dir, digest.hexHash())
+	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, content, filePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatal(err)
+	}
+	return digest
+}
+
+func TestDiskCacheBlobPath(t *testing.T) {
+	// The layout must match Bazel's disk cache, which is what makes sharing a
+	// directory with Bazel (IMG_DISK_CACHE) work in both directions.
+	got := DiskCacheBlobPath("/cache", "abcdef0123456789")
+	want := filepath.Join("/cache", "cas", "ab", "abcdef0123456789")
+	if got != want {
+		t.Errorf("DiskCacheBlobPath = %q, want %q", got, want)
+	}
+}
+
+func TestResolveCacheDirUsesConfiguredDir(t *testing.T) {
+	dir, ephemeral, err := resolveCacheDir("/some/dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dir != "/some/dir" || ephemeral {
+		t.Errorf("resolveCacheDir = (%q, %v), want the configured directory and no cleanup", dir, ephemeral)
+	}
+}
+
+func TestResolveCacheDirDefaultsToUserCacheDir(t *testing.T) {
+	userCacheDir, err := os.UserCacheDir()
+	if err != nil {
+		t.Skipf("no user cache directory: %v", err)
+	}
+	dir, ephemeral, err := resolveCacheDir("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(userCacheDir, cacheDirName); dir != want {
+		t.Errorf("resolveCacheDir = %q, want %q", dir, want)
+	}
+	if ephemeral {
+		t.Error("the user cache directory should persist across runs")
+	}
+	if _, err := os.Stat(dir); err == nil {
+		t.Log("note: the default cache directory already exists on this machine")
+	}
+}
+
+func TestDiskStoreCloseRemovesOnlyEphemeralDir(t *testing.T) {
+	persistent := t.TempDir()
+	store, err := newDiskStore(persistent, false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(persistent); err != nil {
+		t.Errorf("a configured cache directory should survive Close: %v", err)
+	}
+
+	ephemeral := filepath.Join(t.TempDir(), "throwaway")
+	store, err = newDiskStore(ephemeral, true, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(ephemeral); !errors.Is(err, os.ErrNotExist) {
+		t.Error("a temporary cache directory should be removed by Close")
+	}
+}
+
+func TestDiskStoreEnforcesMaxSizeOnExistingDir(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	oldest := writeCachedBlob(t, dir, blobContent(30, 1024), now.Add(-2*time.Hour))
+	newer := writeCachedBlob(t, dir, blobContent(31, 1024), now.Add(-1*time.Hour))
+	newest := writeCachedBlob(t, dir, blobContent(32, 1024), now)
+
+	// A directory we manage is indexed at startup, so the limit covers what
+	// earlier runs left behind.
+	store, err := newDiskStore(dir, false, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.has(oldest) {
+		t.Error("the oldest blob should have been evicted at startup")
+	}
+	for _, digest := range []Digest{newer, newest} {
+		if !store.has(digest) {
+			t.Error("a recent blob was evicted at startup")
+		}
+	}
+	if store.evictions() != 1 {
+		t.Errorf("evicted %d blobs, want 1", store.evictions())
+	}
+}
+
+func TestDiskStoreWithoutMaxSizeLeavesExistingBlobsAlone(t *testing.T) {
+	dir := t.TempDir()
+	// A Bazel disk cache is full of entries that are none of our business: with no
+	// size limit they are neither indexed nor evictable.
+	foreign := writeCachedBlob(t, dir, blobContent(33, 4096), time.Now().Add(-time.Hour))
+
+	store, err := newDiskStore(dir, false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !store.has(foreign) {
+		t.Fatal("an existing blob was removed from an unmanaged cache directory")
+	}
+	if freed := store.freeAtLeast(4096); freed != 0 {
+		t.Errorf("freed %d bytes from unindexed blobs, want 0", freed)
+	}
+	if !store.has(foreign) {
+		t.Error("eviction removed a blob this process did not write")
+	}
+}
+
+func TestDiskStoreSweepsStaleTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	tempDir := filepath.Join(dir, tempDirName)
+	if err := os.MkdirAll(tempDir, dirPerm); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(tempDir, "blob-stale")
+	fresh := filepath.Join(tempDir, "blob-fresh")
+	for _, path := range []string{stale, fresh} {
+		if err := os.WriteFile(path, []byte("partial"), filePerm); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-2 * tempMaxAge)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := newDiskStore(dir, false, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stale); !errors.Is(err, os.ErrNotExist) {
+		t.Error("a temp file left behind by an earlier run should be swept")
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Errorf("a recent temp file may belong to a running process: %v", err)
+	}
+}
+
+func TestDiskStoreOpenRejectsWrongSize(t *testing.T) {
+	dir := t.TempDir()
+	store, err := newDiskStore(dir, false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := blobContent(34, 512)
+	digest := writeCachedBlob(t, dir, content, time.Now())
+
+	file, err := store.open(digest)
+	if err != nil {
+		t.Fatalf("opening a cached blob: %v", err)
+	}
+	file.Close()
+
+	// A file of the wrong length under a digest's name is not that blob.
+	truncated := Digest{algorithm: digest.algorithm, Hash: digest.Hash, SizeBytes: digest.SizeBytes + 1}
+	if _, err := store.open(truncated); err == nil {
+		t.Error("opening a blob with a mismatched size succeeded")
+	}
+}
+
+func TestIsNoSpace(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "errno", err: &os.PathError{Op: "write", Err: syscall.ENOSPC}, want: true},
+		{name: "unix message", err: errors.New("write /tmp/blob: no space left on device"), want: true},
+		{name: "windows message", err: errors.New("write blob: There is not enough space on the disk."), want: true},
+		{name: "other errno", err: &os.PathError{Op: "write", Err: syscall.EACCES}, want: false},
+		{name: "unrelated", err: fmt.Errorf("connection reset"), want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isNoSpace(test.err); got != test.want {
+				t.Errorf("isNoSpace(%v) = %v, want %v", test.err, got, test.want)
+			}
+		})
+	}
+}

--- a/img_tool/pkg/cas/pool.go
+++ b/img_tool/pkg/cas/pool.go
@@ -6,13 +6,19 @@ import (
 	"sync/atomic"
 )
 
-// blobSource is the subset of *CAS a Pool distributes reads across. It exists
-// so the pool's round-robin logic can be unit-tested with fakes.
-type blobSource interface {
+// BlobSource is the CAS read surface: the subset of *CAS a Pool distributes
+// reads across, and the upstream a CachingReader wraps. Exposing it as an
+// interface also lets both be unit-tested with fakes.
+type BlobSource interface {
 	FindMissingBlobs(ctx context.Context, digests []Digest) ([]Digest, error)
 	ReadBlob(ctx context.Context, digest Digest) ([]byte, error)
 	ReaderForBlob(ctx context.Context, digest Digest) (io.ReadCloser, error)
 }
+
+var (
+	_ BlobSource = (*CAS)(nil)
+	_ BlobSource = (*Pool)(nil)
+)
 
 // Pool spreads CAS reads across several independent gRPC connections.
 //
@@ -27,7 +33,7 @@ type blobSource interface {
 // A Pool exposes the same read surface as *CAS (FindMissingBlobs, ReadBlob,
 // ReaderForBlob) and is safe for concurrent use.
 type Pool struct {
-	members []blobSource
+	members []BlobSource
 	next    atomic.Uint64
 }
 
@@ -36,14 +42,14 @@ type Pool struct {
 // any effect. NewPool panics if members is empty; a single-member pool is
 // valid and behaves like the member itself.
 func NewPool(members []*CAS) *Pool {
-	sources := make([]blobSource, len(members))
+	sources := make([]BlobSource, len(members))
 	for i, m := range members {
 		sources[i] = m
 	}
 	return newPool(sources)
 }
 
-func newPool(members []blobSource) *Pool {
+func newPool(members []BlobSource) *Pool {
 	if len(members) == 0 {
 		panic("cas.NewPool: at least one member is required")
 	}
@@ -51,7 +57,7 @@ func newPool(members []blobSource) *Pool {
 }
 
 // pick returns the next member in round-robin order.
-func (p *Pool) pick() blobSource {
+func (p *Pool) pick() BlobSource {
 	if len(p.members) == 1 {
 		return p.members[0]
 	}

--- a/img_tool/pkg/cas/pool_test.go
+++ b/img_tool/pkg/cas/pool_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-// fakeSource is a blobSource that records how many calls it handled.
+// fakeSource is a BlobSource that records how many calls it handled.
 type fakeSource struct {
 	id int
 
@@ -40,7 +40,7 @@ func (f *fakeSource) record() {
 
 func TestPoolPickRoundRobin(t *testing.T) {
 	a, b, c := &fakeSource{id: 0}, &fakeSource{id: 1}, &fakeSource{id: 2}
-	p := newPool([]blobSource{a, b, c})
+	p := newPool([]BlobSource{a, b, c})
 
 	var got []int
 	for range 7 {
@@ -54,7 +54,7 @@ func TestPoolPickRoundRobin(t *testing.T) {
 
 func TestPoolDistributesPublicMethods(t *testing.T) {
 	members := []*fakeSource{{}, {}, {}}
-	sources := make([]blobSource, len(members))
+	sources := make([]BlobSource, len(members))
 	for i, m := range members {
 		sources[i] = m
 	}
@@ -86,7 +86,7 @@ func TestPoolDistributesPublicMethods(t *testing.T) {
 
 func TestPoolSingleMember(t *testing.T) {
 	only := &fakeSource{}
-	p := newPool([]blobSource{only})
+	p := newPool([]BlobSource{only})
 
 	ctx := context.Background()
 	for range 5 {

--- a/img_tool/pkg/deployvfs/deployvfs.go
+++ b/img_tool/pkg/deployvfs/deployvfs.go
@@ -1048,7 +1048,7 @@ func (b *Builder) blobFromDiskCache(desc api.Descriptor) (blobEntry, error) {
 // Layout: {cacheDir}/cas/{first2hex}/{fullhex}
 func diskCacheBlobPath(cacheDir string, digest string) string {
 	_, hex, _ := strings.Cut(digest, ":")
-	return filepath.Join(cacheDir, "cas", hex[:2], hex)
+	return cas.DiskCacheBlobPath(cacheDir, hex)
 }
 
 // blobFromOCILayouts tries to find a blob in any of the configured OCI layout directories.

--- a/img_tool/pkg/prefetch/prefetch.go
+++ b/img_tool/pkg/prefetch/prefetch.go
@@ -7,7 +7,7 @@
 // goroutine which eagerly pulls data from the underlying reader into a bounded
 // ring buffer. A consumer that reads more slowly than the underlying source can
 // deliver (for example because it is bottlenecked on a network upload) therefore
-// does not stall the source: up to the configured prefetch size (by default 64
+// does not stall the source: up to the configured prefetch size (by default 1
 // MiB) is kept ready in memory ahead of the consumer's read position.
 package prefetch
 
@@ -20,7 +20,7 @@ import (
 
 // DefaultSize is the default maximum number of bytes to read ahead of the
 // consumer.
-const DefaultSize = 64 << 20 // 64 MiB
+const DefaultSize = 1 << 20 // 1 MiB
 
 // Option configures a prefetching layer.
 type Option func(*layer)


### PR DESCRIPTION
A lazy push reads the layers, configs and manifests it does not have locally from Bazel's remote cache, and every read went straight to the CAS. A layer pushed to two registries was downloaded twice, an upload retry downloaded it again, a compact layer's input file was downloaded once per layer that references it, and nothing was kept: the next `bazel run //:push` started over.

CAS reads now go through an adapter that fetches a blob once and keeps it. Readers of one digest share a single download — a reader that arrives while a fetch is in flight streams the bytes as they are written instead of opening a second read — and what the fetch writes lands in a directory shaped like Bazel's disk cache (`cas/<xx>/<digest>`), so a later read is served from disk. That later read can be in this process, in a later run, or in Bazel itself when the directory is its disk cache; `FindMissingBlobs` answers from the directory too, so a blob the CAS has since evicted still pushes. Nobody waits for a blob to be complete: the fetch publishes what it has written every time the configured buffer fills up.

Size and content digest are verified before a blob is renamed into place, since that directory may be one Bazel reads from. A file is only renamed into the cache, or removed after a failed fetch, once nobody holds it open any more, which is what makes both work on Windows.

Local problems never fail a read. A directory that cannot be written, a disk that is full after evicting the least recently used blobs, or a file that disappears underneath a reader degrades that read to streaming straight from the CAS: blobs are immutable and content-addressed, so re-reading one and skipping to the reader's offset is always correct.

The cache lives in the user cache directory, capped at 10 GiB, or in Bazel's disk cache when `IMG_DISK_CACHE` points at it. That directory is left uncapped, because Bazel's own garbage collection manages its size and we never evict an entry we did not write there unless the file system runs out of space. `IMG_CAS_CACHE=0` turns the layer off entirely; `IMG_CAS_CACHE_DIR`, `IMG_CAS_CACHE_MAX_SIZE` and `IMG_CAS_CACHE_BUFFER_SIZE` tune it. Only `img deploy` uses the adapter, on both the one-shot and the persistent-worker path; the build event service and the CAS-backed registry keep the plain client.

