### PR TITLE
fix(release): make the pre-release landing page readable

### DIFF
--- a/docs/pre-releases.md
+++ b/docs/pre-releases.md
@@ -60,15 +60,15 @@ be replaced if the build that produced it is re-run.
    platform and pushes it to `ghcr.io` as an ORAS artifact: one layer per
    platform, plus a `prebuilt_lockfile.json` layer naming those layers by digest
    (`//services/img` in `modules/rules_img_services`).
-2. The `publish-dev-registry` job then fetches that lockfile back out of the
-   artifact with the ORAS CLI — the tag names an index holding both the container
-   images and the artifact, so it descends into the manifest whose `artifactType`
-   matches before looking for the layer — and builds the module's source archive
-   with
-   `--//img/private/release:prebuilt_lockfile_override=//:prebuilt_lockfile.json`
-   — the empty lockfile the source tree carries, so the archive is *not* specific
-   to the commit.
-3. `@rules_img_internal_tools//release/devregistry` stores the archive, layers the
+2. The `publish-dev-registry` job fetches that lockfile back out of the artifact
+   with the ORAS CLI. The tag names an index holding both the container images and
+   the artifact, so it descends into the manifest whose `artifactType` matches
+   before looking for the layer.
+3. It builds the module's source archive with
+   `--//img/private/release:prebuilt_lockfile_override=//:prebuilt_lockfile.json`,
+   the empty lockfile the source tree carries, so the archive is not specific to
+   the commit.
+4. `@rules_img_internal_tools//release/devregistry` stores the archive, layers the
    real lockfile on top of it as the version's overlay, and merges the module
    metadata, all into a checkout of the `pages` branch, which the job commits.
 
@@ -85,8 +85,8 @@ modules/rules_img/<version>/patches/                sets the version in the arch
 assets/sha256/<digest>/file.tar.gz                  the module source, addressed by content
 ```
 
-Archives are stored by content, and the one thing that differs between two
-commits with identical sources — the lockfile, which names blobs by digest — is
+Archives are stored by content. The one thing that differs between two commits
+with identical sources is the lockfile, which names blobs by digest, and that is
 published as an [overlay](https://bazel.build/external/registry) rather than
 packaged into the archive. So a commit that does not touch the module's sources
 adds a few kilobytes of metadata and reuses the archive that is already there,

--- a/modules/rules_img_internal_tools/release/devregistry/index.go
+++ b/modules/rules_img_internal_tools/release/devregistry/index.go
@@ -34,53 +34,134 @@ var indexTemplate = template.Must(template.New(indexHTML).Parse(`<!DOCTYPE html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{.Module}} pre-release registry</title>
 <style>
-:root { color-scheme: light dark; }
-body { font-family: system-ui, -apple-system, sans-serif; max-width: 46rem; margin: 3rem auto; padding: 0 1.25rem; line-height: 1.6; }
-h1 { border-bottom: 1px solid color-mix(in srgb, currentColor 25%, transparent); padding-bottom: .4rem; }
-h2 { margin-top: 2.5rem; }
-pre { background: color-mix(in srgb, currentColor 8%, transparent); padding: .9rem 1rem; border-radius: .4rem; overflow-x: auto; }
-code { background: color-mix(in srgb, currentColor 8%, transparent); padding: .1rem .3rem; border-radius: .2rem; }
-pre code { background: none; padding: 0; }
+:root {
+  color-scheme: light dark;
+  --line: color-mix(in srgb, currentColor 15%, transparent);
+  --soft: color-mix(in srgb, currentColor 6%, transparent);
+  --muted: color-mix(in srgb, currentColor 62%, transparent);
+  --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+* { box-sizing: border-box; }
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: 3.5rem 1.25rem 5rem;
+  line-height: 1.6;
+}
+h1 { font-size: 1.6rem; margin: 0 0 .4rem; }
+h2 { font-size: 1.05rem; margin: 2.75rem 0 .75rem; }
+p { margin: 0 0 1rem; }
+header { border-bottom: 1px solid var(--line); padding-bottom: 1.25rem; }
+header p { margin: 0; color: var(--muted); }
+a { color: inherit; text-underline-offset: .15em; text-decoration-color: var(--line); }
+a:hover { text-decoration-color: currentColor; }
+code {
+  font-family: var(--mono);
+  font-size: .875em;
+  background: var(--soft);
+  padding: .1em .35em;
+  border-radius: .25rem;
+}
+
+/* Snippets say which file they belong in, and wrap rather than scroll: a
+   registry URL plus a fallback is longer than a line. */
+figure { margin: 0 0 1.25rem; border: 1px solid var(--line); border-radius: .5rem; }
+figcaption {
+  font-family: var(--mono);
+  font-size: .8rem;
+  color: var(--muted);
+  background: var(--soft);
+  padding: .4rem .9rem;
+  border-bottom: 1px solid var(--line);
+  border-radius: .5rem .5rem 0 0;
+}
+figure pre { margin: 0; padding: .9rem; }
+pre code {
+  display: block;
+  background: none;
+  padding: 0 0 0 1.6em;
+  font-size: .85rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  text-indent: -1.6em;
+}
+
 table { border-collapse: collapse; width: 100%; }
