### PR TITLE
fix(deploy): send a blob mount without go-containerregistry's origin parameter

### DIFF
--- a/img_tool/cmd/deploy/dedup_registry_test.go
+++ b/img_tool/cmd/deploy/dedup_registry_test.go
@@ -79,15 +79,20 @@ type naiveRegistry struct {
 	blobPuts     []string
 	mounts       []string
 	manifestPuts []string
-	// mountOrigins records the "origin" query parameter of every satisfied mount, in
-	// step with mounts. go-containerregistry only sends it -- and only asks the token
-	// service for read access to the source repository -- when the cross-mount source
-	// names a registry, so an empty entry here means the deploy recorded a source that
-	// a scope-enforcing registry would refuse to mount from.
-	mountOrigins []string
+	// mountAttempts records the query parameters of every mount request, satisfied or
+	// not, so a test can check the shape of the request and not just its effect.
+	mountAttempts []mountAttempt
 	// crossRegistryMounts records every mount attempt whose "origin" named another
 	// registry. It must stay empty: see startUpload.
 	crossRegistryMounts []string
+}
+
+// mountAttempt is a POST that asked to mount a blob rather than upload it.
+type mountAttempt struct {
+	repository string
+	digest     string
+	from       string
+	origin     string
 }
 
 type storedManifest struct {
@@ -216,12 +221,14 @@ func (r *naiveRegistry) startUpload(w http.ResponseWriter, req *http.Request, re
 
 	query := req.URL.Query()
 	mount, from, origin := query.Get("mount"), query.Get("from"), query.Get("origin")
+	if mount != "" {
+		r.mountAttempts = append(r.mountAttempts, mountAttempt{repository: repository, digest: mount, from: from, origin: origin})
+	}
 	sameRegistry := origin == "" || origin == req.URL.Host
 	if r.mountable && sameRegistry && mount != "" && from != "" {
 		if content, found := r.blobs[from][mount]; found {
 			r.putBlobLocked(repository, mount, content)
 			r.mounts = append(r.mounts, repository+"@"+mount)
-			r.mountOrigins = append(r.mountOrigins, origin)
 			w.Header().Set("Location", "/v2/"+repository+"/blobs/"+mount)
 			w.Header().Set("Docker-Content-Digest", mount)
 			w.WriteHeader(http.StatusCreated)
@@ -609,10 +616,11 @@ func buildSharedLayerLayouts(t *testing.T, registry string, services, sharedLaye
 //
 // It also holds every one of these tests to the no-cross-registry invariant: whatever
 // the plan decided, the registry must never have been asked to fetch a blob from
-// another registry.
+// another registry -- nor to mount one with an "origin" parameter at all.
 func runDedupDeploy(t *testing.T, registry *naiveRegistry, layoutDirs []string, dm api.DeployManifest) error {
 	t.Helper()
 	defer registry.assertNoCrossRegistryMounts(t)
+	defer registry.assertMountsCarryNoOrigin(t)
 	return runDedupDeployVia(t, registry.transport(), layoutDirs, dm)
 }
 
@@ -624,6 +632,26 @@ func (r *naiveRegistry) assertNoCrossRegistryMounts(t *testing.T) {
 	defer r.mu.Unlock()
 	if len(r.crossRegistryMounts) > 0 {
 		t.Errorf("registry saw cross-registry mount attempts, want none: %v", r.crossRegistryMounts)
+	}
+}
+
+// assertMountsCarryNoOrigin holds every mount request to the shape it leaves the
+// tool with: a "from" naming the source repository, and no "origin". The parameter
+// is go-containerregistry's extension for mounting across registries, which it
+// derives from any mount source that names its registry and sends even for a source
+// the destination already serves; registryopts.WrapMountOrigin removes it, since a
+// registry that mounts only within itself may otherwise refuse the mount.
+func (r *naiveRegistry) assertMountsCarryNoOrigin(t *testing.T) {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, attempt := range r.mountAttempts {
+		if attempt.from == "" {
+			t.Errorf("the mount of %s into %s named no source repository, so it is no mount at all", attempt.digest, attempt.repository)
+		}
+		if attempt.origin != "" {
+			t.Errorf("the mount of %s into %s from %s carried origin %q, want none", attempt.digest, attempt.repository, attempt.from, attempt.origin)
+		}
 	}
 }
 
@@ -716,18 +744,6 @@ func TestDeduplicatedPushUploadsSharedLayersOnce(t *testing.T) {
 	if len(mounts) != 4 {
 		t.Errorf("registry satisfied %d mounts, want 4 (2 shared layers x 2 non-home repositories): %v", len(mounts), mounts)
 	}
-	// Every one of them named the registry the source repository is in. Without that,
-	// go-containerregistry never asks the token service for read access to the source,
-	// and a registry that enforces per-repository scopes cannot authorize the mount --
-	// which for a mount-only layer means a failed push, not a slower one.
-	reg.mu.Lock()
-	origins := append([]string(nil), reg.mountOrigins...)
-	reg.mu.Unlock()
-	for i, origin := range origins {
-		if origin != images.registry {
-			t.Errorf("mount %d carried origin %q, want the destination registry %q", i, origin, images.registry)
-		}
-	}
 	for _, repository := range images.repositories[1:] {
 		for _, digest := range images.shared {
 			if !reg.hasBlob(repository, digest) {
@@ -760,6 +776,46 @@ func TestDeduplicatedPushUploadsSharedLayersOnce(t *testing.T) {
 		if stored, found := reg.storedManifestFor(repository, "latest"); !found || stored.digest != images.manifests[i] {
 			t.Errorf("tag latest in %s = %+v, want it to point at %s", repository, stored.digest, images.manifests[i])
 		}
+	}
+}
+
+// TestDeduplicatedPushMountsNameOnlyTheSourceRepository pins the shape of the mount
+// requests that leave the tool: every one names the home repository as its "from" and
+// carries no "origin". go-containerregistry derives that parameter from the mount
+// source's reference -- which still names the destination's registry, so go-cr asks
+// the token service for read access to the source -- and
+// registryopts.WrapMountOrigin takes it off the wire, because a registry that mounts
+// only within itself may read it as a mount it cannot serve and ask for the bytes. A
+// mount-only layer has none to give.
+func TestDeduplicatedPushMountsNameOnlyTheSourceRepository(t *testing.T) {
+	reg := newNaiveRegistry()
+	layoutDirs, dm, images := buildSharedLayerLayouts(t, "reg.example.com", 3, 2)
+	home := images.repositories[0] // team/service-0, first alphabetically
+
+	if err := runDedupDeploy(t, reg, layoutDirs, dm); err != nil {
+		t.Fatalf("deduplicated push: %v", err)
+	}
+
+	reg.mu.Lock()
+	attempts := append([]mountAttempt(nil), reg.mountAttempts...)
+	reg.mu.Unlock()
+
+	// 2 shared layers x the 2 repositories that are not the home. Without this the
+	// assertions below would hold for a deploy that never mounted anything at all.
+	if len(attempts) != 4 {
+		t.Errorf("registry saw %d mount requests, want 4 (2 shared layers x 2 non-home repositories): %+v", len(attempts), attempts)
+	}
+	for _, attempt := range attempts {
+		if attempt.from != home {
+			t.Errorf("mount of %s into %s named from=%q, want the home repository %q", attempt.digest, attempt.repository, attempt.from, home)
+		}
+		if attempt.origin != "" {
+			t.Errorf("mount of %s into %s carried origin=%q, want no origin at all", attempt.digest, attempt.repository, attempt.origin)
+		}
+	}
+	// Every mount was satisfied, so no layer's bytes were asked for twice.
+	if _, mounts, _ := reg.snapshot(); len(mounts) != len(attempts) {
+		t.Errorf("registry satisfied %d of %d mount requests, want all of them: %v", len(mounts), len(attempts), mounts)
 	}
 }
 
@@ -801,14 +857,7 @@ func TestDeduplicatedPushDeduplicatesEachRegistrySeparately(t *testing.T) {
 		if len(mounts) != 4 {
 			t.Errorf("%s: satisfied %d mounts, want 4 (2 shared layers x 2 non-home repositories): %v", name, len(mounts), mounts)
 		}
-		reg.mu.Lock()
-		origins := append([]string(nil), reg.mountOrigins...)
-		reg.mu.Unlock()
-		for i, origin := range origins {
-			if origin != name {
-				t.Errorf("%s: mount %d carried origin %q, want its own registry", name, i, origin)
-			}
-		}
+		reg.assertMountsCarryNoOrigin(t)
 	}
 }
 

--- a/img_tool/pkg/registryopts/BUILD.bazel
+++ b/img_tool/pkg/registryopts/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "registryopts",
     srcs = [
         "concurrency.go",
+        "mountorigin.go",
         "registryopts.go",
     ],
     importpath = "github.com/bazel-contrib/rules_img/img_tool/pkg/registryopts",
@@ -22,6 +23,7 @@ go_test(
     size = "small",
     srcs = [
         "concurrency_test.go",
+        "mountorigin_test.go",
         "registryopts_test.go",
     ],
     embed = [":registryopts"],

--- a/img_tool/pkg/registryopts/mountorigin.go
+++ b/img_tool/pkg/registryopts/mountorigin.go
@@ -1,0 +1,80 @@
+package registryopts
+
+import (
+	"net/http"
+	"strings"
+)
+
+// WrapMountOrigin wraps base so that a cross-repository blob mount goes out
+// without go-containerregistry's "origin" parameter.
+//
+// This is a workaround for a bug in go-containerregistry, and it is a bad place to
+// fix it: rewriting a request URL underneath the library that built it hides the
+// behavior from every caller reading remote.MountableLayer. Delete this wrapper as
+// soon as there is any other way to keep the parameter from being emitted -- an
+// upstream option to suppress it, an upstream fix that stops sending it for a
+// source on the destination's own registry, or a way to hand go-cr a mount source
+// that keeps its registry for authorization but not for the request.
+//
+// The bug: go-cr derives origin=<registry> from the reference of every mount source
+// that names its registry, and sends it alongside mount/from. The parameter is
+// go-cr's own invention -- the distribution spec knows only mount and from -- and
+// it tells a registry nothing when the source is a repository it already serves,
+// which is what every mount rules_img sends is. A registry that mounts only within
+// itself may nevertheless read it as a mount it cannot serve, and answer 202
+// Accepted asking for the bytes instead; for a layer that may not be uploaded (a
+// deduplicated push's mount-only layer, forbid_layer_push) that costs the push.
+//
+// Removing it here rather than at the reference keeps go-cr's own use of that
+// reference intact: it still asks the token service for read access to the source
+// repository (remote.maybeUpdateScopes), and still sends the mount at all for a
+// Docker Hub destination, which it drops when the origin does not name Docker Hub
+// (google/go-containerregistry#1741).
+//
+// The one thing this gives up is a mount whose source really is on another
+// registry (`cross_mount_from` with a base image elsewhere): without the origin
+// the destination reads "from" as one of its own repositories, does not find the
+// blob there, and asks for the bytes -- which is what a registry that does not
+// implement cross-registry mounts does anyway.
+//
+// It has to sit above any transport that re-addresses the request (the
+// oci-distribution-gateway), so what the gateway forwards is already free of the
+// parameter. Installing a transport through [Options.WithTransport] does that.
+func WrapMountOrigin(base http.RoundTripper) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &mountOriginTransport{inner: base}
+}
+
+type mountOriginTransport struct {
+	inner http.RoundTripper
+}
+
+func (t *mountOriginTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if stripped, ok := withoutMountOrigin(req); ok {
+		req = stripped
+	}
+	return t.inner.RoundTrip(req)
+}
+
+// withoutMountOrigin returns a copy of req with the "origin" parameter removed,
+// and reports whether it changed anything. Only a blob-upload POST that asks for a
+// mount is rewritten, and the copy leaves req itself untouched -- go-cr hands the
+// same request to the transport again when it retries.
+func withoutMountOrigin(req *http.Request) (*http.Request, bool) {
+	if req.Method != http.MethodPost || req.URL == nil {
+		return nil, false
+	}
+	if !strings.HasSuffix(strings.TrimSuffix(req.URL.Path, "/"), "/blobs/uploads") {
+		return nil, false
+	}
+	query := req.URL.Query()
+	if query.Get("mount") == "" || query.Get("origin") == "" {
+		return nil, false
+	}
+	stripped := req.Clone(req.Context())
+	query.Del("origin")
+	stripped.URL.RawQuery = query.Encode()
+	return stripped, true
+}

--- a/img_tool/pkg/registryopts/mountorigin_test.go
+++ b/img_tool/pkg/registryopts/mountorigin_test.go
@@ -1,0 +1,137 @@
+package registryopts
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// recordingTransport records the URL of every request it serves and answers 202
+// Accepted, the way a registry opening an upload session does.
+type recordingTransport struct {
+	urls []*url.URL
+}
+
+func (t *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := *req.URL
+	t.urls = append(t.urls, &clone)
+	recorder := httptest.NewRecorder()
+	recorder.WriteHeader(http.StatusAccepted)
+	resp := recorder.Result()
+	resp.Request = req
+	return resp, nil
+}
+
+// roundTripURL sends one request through rt and returns the URL that reached the
+// recording transport underneath it.
+func roundTripURL(t *testing.T, rt http.RoundTripper, method, rawURL string) *url.URL {
+	t.Helper()
+	inner, ok := rt.(*mountOriginTransport).inner.(*recordingTransport)
+	if !ok {
+		t.Fatalf("transport %T does not wrap a recordingTransport", rt)
+	}
+	req, err := http.NewRequest(method, rawURL, nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	before := req.URL.String()
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+	// A RoundTripper may not modify the request it is handed: go-cr hands the same
+	// one back when it retries.
+	if got := req.URL.String(); got != before {
+		t.Errorf("RoundTrip mutated the request URL: %q, want the untouched %q", got, before)
+	}
+	if len(inner.urls) == 0 {
+		t.Fatal("nothing reached the inner transport")
+	}
+	return inner.urls[len(inner.urls)-1]
+}
+
+// TestWrapMountOriginDropsTheOrigin is what the wrapper exists for: the mount keeps
+// naming its source repository, and the origin parameter go-containerregistry adds
+// alongside it is gone.
+func TestWrapMountOriginDropsTheOrigin(t *testing.T) {
+	rt := WrapMountOrigin(&recordingTransport{})
+	sent := roundTripURL(t, rt, http.MethodPost,
+		"https://reg.example.com/v2/team/service/blobs/uploads/?from=team%2Fblobs&mount=sha256%3Adeadbeef&origin=reg.example.com")
+
+	query := sent.Query()
+	if _, found := query["origin"]; found {
+		t.Errorf("mount kept origin=%q, want it dropped", query.Get("origin"))
+	}
+	// Dropping "mount" or "from" as well would turn the request into an ordinary
+	// upload, which is the very thing a mount avoids.
+	if got := query.Get("mount"); got != "sha256:deadbeef" {
+		t.Errorf("mount = %q, want it kept", got)
+	}
+	if got := query.Get("from"); got != "team/blobs" {
+		t.Errorf("from = %q, want it kept", got)
+	}
+	if got := sent.Path; got != "/v2/team/service/blobs/uploads/" {
+		t.Errorf("path = %q, want it unchanged", got)
+	}
+}
+
+// TestWrapMountOriginDropsAnOriginNamingAnotherRegistry covers the deliberate part
+// of "every mount": a source on another registry loses its origin too, so the
+// destination answers the mount the way a registry without cross-registry mounts
+// does -- by asking for the bytes.
+func TestWrapMountOriginDropsAnOriginNamingAnotherRegistry(t *testing.T) {
+	rt := WrapMountOrigin(&recordingTransport{})
+	sent := roundTripURL(t, rt, http.MethodPost,
+		"https://reg.example.com/v2/team/service/blobs/uploads/?from=other%2Fbase&mount=sha256%3Adeadbeef&origin=other.example.com")
+
+	if got := sent.Query().Get("origin"); got != "" {
+		t.Errorf("origin = %q, want it dropped as well", got)
+	}
+	if got := sent.Query().Get("from"); got != "other/base" {
+		t.Errorf("from = %q, want it kept", got)
+	}
+}
+
+func TestWrapMountOriginLeavesOtherRequestsAlone(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		method string
+		url    string
+	}{
+		{
+			name:   "plain upload session",
+			method: http.MethodPost,
+			url:    "https://reg.example.com/v2/team/service/blobs/uploads/",
+		},
+		{
+			// go-cr sends an origin only alongside a mount, so an origin without one
+			// is not a mount request and there is nothing to fix up.
+			name:   "origin without a mount",
+			method: http.MethodPost,
+			url:    "https://reg.example.com/v2/team/service/blobs/uploads/?origin=reg.example.com",
+		},
+		{
+			name:   "upload session continuation",
+			method: http.MethodPatch,
+			url:    "https://reg.example.com/v2/team/service/blobs/uploads/upload-1?origin=reg.example.com",
+		},
+		{
+			name:   "manifest push",
+			method: http.MethodPut,
+			url:    "https://reg.example.com/v2/team/service/manifests/latest",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := WrapMountOrigin(&recordingTransport{})
+			want, err := url.Parse(tc.url)
+			if err != nil {
+				t.Fatalf("parsing %q: %v", tc.url, err)
+			}
+			if got := roundTripURL(t, rt, tc.method, tc.url); got.String() != want.String() {
+				t.Errorf("request URL = %q, want the untouched %q", got, want)
+			}
+		})
+	}
+}

--- a/img_tool/pkg/registryopts/registryopts.go
+++ b/img_tool/pkg/registryopts/registryopts.go
@@ -2,8 +2,8 @@
 // the img tool enforces for every registry operation: multi-keychain
 // authentication, a patient retry backoff, a transport routed through the
 // oci-distribution-gateway (when one is configured) that honors a registry's
-// Retry-After header and accounts for how many requests are in flight, and a
-// default concurrency.
+// Retry-After header, accounts for how many requests are in flight and sends a
+// blob mount without go-cr's origin parameter, and a default concurrency.
 //
 // Callers assemble options through a small builder so the enforced defaults live
 // in one place while still allowing per-call additions and overrides:
@@ -165,7 +165,7 @@ func Default() *Options {
 		remote.WithJobs(DefaultJobs),
 	}
 	if Insecure() {
-		opts = append(opts, remote.WithTransport(BaseTransport()))
+		opts = append(opts, remote.WithTransport(WrapMountOrigin(BaseTransport())))
 	}
 	return &Options{opts: opts}
 }
@@ -217,8 +217,15 @@ func (o *Options) WithJobs(jobs int) *Options {
 // WithTransport overrides the default transport, e.g. for a caller that wraps
 // its own caching or redirect transport. Wrap the replacement with
 // [WrapRetryAfter] if it should also honor Retry-After.
+//
+// Whatever transport a caller brings is wrapped with [WrapMountOrigin], so a blob
+// mount never carries go-cr's origin parameter. This is the one place every
+// registry transport of the img tool enters go-cr, and it is above any gateway
+// routing the caller's transport does -- which is where that wrapper belongs for
+// as long as it has to exist at all (it works around a go-cr bug; see
+// [WrapMountOrigin]).
 func (o *Options) WithTransport(rt http.RoundTripper) *Options {
-	return o.With(remote.WithTransport(rt))
+	return o.With(remote.WithTransport(WrapMountOrigin(rt)))
 }
 
 // Remote returns the assembled options to pass to go-cr (remote.Get, NewPusher,


### PR DESCRIPTION
go-containerregistry derives an `origin=<registry>` parameter from the reference of every mount source that names its registry, and sends it alongside `mount`/`from`. The parameter is go-cr's own invention — the distribution spec knows only `mount` and `from` — and it tells a registry nothing when the source is a repository it already serves, which is what every mount rules_img sends is. A registry that mounts only within itself may nevertheless read it as a mount it cannot serve, answering `202 Accepted` and asking for the bytes; a layer that may not be uploaded (a deduplicated push's mount-only layer, `forbid_layer_push`) has none to give, so the push fails.

Strip the parameter from every mount request in a transport wrapper, which `registryopts` installs for whatever transport a caller hands go-cr — the one place every registry request of the img tool passes through, and above any gateway routing, so what the gateway forwards is already free of it.

Doing it there rather than at the mount source keeps go-cr's own use of the reference intact: it still asks the token service for read access to the source repository, and still sends the mount at all for a Docker Hub destination, which it drops when the origin does not name Docker Hub ([google/go-containerregistry#1741](https://github.com/google/go-containerregistry/issues/1741)). What it gives up is a mount whose source really is on another registry: without the origin the destination reads `from` as one of its own repositories, finds no blob there and asks for the bytes — which is what a registry without cross-registry mounts does anyway.

This is a workaround for a go-cr bug, and rewriting a request underneath the library that built it is a bad place to fix it. The wrapper says so, and should be deleted as soon as there is another way to keep the parameter from being emitted.

The in-process registry in the deploy tests records the query parameters of every mount it is asked for, and holds all of them to naming a source repository and no origin.