### PR TITLE
feat(deploy): share blob homes across the deploys of one process

### DIFF
--- a/img_tool/cmd/deploy/BUILD.bazel
+++ b/img_tool/cmd/deploy/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "deploy",
     srcs = [
+        "dedup_locations.go",
         "dedup_push.go",
         "deploy.go",
         "persistentworker.go",
@@ -42,6 +43,7 @@ go_test(
     srcs = [
         "casblobcache_test.go",
         "dedup_cascache_test.go",
+        "dedup_locations_test.go",
         "dedup_push_test.go",
         "dedup_registry_test.go",
         "progress_test.go",

--- a/img_tool/cmd/deploy/dedup_locations.go
+++ b/img_tool/cmd/deploy/dedup_locations.go
@@ -1,0 +1,306 @@
+package deploy
+
+import (
+	"context"
+	"sync"
+)
+
+// The process-wide blob location cache.
+//
+// planDedupPush plans one deploy: it knows every destination that deploy writes to,
+// so it can pick one home repository per (registry, blob) and cross-mount the blob
+// into the rest. In persistent worker mode that is not the whole picture. Each work
+// request carries its own deploy manifest and is planned on its own, so two requests
+// that share a layer would each pick a home among their own repositories and upload
+// the layer there -- exactly the duplicate upload the strategy exists to remove, just
+// spread across requests instead of across repositories.
+//
+// blobLocations is what makes those requests agree: one cache for the process,
+// holding the repository this process has put a blob in, or is putting it in right
+// now. The first request to need a blob in a registry claims a home for it and
+// publishes it; every later request mounts from that same home instead of choosing
+// its own.
+//
+// Keyed by (registry, digest) rather than by repository, because that is the scope a
+// home is unique in: two requests must not pick different homes for the same blob in
+// the same registry. Mounts still never cross registries -- every decision stays
+// inside one registry, as it does within a single deploy.
+//
+// Nothing here survives the process. A restarted worker refills the cache from the
+// registry itself: the existence check finds the manifests the previous process
+// pushed, and their layers are mountable out of those repositories for free.
+
+// blobLocations is the process-wide blob location cache described above. A nil
+// *blobLocations is usable and remembers nothing, which is what the deploys that
+// upload no blobs at all (Settings.ForbidLayerPush) pass.
+//
+// Every operation takes the same mutex for its whole decision, so concurrent requests
+// resolving the same blob cannot create two homes for it: whoever gets the lock first
+// claims, the rest observe that claim.
+//
+// It only ever grows, by one digest and one repository name per distinct blob the
+// process pushes -- a few megabytes for a worker that pushes thousands of images, next
+// to nothing beside the blobs themselves.
+type blobLocations struct {
+	mu sync.Mutex
+	// present holds the homes this process knows to hold the blob: it uploaded it
+	// there, or the registry confirmed a manifest referencing it in that repository.
+	// The mount kind travels with the home, because it is what decides whether a
+	// refused mount fails the push or falls back to uploading the bytes.
+	present map[blobKey]blobMount
+	// inflight holds the homes a request has claimed and is uploading to (or is about
+	// to). A request that finds one here mounts from that home and schedules the same
+	// upload itself rather than waiting for the claimer -- see resolve.
+	inflight map[blobKey]blobMount
+	// flights holds the uploads happening right now, so that two requests scheduling
+	// the same one wait for it instead of sending the blob twice -- see uploadOnce.
+	//
+	// Keyed one level finer than the maps above: a home is picked per (registry, blob),
+	// but an upload happens to a repository, and the same blob legitimately goes to a
+	// different repository in another registry at the same time.
+	flights map[uploadTarget]*uploadFlight
+	// incremental records that more destinations may still arrive, i.e. that this is a
+	// persistent worker rather than a one-shot deploy. It is what makes claiming a home
+	// for a blob only one destination needs worth an upload phase: there is nothing to
+	// cross-mount into today, but publishing the home lets the next work request mount
+	// from it instead of uploading the blob into its own repository.
+	incremental bool
+}
+
+// newBlobLocations returns an empty cache. incremental is true for the persistent
+// worker, whose requests arrive one at a time, and false for a one-shot deploy,
+// which plans every destination it will ever have in one go.
+func newBlobLocations(incremental bool) *blobLocations {
+	return &blobLocations{
+		present:     make(map[blobKey]blobMount),
+		inflight:    make(map[blobKey]blobMount),
+		flights:     make(map[uploadTarget]*uploadFlight),
+		incremental: incremental,
+	}
+}
+
+// blobResolution is where a blob is mounted from during the manifest push, and what
+// the request that asked has to do about it first.
+type blobResolution struct {
+	blobMount
+	// upload records that this request has to upload the blob to blobMount.repository
+	// before the manifest push mounts it from there.
+	upload bool
+	// joined records that another request claimed this home first and is uploading the
+	// same blob to it. The upload above is then a duplicate scheduled so that this
+	// request does not have to wait for a request it knows nothing about, and its
+	// failure is not fatal (see uploadDedupBlobs).
+	joined bool
+	// cached records that the home came out of the cache rather than from this
+	// request's own signals, which is what the report counts separately.
+	cached bool
+}
+
+// resolve decides where a blob is served from, claiming a home for it in the cache
+// when nothing knows one yet.
+//
+// The arguments are this request's own signals for one (registry, blob), all scoped
+// to that registry the way resolveBlobMount needs them: the repositories that need
+// the blob, the ones whose manifests the registry just confirmed, the repository the
+// build recorded the layer as coming from, and the build-time staging repository.
+//
+// The cache is consulted first, and in the order the two maps cost:
+//
+//  1. A home in present needs nothing: the blob is there, so this request only
+//     mounts it. When this process uploaded it, the home is mount-only, so a refused
+//     mount fails the push rather than quietly uploading the blob again.
+//  2. A home in inflight is one another request claimed and is uploading to. This
+//     request mounts from the same home and schedules the same upload, which is what
+//     keeps the phases local: no request ever waits on another request's completion,
+//     and the mount source is in place by the end of *this* request's upload phase.
+//     Each request uploads through a pusher of its own, so the worst case is the blob's
+//     bytes crossing the wire twice -- but go-containerregistry HEADs a blob before
+//     uploading it, so unless the two windows really overlap the second one costs a
+//     request rather than a transfer, and either way the same repository ends up
+//     holding it once.
+//  3. Otherwise the request decides for itself (resolveBlobMount) and publishes the
+//     answer: a home it uploads to is claimed in inflight until the upload succeeds,
+//     anything else -- a repository the registry confirmed, an upstream repository --
+//     goes straight into present for later requests to mount from.
+func (l *blobLocations) resolve(key blobKey, needing, confirmed map[string]struct{}, upstream, blobRepository string) blobResolution {
+	if l == nil {
+		mount := resolveBlobMount(needing, confirmed, upstream, blobRepository, false)
+		return blobResolution{blobMount: mount, upload: mount.kind == mountFromUpload}
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if home, found := l.present[key]; found {
+		return blobResolution{blobMount: home, cached: true}
+	}
+	if home, found := l.inflight[key]; found {
+		return blobResolution{blobMount: home, upload: true, joined: true, cached: true}
+	}
+
+	mount := resolveBlobMount(needing, confirmed, upstream, blobRepository, l.incremental)
+	switch {
+	case mount.repository == "":
+		return blobResolution{}
+	case mount.kind == mountFromUpload:
+		l.inflight[key] = mount
+		return blobResolution{blobMount: mount, upload: true}
+	default:
+		l.present[key] = mount
+		return blobResolution{blobMount: mount}
+	}
+}
+
+// promote records that the blob is now in the home repository, so that the requests
+// after this one mount it from there instead of uploading it again. It is called per
+// blob as its upload succeeds, not once for the whole upload phase, so a request
+// that fails halfway still publishes what it did put in place.
+//
+// The home is recorded as one this process uploaded to, which is the strongest of the
+// mount kinds: the requests that mount from it fail loudly if the registry refuses,
+// rather than quietly uploading the blob a second time.
+func (l *blobLocations) promote(key blobKey, home string) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.present[key] = blobMount{repository: home, kind: mountFromUpload}
+	if inflight, found := l.inflight[key]; found && inflight.repository == home {
+		delete(l.inflight, key)
+	}
+}
+
+// abandon withdraws a claim whose upload failed, so that the next request picks a
+// home of its own rather than mounting from a repository the blob never reached. The
+// home is checked because the claim may have been withdrawn and re-made in the
+// meantime; a claim another request has already promoted is left alone.
+func (l *blobLocations) abandon(key blobKey, home string) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if inflight, found := l.inflight[key]; found && inflight.repository == home {
+		delete(l.inflight, key)
+	}
+}
+
+// seedConfirmed publishes the repositories the existence check confirmed hold a
+// blob, for the (registry, blob) pairs this request had no use for: the layers of a
+// manifest the registry already serves, which this deploy therefore does not push
+// anywhere. They cost nothing to remember and are exactly what a later work request
+// pushing a sibling image needs -- a repository to mount the shared layers out of,
+// with no upload and no HEAD of its own.
+//
+// Homes already in the cache are left alone: a claim in flight must not be replaced
+// by a different repository, and a home this process uploaded to is no worse than a
+// confirmed one.
+func (l *blobLocations) seedConfirmed(confirmed map[blobKey]map[string]struct{}) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for key, repositories := range confirmed {
+		if _, found := l.present[key]; found {
+			continue
+		}
+		if _, found := l.inflight[key]; found {
+			continue
+		}
+		// The smallest repository rather than an arbitrary one, so that two processes
+		// looking at the same registry state agree on the home (see smallestRepository).
+		home, found := smallestRepository(repositories)
+		if !found {
+			continue
+		}
+		l.present[key] = blobMount{repository: home, kind: mountFromConfirmed}
+	}
+}
+
+// uploadTarget is one blob in one repository of one registry: the destination a blob
+// upload has, and the granularity two uploads are the same piece of work at.
+type uploadTarget struct {
+	registry   string
+	repository string
+	digest     string
+}
+
+// uploadFlight is one upload of a blob to a repository that a goroutine somewhere in
+// this process is performing right now. err is the attempt's result and is only read
+// after done is closed, which the goroutine performing it does last.
+type uploadFlight struct {
+	done chan struct{}
+	err  error
+	// waiters counts the callers that found this flight and waited for it -- the
+	// duplicate uploads it saved. Read and written under blobLocations.mu.
+	waiters int
+}
+
+// uploadOnce uploads a blob to a repository at most once at a time for the whole
+// process: whoever registers the flight first performs it, and everyone else waits
+// for that attempt rather than sending the same bytes to the same place. Two
+// requests that share a home are the reason it exists -- a joined upload (see
+// resolve) is the same upload as the claimer's, and each request pushes through a
+// remote.Pusher of its own, so go-containerregistry's own per-repository
+// deduplication cannot see the other one.
+//
+// The wait is bounded by the attempt it waits for, and never by an attempt that may
+// never happen: a flight only exists while a goroutine is inside upload, and the
+// goroutine that registered it always publishes a result. ctx cuts the wait short if
+// the caller gives up first, and only the caller's own ctx does -- the leader's
+// cancellation surfaces as a failed attempt, which the waiter then retries with a
+// context of its own rather than adopting an error from a request it has nothing to
+// do with.
+//
+// On failure the waiter goes round: nobody is uploading the blob any more, so it
+// registers a flight of its own and uploads it. Each caller therefore performs at
+// most one attempt -- exactly what it would have done alone -- and the retries are
+// bounded by the number of callers waiting on the same blob.
+//
+// Deadlock needs a cycle, and there is none to build: a goroutine holds no flight
+// while waiting for another (uploadDedupBlobs gives each upload a goroutine of its
+// own), and two goroutines of the same request never share a target, so a waiter's
+// leader is always in another request and cannot be starved by the waiter's own
+// concurrency limit.
+func (l *blobLocations) uploadOnce(ctx context.Context, target uploadTarget, upload func() error) error {
+	if l == nil {
+		return upload()
+	}
+	for {
+		l.mu.Lock()
+		if flight, found := l.flights[target]; found {
+			flight.waiters++
+			l.mu.Unlock()
+			select {
+			case <-flight.done:
+				if flight.err == nil {
+					// Someone else uploaded the blob for us: it is in the repository, and no
+					// bytes left this request at all.
+					return nil
+				}
+				continue
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		flight := &uploadFlight{done: make(chan struct{})}
+		l.flights[target] = flight
+		l.mu.Unlock()
+
+		// Publishing the result is the last thing this attempt does, and deferred so that
+		// it happens however upload returns: a caller waiting for a flight that never
+		// lands would wait for as long as its context allows. Withdrawing the flight
+		// before closing done means a caller arriving after this starts an attempt of its
+		// own rather than waiting for one that is already over.
+		defer func() {
+			l.mu.Lock()
+			delete(l.flights, target)
+			l.mu.Unlock()
+			close(flight.done)
+		}()
+		flight.err = upload()
+		return flight.err
+	}
+}

--- a/img_tool/cmd/deploy/dedup_locations_test.go
+++ b/img_tool/cmd/deploy/dedup_locations_test.go
@@ -1,0 +1,511 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests cover the process-wide blob location cache: the part of the
+// deduplicated push that makes two deploys planned separately -- two work requests
+// of the persistent worker -- upload a blob they share only once, and cross-mount it
+// into the second one's repository instead.
+
+// The registry and blob every test below resolves.
+const locationsRegistry = "reg.example.com"
+
+// repositorySet is the "repositories in this registry that need the blob" argument
+// of blobLocations.resolve.
+func repositorySet(repositories ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(repositories))
+	for _, repository := range repositories {
+		out[repository] = struct{}{}
+	}
+	return out
+}
+
+// sharedKey is the (registry, blob) pair the tests resolve.
+func sharedKey() blobKey {
+	return blobKey{registry: locationsRegistry, digest: sharedLayerDigest}
+}
+
+// TestBlobLocationsSequentialRequestsMountFromTheFirstHome is the sequential
+// persistent worker: the first request to need a blob claims a home, uploads it and
+// publishes it, so the next request -- which knows nothing about the first -- mounts
+// it from there instead of uploading it into its own repository.
+func TestBlobLocationsSequentialRequestsMountFromTheFirstHome(t *testing.T) {
+	locations := newBlobLocations(true)
+	key := sharedKey()
+
+	// Request A, pushing team/service-a only. There is nothing to cross-mount into
+	// yet, but the home is settled and published for whoever comes next.
+	first := locations.resolve(key, repositorySet("team/service-a"), nil, "", "")
+	if first.repository != "team/service-a" || first.kind != mountFromUpload {
+		t.Fatalf("first resolution = %+v, want team/service-a as an uploaded home", first)
+	}
+	if !first.upload || first.joined || first.cached {
+		t.Errorf("first resolution = %+v, want a fresh claim this request uploads", first)
+	}
+	locations.promote(key, first.repository)
+
+	// Request B, pushing team/service-b: the blob is already in team/service-a, so it
+	// is mounted from there and nothing is uploaded.
+	second := locations.resolve(key, repositorySet("team/service-b"), nil, "", "")
+	if second.repository != "team/service-a" {
+		t.Errorf("second resolution = %+v, want the home the first request published", second)
+	}
+	if second.upload {
+		t.Error("the second request uploads the blob, but the first one already put it in the home repository")
+	}
+	if !second.cached {
+		t.Error("the second resolution is not reported as coming from the cache")
+	}
+	// This process put the blob there, so the layer is mount-only: a refused mount is
+	// something to hear about rather than paper over with a full re-upload.
+	if second.kind != mountFromUpload {
+		t.Errorf("second resolution kind = %v, want the mount-only kind", second.kind)
+	}
+	if _, found := locations.inflight[key]; found {
+		t.Error("the claim is still in flight after being promoted")
+	}
+}
+
+// TestBlobLocationsConcurrentRequestsShareOneHome is the concurrent case: several
+// requests resolve the same blob at once, each with a repository of its own. Exactly
+// one of them claims the home; the rest mount from that same home and schedule the
+// same upload rather than waiting for a request they know nothing about.
+func TestBlobLocationsConcurrentRequestsShareOneHome(t *testing.T) {
+	locations := newBlobLocations(true)
+	key := sharedKey()
+
+	const requests = 8
+	resolutions := make([]blobResolution, requests)
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+	for i := range requests {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			start.Wait()
+			resolutions[i] = locations.resolve(key, repositorySet(repositoryFor(i)), nil, "", "")
+		}()
+	}
+	start.Done()
+	done.Wait()
+
+	claims := 0
+	home := resolutions[0].repository
+	for i, resolution := range resolutions {
+		if resolution.repository != home {
+			t.Fatalf("request %d resolved to %q, want the single home %q: concurrent requests must not pick two homes", i, resolution.repository, home)
+		}
+		if !resolution.upload {
+			t.Errorf("request %d does not upload the blob, but no request has finished uploading it yet", i)
+		}
+		if !resolution.joined {
+			claims++
+		}
+	}
+	if claims != 1 {
+		t.Errorf("%d requests claimed the home, want exactly 1 (the rest join its upload)", claims)
+	}
+	if !hasRepository(resolutions, home) {
+		t.Errorf("home %q is not one of the requests' own repositories", home)
+	}
+	// Every one of them uploads to the home, so any of them succeeding is enough for
+	// the mount, and the first to finish publishes it.
+	locations.promote(key, home)
+	if got := locations.resolve(key, repositorySet("team/late"), nil, "", ""); got.upload || got.repository != home {
+		t.Errorf("a later request resolved to %+v, want a mount from %q with no upload", got, home)
+	}
+}
+
+// repositoryFor names the repository the i-th concurrent request pushes to.
+func repositoryFor(i int) string {
+	return "team/service-" + string(rune('a'+i))
+}
+
+// hasRepository reports whether any resolution's own repository is home.
+func hasRepository(resolutions []blobResolution, home string) bool {
+	for i := range resolutions {
+		if repositoryFor(i) == home {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBlobLocationsAbandonedClaimIsClaimedAgain verifies that a claim whose upload
+// failed is withdrawn: the next request picks a home of its own rather than mounting
+// from a repository the blob never reached.
+func TestBlobLocationsAbandonedClaimIsClaimedAgain(t *testing.T) {
+	locations := newBlobLocations(true)
+	key := sharedKey()
+
+	first := locations.resolve(key, repositorySet("team/service-a"), nil, "", "")
+	locations.abandon(key, first.repository)
+
+	second := locations.resolve(key, repositorySet("team/service-b"), nil, "", "")
+	if second.repository != "team/service-b" {
+		t.Errorf("second resolution = %+v, want a home of its own after the first claim was abandoned", second)
+	}
+	if second.joined || !second.upload {
+		t.Errorf("second resolution = %+v, want a fresh claim it uploads itself", second)
+	}
+
+	// A request that joined someone else's claim must not withdraw it when its own
+	// duplicate upload fails: the claimer may still be uploading successfully.
+	locations.abandon(key, "team/service-a")
+	if home, found := locations.inflight[key]; !found || home.repository != "team/service-b" {
+		t.Errorf("inflight home = %+v (found %v), want team/service-b to still own the claim", home, found)
+	}
+	// Nor may a promotion by the claimer be undone by a stale abandon.
+	locations.promote(key, "team/service-b")
+	locations.abandon(key, "team/service-b")
+	if home, found := locations.present[key]; !found || home.repository != "team/service-b" {
+		t.Errorf("present home = %+v (found %v), want the promoted home to survive", home, found)
+	}
+}
+
+// TestBlobLocationsKeepsTheSofterSourcesSoft verifies that the cache carries the
+// mount kind, not just the repository: a home this process only inferred -- a
+// repository whose manifest the registry serves, an upstream repository -- keeps the
+// ordinary byte-upload fallback for every request that mounts from it, while a home
+// this process uploaded to is mount-only.
+func TestBlobLocationsKeepsTheSofterSourcesSoft(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		confirmed map[string]struct{}
+		upstream  string
+		wantHome  string
+		wantKind  mountKind
+	}{
+		{
+			name:      "a repository the registry serves",
+			confirmed: repositorySet("team/service-z"),
+			wantHome:  "team/service-z",
+			wantKind:  mountFromConfirmed,
+		},
+		{
+			name:     "an upstream repository",
+			upstream: "library/base",
+			wantHome: "library/base",
+			wantKind: mountFromUpstream,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			locations := newBlobLocations(true)
+			key := sharedKey()
+
+			first := locations.resolve(key, repositorySet("team/service-a"), tc.confirmed, tc.upstream, "")
+			if first.repository != tc.wantHome || first.kind != tc.wantKind {
+				t.Fatalf("first resolution = %+v, want %s as %v", first, tc.wantHome, tc.wantKind)
+			}
+			if first.upload {
+				t.Error("the blob is uploaded, but it is already in the mount source")
+			}
+			// Published without an upload phase: nothing has to happen for the next
+			// request to mount from the same place.
+			second := locations.resolve(key, repositorySet("team/service-b"), nil, "", "")
+			if second.repository != tc.wantHome || second.kind != tc.wantKind || second.upload {
+				t.Errorf("second resolution = %+v, want the same %v mount with no upload", second, tc.wantKind)
+			}
+			if !second.cached {
+				t.Error("the second resolution is not reported as coming from the cache")
+			}
+		})
+	}
+}
+
+// TestBlobLocationsOneShotLeavesLoneDestinationsAlone verifies that a one-shot
+// deploy still behaves as it did before there was a cache: a blob only one
+// repository needs is left to the ordinary manifest push, because the plan is the
+// whole picture and there is no later request to publish a home for.
+func TestBlobLocationsOneShotLeavesLoneDestinationsAlone(t *testing.T) {
+	locations := newBlobLocations(false)
+	key := sharedKey()
+
+	lone := locations.resolve(key, repositorySet("team/service-a"), nil, "", "")
+	if lone.repository != "" || lone.upload {
+		t.Errorf("resolution = %+v, want none: one destination has nothing to cross-mount into", lone)
+	}
+	if len(locations.inflight) != 0 || len(locations.present) != 0 {
+		t.Errorf("cache recorded %v / %v, want nothing for a blob it did not plan", locations.present, locations.inflight)
+	}
+
+	// Two destinations are deduplicated as ever, and the home is published -- which a
+	// one-shot deploy has no second plan to use, but costs nothing either.
+	shared := locations.resolve(key, repositorySet("team/service-b", "team/service-a"), nil, "", "")
+	if shared.repository != "team/service-a" || !shared.upload || shared.joined {
+		t.Errorf("resolution = %+v, want the first repository alphabetically as a fresh claim", shared)
+	}
+}
+
+// TestBlobLocationsSeedConfirmedPublishesUnusedRepositories verifies the free half
+// of the cache: the layers of a manifest the registry already serves are recorded as
+// available from that repository even though the deploy that checked has no use for
+// them, because the next work request pushing a sibling image does.
+func TestBlobLocationsSeedConfirmedPublishesUnusedRepositories(t *testing.T) {
+	locations := newBlobLocations(true)
+	key := sharedKey()
+	other := blobKey{registry: locationsRegistry, digest: serviceALayerDiges}
+
+	// A claim in flight must not be replaced by a confirmed repository: the requests
+	// that joined it are uploading to the home it names.
+	claimed := locations.resolve(other, repositorySet("team/service-a"), nil, "", "")
+	locations.seedConfirmed(map[blobKey]map[string]struct{}{
+		key:   repositorySet("team/service-z", "team/service-c"),
+		other: repositorySet("team/service-z"),
+	})
+
+	if home, found := locations.present[key]; !found || home.repository != "team/service-c" {
+		t.Errorf("seeded home = %+v (found %v), want the first confirmed repository alphabetically", home, found)
+	}
+	if home := locations.present[key]; home.kind != mountFromConfirmed {
+		t.Errorf("seeded kind = %v, want the confirmed kind, which keeps the byte-upload fallback", home.kind)
+	}
+	if home, found := locations.inflight[other]; !found || home.repository != claimed.repository {
+		t.Errorf("in-flight home = %+v (found %v), want the claim to survive seeding", home, found)
+	}
+	if _, found := locations.present[other]; found {
+		t.Error("a blob with a claim in flight was also published as present")
+	}
+}
+
+// TestBlobLocationsNilPlansOnItsOwn verifies the nil cache the deploys that upload
+// nothing use (Settings.ForbidLayerPush): every operation works and every decision
+// comes from the request's own signals.
+func TestBlobLocationsNilPlansOnItsOwn(t *testing.T) {
+	var locations *blobLocations
+	key := sharedKey()
+
+	first := locations.resolve(key, repositorySet("team/service-b", "team/service-a"), nil, "", "")
+	if first.repository != "team/service-a" || !first.upload || first.cached {
+		t.Errorf("resolution = %+v, want the plain per-deploy answer", first)
+	}
+	// Nothing is remembered, so a second deploy decides for itself again.
+	locations.promote(key, first.repository)
+	second := locations.resolve(key, repositorySet("team/service-c"), nil, "", "")
+	if second.repository != "" {
+		t.Errorf("resolution = %+v, want none: a nil cache remembers nothing", second)
+	}
+	locations.abandon(key, first.repository)
+	locations.seedConfirmed(map[blobKey]map[string]struct{}{key: repositorySet("team/service-z")})
+
+	// An upload still happens, it is just never deduplicated against anything.
+	uploads := 0
+	if err := locations.uploadOnce(context.Background(), sharedTarget("team/service-a"), func() error {
+		uploads++
+		return nil
+	}); err != nil || uploads != 1 {
+		t.Errorf("uploadOnce = %v after %d uploads, want one upload and no error", err, uploads)
+	}
+}
+
+// sharedTarget is the upload destination the flight tests use: the shared blob in a
+// repository of the test registry.
+func sharedTarget(repository string) uploadTarget {
+	return uploadTarget{registry: locationsRegistry, repository: repository, digest: sharedLayerDigest}
+}
+
+// waitForWaiters blocks until at least want callers are waiting for the flight to
+// target, so a test can be sure the callers piled up behind one attempt rather than
+// arriving one after another.
+func waitForWaiters(t *testing.T, locations *blobLocations, target uploadTarget, want int) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		locations.mu.Lock()
+		got := 0
+		if flight, found := locations.flights[target]; found {
+			got = flight.waiters
+		}
+		locations.mu.Unlock()
+		if got >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%d callers are waiting for the upload of %+v, want %d: they are not sharing one attempt", got, target, want)
+		}
+		time.Sleep(50 * time.Microsecond)
+	}
+}
+
+// TestUploadOnceUploadsABlobToARepositoryOnceAtATime is what the flights exist for:
+// several deploys of this process scheduling the same upload must not send the same
+// blob to the same repository at the same time. Whichever gets there first performs
+// it; the rest wait for that attempt and send nothing.
+//
+// Each deploy pushes through a remote.Pusher of its own, so go-containerregistry's
+// per-repository deduplication cannot see the others -- without this they would all
+// HEAD the blob, all miss, and all upload it.
+func TestUploadOnceUploadsABlobToARepositoryOnceAtATime(t *testing.T) {
+	locations := newBlobLocations(true)
+	target := sharedTarget("team/service-a")
+
+	const callers = 8
+	var attempts, concurrent atomic.Int32
+	inUpload := make(chan struct{})
+	release := make(chan struct{})
+	var announce sync.Once
+	upload := func() error {
+		attempts.Add(1)
+		if concurrent.Add(1) > 1 {
+			t.Error("two goroutines uploaded the same blob to the same repository at once")
+		}
+		defer concurrent.Add(-1)
+		announce.Do(func() { close(inUpload) })
+		<-release
+		return nil
+	}
+
+	errs := make([]error, callers)
+	var done sync.WaitGroup
+	for i := range callers {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			errs[i] = locations.uploadOnce(context.Background(), target, upload)
+		}()
+	}
+	// An attempt is in flight, and every other caller is behind it rather than sending
+	// the blob a second time.
+	<-inUpload
+	waitForWaiters(t, locations, target, callers-1)
+	close(release)
+	done.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("caller %d: %v", i, err)
+		}
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("the blob was uploaded %d times for %d callers, want exactly 1", got, callers)
+	}
+	if len(locations.flights) != 0 {
+		t.Errorf("%d flights are still registered, want none once every upload has finished", len(locations.flights))
+	}
+}
+
+// TestUploadOnceRetriesAfterAFailedAttempt verifies the failure half of the contract:
+// a caller that waited for an attempt which failed is not handed that failure, because
+// the blob still has to get there. It takes the upload over itself, and only its own
+// attempt decides its result.
+//
+// Which is also what keeps one work request's cancellation out of another's: a
+// cancelled upload is just a failed attempt to whoever was waiting for it.
+func TestUploadOnceRetriesAfterAFailedAttempt(t *testing.T) {
+	locations := newBlobLocations(true)
+	target := sharedTarget("team/service-a")
+	failure := errors.New("upload refused")
+
+	var attempts atomic.Int32
+	inUpload := make(chan struct{})
+	release := make(chan struct{})
+	leaderErr := make(chan error, 1)
+	go func() {
+		leaderErr <- locations.uploadOnce(context.Background(), target, func() error {
+			attempts.Add(1)
+			close(inUpload)
+			<-release
+			return failure
+		})
+	}()
+	<-inUpload
+
+	waiterErr := make(chan error, 1)
+	go func() {
+		waiterErr <- locations.uploadOnce(context.Background(), target, func() error {
+			attempts.Add(1)
+			return nil
+		})
+	}()
+	close(release)
+
+	if err := <-leaderErr; !errors.Is(err, failure) {
+		t.Errorf("the failed attempt returned %v, wants its own error %v", err, failure)
+	}
+	if err := <-waiterErr; err != nil {
+		t.Errorf("the waiting caller returned %v, want it to have retried and succeeded", err)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Errorf("the blob was uploaded %d times, want 2: the failed attempt and the retry", got)
+	}
+}
+
+// TestUploadOnceSerializesNothingElse verifies the flights are per destination: two
+// uploads that are not the same piece of work run at the same time, even when they
+// are the same blob in a different repository -- a registry with per-repository blob
+// storage needs both.
+func TestUploadOnceSerializesNothingElse(t *testing.T) {
+	locations := newBlobLocations(true)
+	targets := []uploadTarget{
+		sharedTarget("team/service-a"),
+		sharedTarget("team/service-b"),
+		{registry: locationsRegistry, repository: "team/service-a", digest: serviceALayerDiges},
+		{registry: "other.example.com", repository: "team/service-a", digest: sharedLayerDigest},
+	}
+
+	// Each upload waits for every other one to have started, so anything serialized
+	// here would never finish.
+	var inUpload sync.WaitGroup
+	inUpload.Add(len(targets))
+	var done sync.WaitGroup
+	finished := make(chan struct{})
+	for _, target := range targets {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			if err := locations.uploadOnce(context.Background(), target, func() error {
+				inUpload.Done()
+				inUpload.Wait()
+				return nil
+			}); err != nil {
+				t.Errorf("uploading %+v: %v", target, err)
+			}
+		}()
+	}
+	go func() { done.Wait(); close(finished) }()
+
+	select {
+	case <-finished:
+	case <-time.After(30 * time.Second):
+		t.Fatal("uploads to different destinations were serialized: they never all ran at once")
+	}
+}
+
+// TestUploadOnceStopsWaitingWhenTheCallerGivesUp verifies a caller is never stuck
+// behind another request's upload: its own context ends the wait, and it reports that
+// rather than the other request's outcome.
+func TestUploadOnceStopsWaitingWhenTheCallerGivesUp(t *testing.T) {
+	locations := newBlobLocations(true)
+	target := sharedTarget("team/service-a")
+
+	inUpload := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+	leaderErr := make(chan error, 1)
+	go func() {
+		leaderErr <- locations.uploadOnce(context.Background(), target, func() error {
+			close(inUpload)
+			<-release
+			return nil
+		})
+	}()
+	<-inUpload
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := locations.uploadOnce(ctx, target, func() error {
+		t.Error("the caller uploaded the blob although its context was already cancelled")
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("uploadOnce = %v, want the caller's own context error", err)
+	}
+}

--- a/img_tool/cmd/deploy/dedup_push.go
+++ b/img_tool/cmd/deploy/dedup_push.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 
@@ -52,6 +53,12 @@ import (
 // Phase 5 is the ordinary manifest push, unchanged. A blob headed for a single
 // repository is left out of all of this, so a single-image deploy behaves exactly
 // as it would with the strategy off.
+//
+// One deploy is the whole picture for the phases above, but not for the process: the
+// persistent worker plans each work request on its own, so the home a blob is
+// uploaded to is settled in a cache the whole process shares (dedup_locations.go).
+// That is what keeps two requests sharing a layer from uploading it into a repository
+// each -- and what makes the single-repository case above worth planning there.
 
 // Values of the --deduplicated-push override. Empty inherits the deploy
 // manifest's deduplicated_push setting.
@@ -159,6 +166,10 @@ type dedupOptions struct {
 	// they were pushed at build time).
 	forbidUpload  bool
 	pushTransport http.RoundTripper
+	// locations is the process-wide blob location cache, shared by every deploy this
+	// process plans (see dedup_locations.go). Nil plans this deploy on its own, which
+	// is what the deploys that upload nothing do.
+	locations *blobLocations
 }
 
 // destination is one manifest this deploy intends the registry to hold. Several
@@ -312,6 +323,11 @@ type dedupPlan struct {
 	// repository rather than by registry because two blobs in one registry can have
 	// different home repositories.
 	uploads map[string][]registryv1.Hash
+	// joined lists the blobs whose home another request claimed first and is uploading
+	// to. Their upload is in uploads too -- scheduled here rather than waited on -- but
+	// it is another request's upload we are duplicating, so failing it only costs this
+	// deploy the cross-mount (see uploadDedupBlobs).
+	joined map[blobKey]struct{}
 	// sources are the cross-mount sources for the layers of the still-missing
 	// manifests, keyed by registry and then by digest string.
 	sources map[string]map[string]api.CrossMountSource
@@ -327,9 +343,26 @@ type dedupPlan struct {
 	// repository the build recorded the layer as coming from. Neither needs an upload.
 	confirmed int
 	upstream  int
+	// cached counts the (registry, blob) pairs whose home came out of the process-wide
+	// location cache: a repository an earlier deploy in this process put the blob in,
+	// or one a concurrent deploy is putting it in (those are in joined as well).
+	cached int
+	// waitedMu guards waited, which the upload phase counts from its goroutines.
+	waitedMu sync.Mutex
+	// waited counts the uploads another deploy of this process was already performing,
+	// so this one waited for it and sent nothing (see blobLocations.uploadOnce).
+	waited int
 	// skipped counts the (registry, blob) pairs left to the ordinary push because
 	// they have nowhere to be mounted from (see resolveBlobMount).
 	skipped int
+}
+
+// countWaited records an upload another deploy of this process performed while this
+// one waited for it.
+func (p *dedupPlan) countWaited() {
+	p.waitedMu.Lock()
+	defer p.waitedMu.Unlock()
+	p.waited++
 }
 
 // uploadRepositories returns the repositories with blobs to upload, sorted.
@@ -365,8 +398,20 @@ func (p *dedupPlan) report(w io.Writer, opts dedupOptions) {
 		// Nothing was uploaded; the blobs were expected to be in place already.
 		verb = "expected in place"
 	}
-	fmt.Fprintf(w, "    deduplicated push: %d of %d manifests already present; %d blobs %s, %d mounted from a repository the registry serves, %d from an upstream repository; %d repository/blob pairs cross-mounted; %d layers left to the ordinary push\n",
-		p.present, p.total, uploaded, verb, p.confirmed, p.upstream, p.mounted, p.skipped)
+	// The uploads a concurrent deploy of this process was already performing, which
+	// this one waited for instead of repeating.
+	var shared string
+	if p.waited > 0 {
+		shared = fmt.Sprintf(" (%d of them by a concurrent deploy in this process)", p.waited)
+	}
+	// Only mentioned when the process-wide cache contributed something, which it
+	// cannot in a one-shot deploy planning every destination it has in one go.
+	var fromCache string
+	if p.cached > 0 {
+		fromCache = fmt.Sprintf(", %d from a repository another deploy in this process filled (%d uploaded alongside it)", p.cached, len(p.joined))
+	}
+	fmt.Fprintf(w, "    deduplicated push: %d of %d manifests already present; %d blobs %s%s, %d mounted from a repository the registry serves, %d from an upstream repository%s; %d repository/blob pairs cross-mounted; %d layers left to the ordinary push\n",
+		p.present, p.total, uploaded, verb, shared, p.confirmed, p.upstream, fromCache, p.mounted, p.skipped)
 }
 
 // blobKey is one blob in one registry: the granularity every mount decision is
@@ -378,10 +423,15 @@ type blobKey struct {
 
 // planDedupPush decides where each layer is mounted from and which blobs have to
 // be uploaded first. It performs no I/O: the registry's answers arrive as present.
-func planDedupPush(working []manifestDestination, present map[destination]bool, blobRepository string) (*dedupPlan, error) {
+//
+// locations is the process-wide location cache, which is what lets deploys planned
+// separately agree on one home per (registry, blob); it may be nil, and then this
+// deploy is planned entirely on its own signals.
+func planDedupPush(working []manifestDestination, present map[destination]bool, blobRepository string, locations *blobLocations) (*dedupPlan, error) {
 	plan := &dedupPlan{
 		total:     len(working),
 		uploads:   make(map[string][]registryv1.Hash),
+		joined:    make(map[blobKey]struct{}),
 		sources:   make(map[string]map[string]api.CrossMountSource),
 		mountOnly: make(map[string]map[string]struct{}),
 	}
@@ -439,8 +489,8 @@ func planDedupPush(working []manifestDestination, present map[destination]bool, 
 		if need.mixed {
 			upstream = ""
 		}
-		mount := resolveBlobMount(need.needing, confirmed[key], upstream, blobRepository)
-		if mount.repository == "" {
+		resolution := locations.resolve(key, need.needing, confirmed[key], upstream, blobRepository)
+		if resolution.repository == "" {
 			// Nothing to gain: let the manifest push upload it as it normally would.
 			plan.skipped++
 			continue
@@ -451,26 +501,49 @@ func planDedupPush(working []manifestDestination, present map[destination]bool, 
 		if plan.sources[key.registry] == nil {
 			plan.sources[key.registry] = make(map[string]api.CrossMountSource)
 		}
-		plan.sources[key.registry][key.digest] = api.CrossMountSource{Registry: key.registry, Repository: mount.repository}
-		plan.mounted += countMountedInto(need.needing, mount.repository)
-		switch mount.kind {
-		case mountFromConfirmed:
+		plan.sources[key.registry][key.digest] = api.CrossMountSource{Registry: key.registry, Repository: resolution.repository}
+		mountedInto := countMountedInto(need.needing, resolution.repository)
+		plan.mounted += mountedInto
+		switch {
+		case resolution.cached:
+			plan.cached++
+		case resolution.kind == mountFromConfirmed:
 			plan.confirmed++
-		case mountFromUpstream:
+		case resolution.kind == mountFromUpstream:
 			plan.upstream++
-		case mountFromUpload:
-			hash, err := registryv1.NewHash(key.digest)
-			if err != nil {
-				return nil, fmt.Errorf("parsing layer digest %s: %w", key.digest, err)
-			}
+		}
+		// A home this process puts the blob in is one we know the mount can come from,
+		// which is what makes the layer mount-only -- whether the upload is this
+		// request's own claim, one it joined, or one an earlier request already
+		// finished.
+		//
+		// Except when this request mounts the blob nowhere: a home claimed for the one
+		// repository that needs it (see resolveBlobMount's claimLone) is claimed for the
+		// requests that come after, and they set their own mount-only. Insisting on it
+		// here would turn "the upload landed but the registry cannot see it yet" into a
+		// failed deploy, where uploading the bytes again is the right recovery.
+		if resolution.kind == mountFromUpload && mountedInto > 0 {
 			if plan.mountOnly[key.registry] == nil {
 				plan.mountOnly[key.registry] = make(map[string]struct{})
 			}
 			plan.mountOnly[key.registry][key.digest] = struct{}{}
-			target := key.registry + "/" + mount.repository
+		}
+		if resolution.upload {
+			hash, err := registryv1.NewHash(key.digest)
+			if err != nil {
+				return nil, fmt.Errorf("parsing layer digest %s: %w", key.digest, err)
+			}
+			target := key.registry + "/" + resolution.repository
 			plan.uploads[target] = append(plan.uploads[target], hash)
+			if resolution.joined {
+				plan.joined[key] = struct{}{}
+			}
 		}
 	}
+	// Whatever this deploy did not need, the next one in this process might: the
+	// layers of the manifests the registry already serves are mountable out of those
+	// repositories for free.
+	locations.seedConfirmed(confirmed)
 
 	for _, digests := range plan.uploads {
 		slices.SortFunc(digests, func(a, b registryv1.Hash) int {
@@ -543,7 +616,15 @@ const (
 // is the mount source itself. There is nothing to mount it into, so going through
 // this at all would only move the upload out of the manifest push and cost an extra
 // HEAD. This is what makes the strategy a no-op for a single-image deploy.
-func resolveBlobMount(needing map[string]struct{}, confirmed map[string]struct{}, upstream, blobRepository string) blobMount {
+//
+// claimLone overrides that last rule for a deploy whose destinations arrive
+// incrementally (the persistent worker). There the blob's home is worth settling
+// even with nothing to mount it into yet, because publishing it lets the *next* work
+// request mount from it instead of uploading the blob into a repository of its own.
+// The cost is one HEAD per layer: the upload moves into the deduplicated push's own
+// phase, where go-containerregistry HEADs it, and the manifest push then finds the
+// blob in its destination and skips it.
+func resolveBlobMount(needing map[string]struct{}, confirmed map[string]struct{}, upstream, blobRepository string, claimLone bool) blobMount {
 	if len(needing) == 0 {
 		return blobMount{}
 	}
@@ -564,7 +645,7 @@ func resolveBlobMount(needing map[string]struct{}, confirmed map[string]struct{}
 		mount = blobMount{repository: home, kind: mountFromUpload}
 	}
 
-	if countMountedInto(needing, mount.repository) == 0 {
+	if !claimLone && countMountedInto(needing, mount.repository) == 0 {
 		return blobMount{}
 	}
 	return mount
@@ -573,6 +654,12 @@ func resolveBlobMount(needing map[string]struct{}, confirmed map[string]struct{}
 // smallestRepository returns the lexicographically smallest repository of a set, so
 // that a blob several repositories need always gets the same home whatever order
 // the operations arrive in.
+//
+// Which is worth keeping even though the location cache already makes the deploys of
+// one process agree on a home: two *processes* looking at the same registry agree
+// too, so re-running a deploy -- or running the second half of one on another
+// machine -- finds the blob in the home repository it would have picked and uploads
+// nothing.
 func smallestRepository(repositories map[string]struct{}) (string, bool) {
 	if len(repositories) == 0 {
 		return "", false
@@ -684,25 +771,59 @@ func manifestAbsent(err error) bool {
 }
 
 // uploadDedupBlobs uploads each blob the plan calls for to its home repository,
-// with --jobs uploads in flight.
+// with --jobs uploads in flight, and publishes each home in locations as its upload
+// succeeds so the deploys that follow in this process mount from it instead.
 //
 // The blobs are read through VFS.RawLayer: the mount-only wrapping applies to the
 // manifest push, not to the upload that puts the bytes in the home repository in
 // the first place. go-containerregistry HEADs each blob before uploading it, so
 // re-running a deploy costs one request per blob instead of a re-upload.
-func uploadDedupBlobs(ctx context.Context, vfs *deployvfs.VFS, plan *dedupPlan, jobs int, remoteOptions []remote.Option) (retErr error) {
+//
+// Every upload goes through locations.uploadOnce, so a blob is never sent to the same
+// repository twice at once, however many deploys of this process are pushing it:
+// whichever of them gets there first uploads it while the others wait for that
+// attempt. A deploy that waited transfers nothing and reads nothing -- the blob is not
+// even resolved from the VFS, so a lazy push does not fetch it from the CAS.
+//
+// An upload this deploy claimed is its own work, so failing it fails the deploy. An
+// upload it joined (plan.joined) is a duplicate of one another deploy in this process
+// claimed, and failing that says nothing about this deploy's own access to the
+// registry -- the home repository is one it never meant to write to. Rather than fail,
+// it gives up the cross-mount for that blob: the layer stops being mount-only, so the
+// manifest push mounts it if the claimer's upload made it and uploads the bytes into
+// its own repository if it did not, which is what would have happened without the
+// cache.
+func uploadDedupBlobs(ctx context.Context, vfs *deployvfs.VFS, plan *dedupPlan, jobs int, remoteOptions []remote.Option, locations *blobLocations) (retErr error) {
 	type upload struct {
 		repo   name.Repository
 		digest registryv1.Hash
+		// key, home and target are the plan's own spelling of the destination, so that
+		// what is published in locations is exactly what was claimed there. The parsed
+		// repository above is not: it fills in the parts a registry client may leave out,
+		// and "docker.io/nginx" comes back as the repository "library/nginx".
+		key    blobKey
+		home   string
+		target uploadTarget
+		joined bool
 	}
 	var uploads []upload
-	for _, repository := range plan.uploadRepositories() {
-		repo, err := name.NewRepository(repository, registryopts.NameOptions()...)
+	for _, target := range plan.uploadRepositories() {
+		repo, err := name.NewRepository(target, registryopts.NameOptions()...)
 		if err != nil {
-			return fmt.Errorf("parsing home repository %s: %w", repository, err)
+			return fmt.Errorf("parsing home repository %s: %w", target, err)
 		}
-		for _, digest := range plan.uploads[repository] {
-			uploads = append(uploads, upload{repo: repo, digest: digest})
+		registry, home, _ := strings.Cut(target, "/")
+		for _, digest := range plan.uploads[target] {
+			key := blobKey{registry: registry, digest: digest.String()}
+			_, joined := plan.joined[key]
+			uploads = append(uploads, upload{
+				repo:   repo,
+				digest: digest,
+				key:    key,
+				home:   home,
+				target: uploadTarget{registry: registry, repository: home, digest: digest.String()},
+				joined: joined,
+			})
 		}
 	}
 	if len(uploads) == 0 {
@@ -717,22 +838,60 @@ func uploadDedupBlobs(ctx context.Context, vfs *deployvfs.VFS, plan *dedupPlan, 
 	}
 	defer func() { finishProgress(retErr) }()
 
+	// The blobs whose joined upload failed, collected here and applied to the plan
+	// once every upload has finished rather than from the goroutines themselves.
+	var abandonedMu sync.Mutex
+	var abandoned []upload
+
 	g, groupCtx := errgroup.WithContext(ctx)
 	g.SetLimit(jobs)
 	for _, up := range uploads {
 		up := up
 		g.Go(func() error {
-			layer, err := vfs.RawLayer(up.digest)
-			if err != nil {
-				return fmt.Errorf("resolving blob %s: %w", up.digest, err)
+			mine := false
+			err := locations.uploadOnce(groupCtx, up.target, func() error {
+				mine = true
+				layer, err := vfs.RawLayer(up.digest)
+				if err != nil {
+					return fmt.Errorf("resolving blob %s: %w", up.digest, err)
+				}
+				if err := pusher.Upload(groupCtx, up.repo, layer); err != nil {
+					return fmt.Errorf("uploading blob %s to %s: %w", up.digest, up.repo, err)
+				}
+				return nil
+			})
+			switch {
+			case err == nil:
+				if !mine {
+					// Another deploy in this process uploaded it while we waited.
+					plan.countWaited()
+				}
+				locations.promote(up.key, up.home)
+				return nil
+			case !up.joined:
+				// This deploy's own claim: the home is not where the blob is after all, so
+				// give it up before failing, or the next deploy would mount from it.
+				locations.abandon(up.key, up.home)
+				return err
+			case groupCtx.Err() != nil:
+				// Cancelled because another upload failed; that error is the one to report.
+				return nil
+			default:
+				abandonedMu.Lock()
+				abandoned = append(abandoned, up)
+				abandonedMu.Unlock()
+				fmt.Fprintf(os.Stderr, "warning: leaving blob %s to the ordinary push: %v\n", up.digest, err)
+				return nil
 			}
-			if err := pusher.Upload(groupCtx, up.repo, layer); err != nil {
-				return fmt.Errorf("uploading blob %s to %s: %w", up.digest, up.repo, err)
-			}
-			return nil
 		})
 	}
-	return g.Wait()
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	for _, up := range abandoned {
+		delete(plan.mountOnly[up.key.registry], up.key.digest)
+	}
+	return nil
 }
 
 // dedupViews serves the blobs of a deduplicated push. Each registry gets its own
@@ -788,13 +947,22 @@ func prepareDedupPush(ctx context.Context, vfs *deployvfs.VFS, pushOps []api.Ind
 		return nil, err
 	}
 
-	plan, err := planDedupPush(working, present, opts.blobRepository)
+	// A deploy that uploads nothing learns nothing about where a blob is, and what it
+	// would publish is an assumption about the registry it never checked: the blobs
+	// are expected to be in place already. So it plans on its own signals and leaves
+	// the process-wide cache untouched.
+	locations := opts.locations
+	if opts.forbidUpload {
+		locations = nil
+	}
+
+	plan, err := planDedupPush(working, present, opts.blobRepository, locations)
 	if err != nil {
 		return nil, err
 	}
 
 	if !opts.forbidUpload {
-		if err := uploadDedupBlobs(ctx, vfs, plan, opts.jobs, remoteOptions); err != nil {
+		if err := uploadDedupBlobs(ctx, vfs, plan, opts.jobs, remoteOptions, locations); err != nil {
 			return nil, fmt.Errorf("uploading shared blobs: %w", err)
 		}
 	}

--- a/img_tool/cmd/deploy/dedup_push_test.go
+++ b/img_tool/cmd/deploy/dedup_push_test.go
@@ -54,11 +54,132 @@ func pushOp(registry, repository, manifestDigest string, layers ...api.LayerBlob
 // present and no build-time staging repository -- the default configuration.
 func planFor(t *testing.T, ops ...api.IndexedPushDeployOperation) *dedupPlan {
 	t.Helper()
-	plan, err := planDedupPush(dedupWorkingSet(ops, nil, dedupSelector{}, "", ""), nil, "")
+	plan, err := planDedupPush(dedupWorkingSet(ops, nil, dedupSelector{}, "", ""), nil, "", newBlobLocations(false))
 	if err != nil {
 		t.Fatalf("planDedupPush: %v", err)
 	}
 	return plan
+}
+
+// planWith runs the planner the way one persistent worker request does: over that
+// request's operations alone, against the location cache the whole process shares.
+func planWith(t *testing.T, locations *blobLocations, ops ...api.IndexedPushDeployOperation) *dedupPlan {
+	t.Helper()
+	plan, err := planDedupPush(dedupWorkingSet(ops, nil, dedupSelector{}, "", ""), nil, "", locations)
+	if err != nil {
+		t.Fatalf("planDedupPush: %v", err)
+	}
+	return plan
+}
+
+// promoteUploads publishes the plan's uploads the way a successful upload phase
+// does, so a test can play out the requests that come after it.
+func promoteUploads(plan *dedupPlan, locations *blobLocations) {
+	for _, target := range plan.uploadRepositories() {
+		registry, repository, _ := strings.Cut(target, "/")
+		for _, digest := range plan.uploads[target] {
+			locations.promote(blobKey{registry: registry, digest: digest.String()}, repository)
+		}
+	}
+}
+
+// TestPlanDedupPushReusesAnEarlierRequestsHome is the persistent worker: each work
+// request is planned on its own, so it is the shared location cache that keeps two
+// requests sharing a layer from uploading it into two repositories. A lone
+// destination therefore still settles a home -- there is nothing to mount it into
+// today, but the next request mounts from it instead of uploading its own copy.
+func TestPlanDedupPushReusesAnEarlierRequestsHome(t *testing.T) {
+	locations := newBlobLocations(true)
+
+	// Request A pushes one image. Without the cache this would be a no-op.
+	first := planWith(t, locations, pushOp("reg.example.com", "team/service-a", manifestADigest,
+		layer(sharedLayerDigest), layer(serviceALayerDiges)))
+	if got := strings.Join(uploadedDigests(first, "reg.example.com/team/service-a"), ","); got != sharedLayerDigest+","+serviceALayerDiges {
+		t.Errorf("request A uploads %v, want both of its layers to their own repository as their home", got)
+	}
+	if first.mounted != 0 || first.skipped != 0 {
+		t.Errorf("request A cross-mounts %d and skips %d, want 0 and 0: it claims a home for each layer", first.mounted, first.skipped)
+	}
+	// It mounts nothing itself, so nothing is mount-only for it: the claim is for the
+	// requests that come after, and insisting the registry serve a mount request A does
+	// not need would only be a way to fail.
+	if countMountOnly(first) != 0 {
+		t.Errorf("request A marked %v mount-only, but it cross-mounts nothing", first.mountOnly)
+	}
+
+	// Request B arrives while A's upload phase is still running: it mounts from A's
+	// home and schedules the same upload rather than waiting for a request it knows
+	// nothing about, so the mount source is in place by the end of its own phase.
+	concurrent := planWith(t, locations, pushOp("reg.example.com", "team/service-b", manifestBDigest, layer(sharedLayerDigest)))
+	if src := sourceIn(concurrent, testRegistry, sharedLayerDigest); src.Repository != "team/service-a" {
+		t.Errorf("source for the shared layer = %+v, want request A's home team/service-a", src)
+	}
+	if got := strings.Join(uploadedDigests(concurrent, "reg.example.com/team/service-a"), ","); got != sharedLayerDigest {
+		t.Errorf("request B uploads %v to A's home, want the shared layer (it joins A's upload)", got)
+	}
+	key := blobKey{registry: testRegistry, digest: sharedLayerDigest}
+	if _, joined := concurrent.joined[key]; !joined {
+		t.Error("request B's upload is not recorded as joined, so failing it would fail the deploy")
+	}
+	if concurrent.cached != 1 {
+		t.Errorf("request B resolved %d blobs from the cache, want 1", concurrent.cached)
+	}
+
+	// Once the blob is in the home repository, the requests after that upload nothing
+	// for it at all.
+	promoteUploads(first, locations)
+	sequential := planWith(t, locations, pushOp("reg.example.com", "team/service-c", "sha256:cccc333333333333333333333333333333333333333333333333333333333333",
+		layer(sharedLayerDigest)))
+	if len(sequential.uploads) != 0 {
+		t.Errorf("request C uploads %v, want nothing: the shared layer is already in team/service-a", sequential.uploads)
+	}
+	if src := sourceIn(sequential, testRegistry, sharedLayerDigest); src.Repository != "team/service-a" || src.Registry != testRegistry {
+		t.Errorf("source for the shared layer = %+v, want team/service-a in %s", src, testRegistry)
+	}
+	// This process put the blob there, so a refused mount is a failure rather than a
+	// silent re-upload.
+	if !mountOnlyIn(sequential, testRegistry, sharedLayerDigest) {
+		t.Error("the shared layer is not mount-only, but this process uploaded it to team/service-a")
+	}
+	if sequential.mounted != 1 {
+		t.Errorf("request C cross-mounts %d times, want 1", sequential.mounted)
+	}
+}
+
+// TestPlanDedupPushSeedsTheCacheFromPresentManifests verifies the free half of the
+// cache: the layers of a manifest the registry already serves are published as
+// mountable out of that repository, so a later work request pushing a sibling image
+// mounts them without an upload -- even though the request that checked had nothing
+// to do with them.
+func TestPlanDedupPushSeedsTheCacheFromPresentManifests(t *testing.T) {
+	locations := newBlobLocations(true)
+	working := dedupWorkingSet([]api.IndexedPushDeployOperation{
+		pushOp("reg.example.com", "team/service-a", manifestADigest, layer(sharedLayerDigest)),
+	}, nil, dedupSelector{}, "", "")
+	present := map[destination]bool{
+		{registry: "reg.example.com", repository: "team/service-a", digest: manifestADigest}: true,
+	}
+	first, err := planDedupPush(working, present, "", locations)
+	if err != nil {
+		t.Fatalf("planDedupPush: %v", err)
+	}
+	if first.present != 1 || len(first.uploads) != 0 {
+		t.Fatalf("request A planned %d uploads with %d/%d manifests present, want none: it has nothing to push",
+			len(first.uploads), first.present, first.total)
+	}
+
+	second := planWith(t, locations, pushOp("reg.example.com", "team/service-b", manifestBDigest, layer(sharedLayerDigest)))
+	if src := sourceIn(second, testRegistry, sharedLayerDigest); src.Repository != "team/service-a" {
+		t.Errorf("source for the shared layer = %+v, want the repository the registry serves it from", src)
+	}
+	if len(second.uploads) != 0 {
+		t.Errorf("request B uploads %v, want nothing: team/service-a already holds the layer", second.uploads)
+	}
+	// The inference is the registry's, not something this process did, so the layer
+	// keeps its byte-upload fallback.
+	if mountOnlyIn(second, testRegistry, sharedLayerDigest) {
+		t.Error("the shared layer is mount-only, but this process never uploaded it")
+	}
 }
 
 // uploadedDigests returns the digests the plan uploads to the given full
@@ -176,7 +297,7 @@ func TestPlanDedupPushUsesTheBuildTimeStagingRepository(t *testing.T) {
 		pushOp("reg.example.com", "team/service-a", manifestADigest, layer(sharedLayerDigest)),
 		pushOp("reg.example.com", "team/service-b", manifestBDigest, layer(sharedLayerDigest)),
 	}
-	plan, err := planDedupPush(dedupWorkingSet(ops, nil, dedupSelector{}, "", ""), nil, "shared/blobs")
+	plan, err := planDedupPush(dedupWorkingSet(ops, nil, dedupSelector{}, "", ""), nil, "shared/blobs", newBlobLocations(false))
 	if err != nil {
 		t.Fatalf("planDedupPush: %v", err)
 	}
@@ -249,7 +370,7 @@ func TestPlanDedupPushMountsFromAPresentSibling(t *testing.T) {
 	present := map[destination]bool{
 		{registry: "reg.example.com", repository: "team/service-b", digest: manifestBDigest}: true,
 	}
-	plan, err := planDedupPush(dedupWorkingSet(ops, nil, dedupSelector{}, "", ""), present, "")
+	plan, err := planDedupPush(dedupWorkingSet(ops, nil, dedupSelector{}, "", ""), present, "", newBlobLocations(false))
 	if err != nil {
 		t.Fatalf("planDedupPush: %v", err)
 	}
@@ -322,7 +443,7 @@ func TestPlanDedupPushMixesSourcesPerRegistry(t *testing.T) {
 	present := map[destination]bool{
 		{registry: "a.example.com", repository: "team/service-b", digest: manifestBDigest}: true,
 	}
-	plan, err := planDedupPush(dedupWorkingSet(ops, nil, dedupSelector{}, "", ""), present, "")
+	plan, err := planDedupPush(dedupWorkingSet(ops, nil, dedupSelector{}, "", ""), present, "", newBlobLocations(false))
 	if err != nil {
 		t.Fatalf("planDedupPush: %v", err)
 	}
@@ -428,7 +549,7 @@ func TestPlanDedupPushNeverCrossesRegistries(t *testing.T) {
 	present := map[destination]bool{
 		{registry: "b.example.com", repository: "team/service-b", digest: manifestBDigest}: true,
 	}
-	plan, err := planDedupPush(dedupWorkingSet(ops, nil, dedupSelector{}, "", ""), present, "shared/blobs")
+	plan, err := planDedupPush(dedupWorkingSet(ops, nil, dedupSelector{}, "", ""), present, "shared/blobs", newBlobLocations(false))
 	if err != nil {
 		t.Fatalf("planDedupPush: %v", err)
 	}
@@ -506,7 +627,7 @@ func TestDedupWorkingSetIncludesRegistryTagOperations(t *testing.T) {
 	}
 
 	// Both destinations need the layer, so it is deduplicated across them.
-	plan, err := planDedupPush(working, nil, "")
+	plan, err := planDedupPush(working, nil, "", newBlobLocations(false))
 	if err != nil {
 		t.Fatalf("planDedupPush: %v", err)
 	}
@@ -564,7 +685,7 @@ func TestPlanDedupPushIndexPrunesPresentChildren(t *testing.T) {
 	present := map[destination]bool{
 		{registry: "reg.example.com", repository: "team/service-a", digest: manifestADigest}: true,
 	}
-	plan, err := planDedupPush(working, present, "")
+	plan, err := planDedupPush(working, present, "", newBlobLocations(false))
 	if err != nil {
 		t.Fatalf("planDedupPush: %v", err)
 	}
@@ -600,6 +721,7 @@ func TestResolveBlobMount(t *testing.T) {
 		confirmed      map[string]struct{}
 		upstream       string
 		blobRepository string
+		claimLone      bool
 		want           blobMount
 	}{
 		{
@@ -612,8 +734,24 @@ func TestResolveBlobMount(t *testing.T) {
 			needing: set("team/a"),
 		},
 		{
+			// ... unless more destinations may still arrive and mount from it (the
+			// persistent worker): then settling the home now is what lets the next work
+			// request mount instead of uploading its own copy.
+			name:      "a single repository claims a home when more may arrive",
+			needing:   set("team/a"),
+			claimLone: true,
+			want:      blobMount{repository: "team/a", kind: mountFromUpload},
+		},
+		{
 			name:    "no repository at all is not worth it",
 			needing: set(),
+		},
+		{
+			// Not even then: nothing in this request needs the blob, so there is nothing
+			// to upload and nothing to mount.
+			name:      "no repository at all is not worth it even incrementally",
+			needing:   set(),
+			claimLone: true,
 		},
 		{
 			name:      "a repository the registry already serves needs no upload",
@@ -639,6 +777,15 @@ func TestResolveBlobMount(t *testing.T) {
 			name:      "a confirmed repository that is the only destination",
 			needing:   set("team/a"),
 			confirmed: set("team/a"),
+		},
+		{
+			// Incrementally it is worth recording all the same -- and for free, since a
+			// confirmed repository needs no upload.
+			name:      "a confirmed repository that is the only destination, incrementally",
+			needing:   set("team/a"),
+			confirmed: set("team/a"),
+			claimLone: true,
+			want:      blobMount{repository: "team/a", kind: mountFromConfirmed},
 		},
 		{
 			name:      "confirmed beats upstream",
@@ -676,7 +823,7 @@ func TestResolveBlobMount(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := resolveBlobMount(tc.needing, tc.confirmed, tc.upstream, tc.blobRepository); got != tc.want {
+			if got := resolveBlobMount(tc.needing, tc.confirmed, tc.upstream, tc.blobRepository, tc.claimLone); got != tc.want {
 				t.Errorf("resolveBlobMount = %+v, want %+v", got, tc.want)
 			}
 		})
@@ -759,7 +906,7 @@ func TestDedupWorkingSetExcludesOptedOutOperations(t *testing.T) {
 	// The shared layer now has a single deduplicating destination, so it is not
 	// deduplicated at all -- and in particular is not mount-only, which would have
 	// broken the opted-out operation's push.
-	plan, err := planDedupPush(working, nil, "")
+	plan, err := planDedupPush(working, nil, "", newBlobLocations(false))
 	if err != nil {
 		t.Fatalf("planDedupPush: %v", err)
 	}
@@ -814,7 +961,7 @@ func TestPlanDedupPushMountsAcrossEveryOptedInOperation(t *testing.T) {
 		optedOut,
 	}
 
-	plan, err := planDedupPush(dedupWorkingSet(ops, nil, dedupSelector{}, "", ""), nil, "")
+	plan, err := planDedupPush(dedupWorkingSet(ops, nil, dedupSelector{}, "", ""), nil, "", newBlobLocations(false))
 	if err != nil {
 		t.Fatalf("planDedupPush: %v", err)
 	}

--- a/img_tool/cmd/deploy/dedup_registry_test.go
+++ b/img_tool/cmd/deploy/dedup_registry_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -47,6 +48,12 @@ type naiveRegistry struct {
 	// that does not support them, which must make a mount-only layer fail rather
 	// than quietly re-upload.
 	mountable bool
+
+	// refuseUploads holds the repositories that answer an upload session with 401,
+	// modelling a credential that may not write there. A deploy is only ever asked to
+	// upload into a repository it does not push to by the process-wide blob location
+	// cache, when it joins another deploy's claim (see blobLocations).
+	refuseUploads map[string]struct{}
 
 	// blobPuts records every finalized blob upload as "<repository>@<digest>", and
 	// mounts every satisfied mount as "<repository>@<digest>". A blob that appears
@@ -170,6 +177,11 @@ func (r *naiveRegistry) startUpload(w http.ResponseWriter, req *http.Request, re
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	if _, refused := r.refuseUploads[repository]; refused {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
 
 	query := req.URL.Query()
 	mount, from, origin := query.Get("mount"), query.Get("from"), query.Get("origin")
@@ -322,6 +334,26 @@ func (r *naiveRegistry) putBlob(repository, digest string, content []byte) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.putBlobLocked(repository, digest, content)
+}
+
+// blobPutRepositories returns the repositories the blob's bytes were uploaded to,
+// sorted and without duplicates. One entry means every other repository that has the
+// blob cross-mounted it.
+func (r *naiveRegistry) blobPutRepositories(digest string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var repositories []string
+	for _, put := range r.blobPuts {
+		repository, uploaded, found := strings.Cut(put, "@")
+		if !found || uploaded != digest {
+			continue
+		}
+		if !slices.Contains(repositories, repository) {
+			repositories = append(repositories, repository)
+		}
+	}
+	sort.Strings(repositories)
+	return repositories
 }
 
 // hasBlob reports whether the repository holds the blob.
@@ -488,6 +520,14 @@ func (r *naiveRegistry) assertNoCrossRegistryMounts(t *testing.T) {
 // serve more than one registry (see registryFleet).
 func runDedupDeployVia(t *testing.T, transport http.RoundTripper, layoutDirs []string, dm api.DeployManifest) error {
 	t.Helper()
+	return runDedupDeployWith(t, transport, layoutDirs, dm, newBlobLocations(false))
+}
+
+// runDedupDeployWith is runDedupDeployVia against a given blob location cache, so a
+// test can play several deploys through one cache the way the persistent worker
+// handles several work requests.
+func runDedupDeployWith(t *testing.T, transport http.RoundTripper, layoutDirs []string, dm api.DeployManifest, locations *blobLocations) error {
+	t.Helper()
 	vfsBuilder := deployvfs.NewBuilder(dm)
 	for _, layoutDir := range layoutDirs {
 		vfsBuilder = vfsBuilder.WithOCILayout(layoutDir)
@@ -509,6 +549,7 @@ func runDedupDeployVia(t *testing.T, transport http.RoundTripper, layoutDirs []s
 		jobs:           4,
 		forbidUpload:   dm.Settings.ForbidLayerPush,
 		pushTransport:  transport,
+		locations:      locations,
 	})
 	if err != nil {
 		return err
@@ -907,6 +948,223 @@ func TestDeduplicatedPushMountsUpstreamLayersInsteadOfUploading(t *testing.T) {
 		if got := reg.countBlobPuts(digest); got != 1 {
 			t.Errorf("layer %s uploaded %d times, want exactly 1", digest, got)
 		}
+	}
+}
+
+// workRequest returns dm with only the operation at the given index, which is the
+// shape a persistent worker sees: one deploy manifest per work request, planned on
+// its own, with no way to know what the next request will push.
+func workRequest(dm api.DeployManifest, index int) api.DeployManifest {
+	out := dm
+	out.Operations = dm.Operations[index : index+1]
+	return out
+}
+
+// TestDeduplicatedPushMountsFromAnEarlierWorkRequestsHome is the persistent worker,
+// one request at a time: two services that share their base layers are deployed by
+// two work requests, each of which only knows its own image. The process-wide
+// location cache is what makes the second one mount the shared layers out of the
+// first one's repository instead of uploading its own copy -- and the control below
+// shows that without it, it does.
+func TestDeduplicatedPushMountsFromAnEarlierWorkRequestsHome(t *testing.T) {
+	reg := newNaiveRegistry()
+	layoutDirs, dm, images := buildSharedLayerLayouts(t, "reg.example.com", 2, 2)
+	locations := newBlobLocations(true)
+
+	for i := range images.repositories {
+		if err := runDedupDeployWith(t, reg.transport(), layoutDirs, workRequest(dm, i), locations); err != nil {
+			t.Fatalf("work request %d: %v", i, err)
+		}
+	}
+	reg.assertNoCrossRegistryMounts(t)
+
+	home := images.repositories[0] // the first request's repository: it settled the home
+	for _, digest := range images.shared {
+		if got := reg.countBlobPuts(digest); got != 1 {
+			t.Errorf("shared layer %s uploaded %d times across the two work requests, want exactly 1", digest, got)
+		}
+		if !reg.hasBlob(home, digest) {
+			t.Errorf("shared layer %s is not in the home repository %s", digest, home)
+		}
+		if !reg.hasBlob(images.repositories[1], digest) {
+			t.Errorf("shared layer %s never reached %s", digest, images.repositories[1])
+		}
+	}
+	// One cross-mount per shared layer, into the second request's repository.
+	_, mounts, _ := reg.snapshot()
+	if len(mounts) != len(images.shared) {
+		t.Errorf("registry satisfied %d mounts, want one per shared layer (%d): %v", len(mounts), len(images.shared), mounts)
+	}
+	// Each service's own layer is still uploaded to its own repository.
+	for i, digest := range images.unique {
+		if got := reg.countBlobPuts(digest); got != 1 {
+			t.Errorf("layer %s uploaded %d times, want exactly 1", digest, got)
+		}
+		if !reg.hasBlob(images.repositories[i], digest) {
+			t.Errorf("layer %s never reached %s", digest, images.repositories[i])
+		}
+	}
+	for i, repository := range images.repositories {
+		if _, found := reg.storedManifestFor(repository, images.manifests[i]); !found {
+			t.Errorf("manifest %s never reached %s", images.manifests[i], repository)
+		}
+	}
+
+	// The control: the same two work requests without a shared cache -- each planning
+	// its own deploy, as a one-shot img deploy does -- upload every shared layer twice.
+	// A single-image deploy has nothing to cross-mount into, so on its own the strategy
+	// cannot help here at all.
+	control := newNaiveRegistry()
+	for i := range images.repositories {
+		if err := runDedupDeployVia(t, control.transport(), layoutDirs, workRequest(dm, i)); err != nil {
+			t.Fatalf("control work request %d: %v", i, err)
+		}
+	}
+	for _, digest := range images.shared {
+		if got := control.countBlobPuts(digest); got != 2 {
+			t.Errorf("without the shared cache, shared layer %s was uploaded %d times, want once per work request (2)", digest, got)
+		}
+	}
+}
+
+// TestDeduplicatedPushConcurrentWorkRequestsShareOneHome is the concurrent worker:
+// several work requests are planned at the same time, so none of them can see
+// another's finished upload. They must still agree on one home per shared blob, and
+// the blob's bytes must cross the wire exactly once -- each request pushes through a
+// remote.Pusher of its own, so nothing below the location cache would keep them from
+// all uploading it.
+func TestDeduplicatedPushConcurrentWorkRequestsShareOneHome(t *testing.T) {
+	reg := newNaiveRegistry()
+	layoutDirs, dm, images := buildSharedLayerLayouts(t, "reg.example.com", 3, 2)
+	locations := newBlobLocations(true)
+
+	errs := make([]error, len(images.repositories))
+	var wg sync.WaitGroup
+	for i := range images.repositories {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = runDedupDeployWith(t, reg.transport(), layoutDirs, workRequest(dm, i), locations)
+		}()
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent work request %d: %v", i, err)
+		}
+	}
+	reg.assertNoCrossRegistryMounts(t)
+
+	for _, digest := range images.shared {
+		// One home, whichever request got there first, and one upload into it: the
+		// requests that did not perform it either waited for the one that did or found
+		// the blob already there.
+		if repositories := reg.blobPutRepositories(digest); len(repositories) != 1 {
+			t.Errorf("shared layer %s was uploaded to %v, want a single home repository", digest, repositories)
+		}
+		if got := reg.countBlobPuts(digest); got != 1 {
+			t.Errorf("shared layer %s uploaded %d times, want exactly 1 across the concurrent requests", digest, got)
+		}
+		for _, repository := range images.repositories {
+			if !reg.hasBlob(repository, digest) {
+				t.Errorf("shared layer %s never reached %s", digest, repository)
+			}
+		}
+	}
+	for i, repository := range images.repositories {
+		if _, found := reg.storedManifestFor(repository, images.manifests[i]); !found {
+			t.Errorf("manifest %s never reached %s", images.manifests[i], repository)
+		}
+	}
+}
+
+// TestDeduplicatedPushLeavesARefusedJoinedUploadToTheOrdinaryPush covers the one
+// thing the location cache asks of a deploy that it did not ask for itself: uploading
+// a blob to a repository it does not push to, because a concurrent deploy claimed it
+// as the home. A credential that may not write there must not fail the deploy -- it
+// gives up the cross-mount for that blob and uploads the bytes into its own
+// repository, which is what would have happened without the cache.
+func TestDeduplicatedPushLeavesARefusedJoinedUploadToTheOrdinaryPush(t *testing.T) {
+	reg := newNaiveRegistry()
+	reg.refuseUploads = map[string]struct{}{"other/home": {}}
+	layoutDirs, dm, images := buildSharedLayerLayouts(t, "reg.example.com", 1, 1)
+	shared := images.shared[0]
+
+	// A concurrent deploy in this process claimed a home this one cannot write to.
+	locations := newBlobLocations(true)
+	locations.inflight[blobKey{registry: "reg.example.com", digest: shared}] = blobMount{repository: "other/home", kind: mountFromUpload}
+
+	if err := runDedupDeployWith(t, reg.transport(), layoutDirs, dm, locations); err != nil {
+		t.Fatalf("deduplicated push: %v", err)
+	}
+	reg.assertNoCrossRegistryMounts(t)
+
+	if reg.hasBlob("other/home", shared) {
+		t.Error("the shared layer reached the home repository, which refuses uploads")
+	}
+	if !reg.hasBlob(images.repositories[0], shared) {
+		t.Errorf("the shared layer never reached %s, so the deploy pushed an unservable manifest", images.repositories[0])
+	}
+	if got := reg.countBlobPuts(shared); got != 1 {
+		t.Errorf("the shared layer's bytes were uploaded %d times, want 1 (into its own repository)", got)
+	}
+	if _, found := reg.storedManifestFor(images.repositories[0], images.manifests[0]); !found {
+		t.Errorf("manifest %s never reached %s", images.manifests[0], images.repositories[0])
+	}
+}
+
+// TestDeduplicatedPushFailsWhenItsOwnHomeRefusesTheUpload is the other half of the
+// pair: an upload this deploy chose to make is its own work, so failing it fails the
+// deploy rather than being papered over.
+func TestDeduplicatedPushFailsWhenItsOwnHomeRefusesTheUpload(t *testing.T) {
+	reg := newNaiveRegistry()
+	layoutDirs, dm, images := buildSharedLayerLayouts(t, "reg.example.com", 2, 1)
+	reg.refuseUploads = map[string]struct{}{images.repositories[0]: {}} // the home
+
+	err := runDedupDeploy(t, reg, layoutDirs, dm)
+	if err == nil {
+		t.Fatal("deduplicated push succeeded although the home repository refused the upload")
+	}
+	if !strings.Contains(err.Error(), "uploading shared blobs") {
+		t.Errorf("error = %v, want the upload phase to name itself", err)
+	}
+	if !strings.Contains(err.Error(), images.shared[0]) {
+		t.Errorf("error = %v, want it to name the shared layer %s", err, images.shared[0])
+	}
+}
+
+// TestDeduplicatedPushFailsWhenAnEarlierHomeCannotBeMounted pins the trust the
+// location cache carries across work requests: the home is a repository *this
+// process* uploaded the blob to, so the request that mounts from it fails loudly if
+// the registry refuses, exactly as it would for a home of its own choosing. A silent
+// fallback would upload the blob into every repository after having already uploaded
+// it to the home -- strictly worse than never enabling the strategy.
+func TestDeduplicatedPushFailsWhenAnEarlierHomeCannotBeMounted(t *testing.T) {
+	reg := newNaiveRegistry()
+	layoutDirs, dm, images := buildSharedLayerLayouts(t, "reg.example.com", 2, 1)
+	locations := newBlobLocations(true)
+
+	// The first work request settles the home and puts the shared layer in it.
+	if err := runDedupDeployWith(t, reg.transport(), layoutDirs, workRequest(dm, 0), locations); err != nil {
+		t.Fatalf("first work request: %v", err)
+	}
+	home := images.repositories[0]
+	if !reg.hasBlob(home, images.shared[0]) {
+		t.Fatalf("the shared layer is not in the home repository %s, so this test proves nothing", home)
+	}
+
+	// The second one has nothing to upload for that layer -- and no way to push it
+	// either, once the registry stops mounting.
+	reg.mountable = false
+	err := runDedupDeployWith(t, reg.transport(), layoutDirs, workRequest(dm, 1), locations)
+	if err == nil {
+		t.Fatal("the second work request succeeded against a registry without mount support, want a mount-only failure")
+	}
+	if !strings.Contains(err.Error(), "refusing to upload layer") {
+		t.Fatalf("error = %v, want the mount-only refusal", err)
+	}
+	if !strings.Contains(err.Error(), home) {
+		t.Errorf("error = %v, want it to name the home repository %s the first request uploaded to", err, home)
 	}
 }
 

--- a/img_tool/cmd/deploy/deploy.go
+++ b/img_tool/cmd/deploy/deploy.go
@@ -410,6 +410,11 @@ func DeployWithExtras(ctx context.Context, rawRequest []byte, opts DeployOptions
 			jobs:               opts.Jobs,
 			forbidUpload:       req.Settings.ForbidLayerPush,
 			pushTransport:      pushTransport,
+			// One-shot: every destination this deploy will ever have is in the plan
+			// below, so the cache has no second deploy to agree with. It is passed all
+			// the same, so that both entry points resolve a blob's home through the one
+			// mechanism (see dedup_locations.go).
+			locations: newBlobLocations(false),
 		})
 		if err != nil {
 			return fmt.Errorf("preparing deduplicated push: %w", err)

--- a/img_tool/cmd/deploy/persistentworker.go
+++ b/img_tool/cmd/deploy/persistentworker.go
@@ -41,6 +41,12 @@ type deployWorkerHandler struct {
 	// decide, and a work request may override it in turn.
 	deduplicatedPush string
 
+	// blobLocations remembers where the deduplicated push has put each shared blob,
+	// for the lifetime of the worker: a work request only knows its own destinations,
+	// so without it two requests sharing a layer would each upload it into a
+	// repository of their own (see dedup_locations.go).
+	blobLocations *blobLocations
+
 	// globalSink, when set, redirects every request's operations into a shared
 	// local sink (distribution/oci) instead of a registry. It is not
 	// concurrency-safe, so access is serialized by sinkMu.
@@ -86,6 +92,9 @@ func newDeployWorkerHandler(jobs int, sinkSpec, deduplicatedPush string) (*deplo
 		pushTransport:    pushTransport,
 		casBlobs:         casBlobs,
 		deduplicatedPush: deduplicatedPush,
+		// Requests arrive one at a time, so a blob's home is settled the first time a
+		// request needs it and published for the rest.
+		blobLocations: newBlobLocations(true),
 	}
 
 	if sinkSpec != "" {
@@ -203,6 +212,10 @@ func (h *deployWorkerHandler) processRequest(ctx context.Context, req persistent
 	// dedupVFS is how the operations that opted into the deduplicated push see the
 	// blobs: one view per destination registry, planned across all of them together.
 	// Operations that did not opt in keep the plain VFS (see DeployWithExtras).
+	//
+	// The plan spans this request's destinations only -- another request's are not
+	// known yet -- so it is the shared location cache that keeps two requests from
+	// uploading the same blob into two repositories.
 	var dedupVFS *dedupViews
 	if dedupSelect.any(pushOps, registryTagOps) {
 		if err := validateDeduplicatedPush(dm.Settings); err != nil {
@@ -216,6 +229,7 @@ func (h *deployWorkerHandler) processRequest(ctx context.Context, req persistent
 			jobs:               h.jobs,
 			forbidUpload:       dm.Settings.ForbidLayerPush,
 			pushTransport:      h.pushTransport,
+			locations:          h.blobLocations,
 		})
 		if err != nil {
 			return "", fmt.Errorf("preparing deduplicated push: %w", err)

--- a/img_tool/pkg/cas/cache.go
+++ b/img_tool/pkg/cas/cache.go
@@ -306,7 +306,10 @@ func (c *CachingReader) ReaderForBlob(ctx context.Context, digest Digest) (io.Re
 			return file, nil
 		}
 
-		fetch, joined := c.fetchFor(digest)
+		fetch, joined, inStore := c.fetchFor(digest)
+		if inStore {
+			continue // another reader just finalized it; store.open will find it
+		}
 		if fetch == nil {
 			break // the cache directory is unusable; read straight from upstream
 		}
@@ -324,22 +327,32 @@ func (c *CachingReader) ReaderForBlob(ctx context.Context, digest Digest) (io.Re
 }
 
 // fetchFor returns the fetch for a digest, starting one if none is in flight,
-// and reports whether it joined an existing one. It returns nil if the blob
-// cannot be cached locally.
-func (c *CachingReader) fetchFor(digest Digest) (*blobFetch, bool) {
+// and reports whether it joined an existing one. It returns a nil fetch and
+// inStore==false if the blob cannot be cached locally, or inStore==true if the
+// blob is already in the store and the caller should read it from there.
+func (c *CachingReader) fetchFor(digest Digest) (fetch *blobFetch, joined, inStore bool) {
 	key := digest.cacheKey()
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if fetch, ok := c.inflight[key]; ok {
-		return fetch, true
+		return fetch, true, false
 	}
-	fetch := c.startFetch(digest, key)
-	if fetch == nil {
-		return nil, false
+	// No fetch is in flight. Because finalize renames the blob into the store
+	// before it forgets the fetch, and both forget and this lookup hold c.mu, a
+	// digest missing from inflight but present in the store was just completed by
+	// another reader. Send the caller back to the store instead of starting a
+	// redundant fetch that would read the same bytes from upstream again -- the
+	// race the caller's earlier store.open lost to a finalize in progress.
+	if c.store.has(digest) {
+		return nil, false, true
 	}
-	c.inflight[key] = fetch
-	return fetch, false
+	newFetch := c.startFetch(digest, key)
+	if newFetch == nil {
+		return nil, false, false
+	}
+	c.inflight[key] = newFetch
+	return newFetch, false, false
 }
 
 // startFetch begins fetching a blob into a temp file. c.mu must be held.
@@ -609,10 +622,16 @@ func (b *blobFetch) finalize() {
 	if !eligible {
 		return
 	}
-	b.cache.forget(b.key, b)
+	// Move the completed blob into the store before dropping the in-flight
+	// fetch, not after: a reader entering ReaderForBlob between the two steps
+	// must always find the blob in one place or the other. Forgetting first
+	// leaves a window where the temp file is neither in the store nor reachable
+	// through c.inflight, and a racing reader starts a redundant second fetch of
+	// a blob that is already downloaded.
 	if err := b.cache.store.finalize(b.tempPath, b.digest); err != nil && isNoSpace(err) {
 		b.cache.store.disable(err)
 	}
+	b.cache.forget(b.key, b)
 }
 
 // waitFor blocks until data past off is available or the fetch has ended,


### PR DESCRIPTION
The deduplicated push plans one deploy: it knows every destination that deploy
writes to, so it can pick one home repository per (registry, blob), upload the
blob there once and cross-mount it into the rest. In persistent worker mode that
is not the whole picture — each work request carries its own deploy manifest and
is planned on its own, so two requests that share a layer would each pick a home
among their own repositories and upload it there. The duplicate upload the
strategy exists to remove, just spread across requests instead of repositories.

Keep one blob location cache for the process, keyed by (registry, digest), which
holds the repository this process has put a blob in or is putting it in right
now. The first request to need a blob claims a home and publishes it; every
later request mounts from that same home and, once the claimer's upload has
finished, uploads nothing at all. The layers of the manifests the existence
check found are published too, so a request pushing a sibling image mounts them
out of a repository the registry already serves without a check of its own.

A request that arrives while the claimer is still uploading mounts from the same
home and schedules the same upload rather than waiting on a request it knows
nothing about, so the phases stay per-request: the mount source is in place by
the end of its own upload phase. Scheduling it is not performing it, though —
every upload goes through the cache's flight registry, which holds at most one
attempt per (registry, repository, digest) for the whole process. Whichever
request gets there first uploads the blob while the others wait for that
attempt, so the same bytes are never sent to the same repository twice at once,
and a request that waited reads nothing either: the blob is not even resolved
from the VFS, so a lazy push does not fetch it from the CAS. Each request pushes
through a `remote.Pusher` of its own, and go-containerregistry deduplicates per
pusher, so nothing below this would have caught it.

A failed attempt is not contagious. The caller that waited for it takes the
upload over rather than adopting an error from a request it has nothing to do
with — which is also what keeps one work request's cancellation from failing
another's push — and only its own attempt decides its result. Each caller
therefore performs at most one attempt, exactly what it would have done alone.

What a final failure means is the caller's to decide, and the two cases differ.
An upload a request only joined is another request's work, and the home is a
repository it never meant to write to, so failing it does not fail the deploy:
that blob gives up its cross-mount and is pushed the way it would have been
without the cache, which keeps a credential that may not write there from
breaking a deploy that never asked to. An upload a request claimed itself is its
own work and still fails loudly.

A blob only one destination needs now settles a home too — there is nothing to
cross-mount it into today, but publishing it is what lets the next request mount
it. That request mounts nothing, so nothing is mount-only for it: the strict
mount belongs to the requests that mount from the home later. One-shot deploys
keep the old rule and are unchanged, so a single-image `bazel run //:push` still
behaves exactly as it would with the flag off.

Homes are still picked alphabetically within a request. The cache makes the
deploys of one process agree; the alphabetical rule is what makes two processes
agree, so a re-run finds the blob in the home repository it would have picked
anyway and uploads nothing.

A deploy that uploads nothing (`forbid_layer_push`) leaves the cache alone: it
learns nothing about where a blob is, and what it would publish is an assumption
about the registry it never checked.

The persistent worker is undocumented, so `push-strategies.md` is unchanged.