-th, td { text-align: left; padding: .4rem .6rem .4rem 0; border-bottom: 1px solid color-mix(in srgb, currentColor 15%, transparent); }
-td.version { font-family: ui-monospace, monospace; font-size: .9rem; }
-.note { font-size: .9rem; opacity: .8; }
+th {
+  font-size: .75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--muted);
+  text-align: left;
+  padding: 0 .75rem .4rem 0;
+  border-bottom: 1px solid var(--line);
+}
+td { padding: .6rem .75rem; border-bottom: 1px solid var(--line); vertical-align: baseline; }
+td:first-child, th:first-child { padding-left: 0; }
+td:last-child, th:last-child { padding-right: 0; text-align: right; }
+td.version { font-family: var(--mono); font-size: .85rem; overflow-wrap: anywhere; }
+td.built { color: var(--muted); white-space: nowrap; }
+.latest {
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: .7rem;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--muted);
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  padding: .05rem .45rem;
+  margin-left: .45rem;
+  white-space: nowrap;
+}
+.note { color: var(--muted); font-size: .95rem; }
 </style>
 </head>
 <body>
+<header>
 <h1>{{.Module}} pre-release registry</h1>
-
-<p>A Bazel registry serving one <code>{{.Module}}</code> version per commit to the
-main branch, so a change can be tried out before it is released.
-{{if .Repository}}Sources: <a href="{{.Repository}}">{{.Repository}}</a>.{{end}}</p>
+<p>Every commit to the main branch is published here as a <code>{{.Module}}</code>
+version, so you can use a change before it ships in a release.{{if .Repository}}
+<a href="{{.Repository}}">Source</a>.{{end}}</p>
+</header>
 
 <h2>Using it</h2>
-<p>Add the registry, keeping the Bazel Central Registry as the fallback for
-everything else:</p>
+<p>Add this registry, with the Bazel Central Registry second so that everything
+else still resolves:</p>
+<figure>
+<figcaption>.bazelrc</figcaption>
 <pre><code>common --registry={{.RegistryURL}} --registry=https://bcr.bazel.build</code></pre>
-<p>Then depend on a version from the table below:</p>
+</figure>
+<p>Then pick a version from the list below:</p>
+<figure>
+<figcaption>MODULE.bazel</figcaption>
 <pre><code>bazel_dep(name = "{{.Module}}", version = "{{.Latest}}")</code></pre>
+</figure>
 
 <h2 id="versions">Versions</h2>
 <table>
+<thead>
 <tr><th>Version</th><th>Built</th><th>Commit</th></tr>
-{{- range .Versions}}
+</thead>
+<tbody>
+{{- range $index, $version := .Versions}}
 <tr>
-<td class="version">{{.Version}}</td>
-<td>{{.Date}}</td>
-<td>{{if .CommitURL}}<a href="{{.CommitURL}}"><code>{{.Commit}}</code></a>{{else if .Commit}}<code>{{.Commit}}</code>{{end}}</td>
+<td class="version">{{$version.Version}}{{if eq $index 0}}<span class="latest">latest</span>{{end}}</td>
+<td class="built">{{$version.Date}}</td>
+<td>{{if $version.CommitURL}}<a href="{{$version.CommitURL}}"><code>{{$version.Commit}}</code></a>{{else if $version.Commit}}<code>{{$version.Commit}}</code>{{end}}</td>
 </tr>
 {{- end}}
+</tbody>
 </table>
 
-<h2>What you get</h2>
-<p class="note">Each version is the module source as of one commit, carrying a
-prebuilt lockfile that fetches the <code>img</code> tool from
-<code>{{.Artifact}}</code> as an OCI blob, so no tool is built from source.
-Versions are pre-releases of the next patch version: they resolve above the last
-release and below the next one. Nothing here is a supported release -- a version
-may be rewritten by a re-run of the build that produced it, and no version is
-ever removed.</p>
+<h2>What a version is</h2>
+<p class="note">The module source at one commit, plus a lockfile that downloads
+the <code>img</code> tool from <code>{{.Artifact}}</code> instead of building it.
+There is nothing else to set up.</p>
+<p class="note">The numbers are pre-releases of the next patch version, so they
+sort above the last release and below the next one. These are not releases: a
+version can be rewritten if its build is re-run, and none are ever deleted.</p>
 </body>
 </html>
 `))


### PR DESCRIPTION
The registry line is longer than the page is wide, and it was in a box that scrolled sideways, so the half of it naming the fallback registry was hidden. Neither snippet said which file it belongs in either, which is the one thing a reader needs to act on them.

Snippets now wrap instead of scrolling, with the continuation line indented, and each carries the name of its file:

```
┌─────────────────────────────────────────────────────────┐
│ .bazelrc                                                │
├─────────────────────────────────────────────────────────┤
│ common --registry=https://bazel-contrib.github.io/...   │
│     --registry=https://bcr.bazel.build                  │
└─────────────────────────────────────────────────────────┘
```

The rest is a table that reads as one, a tag on the newest version, and secondary text that looks secondary. The page copy is plainer too.
